### PR TITLE
Improve generated permissions tests

### DIFF
--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -15,13 +15,12 @@ RSpec.describe ApplicationRecord, type: :model do
       allow(Request).to receive(:current_user).and_return(user)
     end
 
-    # This test ensures that every model is handled for permissions purposes,
+    # These tests ensures that every model is handled for permissions purposes,
     # by either specifying how it is related to a Site (which will be used to
     # enforce that a non-admin User is a contact for that Site in order to
     # access it) or by specifying that it is globally available (and so will be
     # accessible by any User).
-
-    describe 'regular models should be related to a Site xor explicitly globally available' do
+    describe 'models should normally be related to a Site xor explicitly globally available' do
       # Eager load app so get all descendants of ApplicationRecord, not just
       # those which happen to already be loaded.
       Rails.application.eager_load!

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -27,12 +27,13 @@ RSpec.describe ApplicationRecord, type: :model do
       Rails.application.eager_load!
 
       ApplicationRecord.descendants.each do |klass|
-        # Irregular models:
-        # Users: have a relation with a Site but are also global
-        # Exception: is a base class for STI and is neither
-        irregular_models = [User, Expansion]
+        # The class is a base class for use in STI; skip it and just its
+        # subclasses will be checked.
+        next if klass.descendants.present?
 
-        next if irregular_models.include? klass
+        # Users are special, they have a relation with a Site but are also
+        # globally available, i.e. able to be read by any other User.
+        next if klass == User
 
         it "#{klass.to_s} has Site xor is global" do
           related_to_site = klass.new.respond_to?(:site)


### PR DESCRIPTION
This PR follows on from #30 with a couple of tweaks to the generated model permissions tests. In particular this:

a. always skips the generated test when the model is an STI base class;

b. changes how we iterate through all app models to include STI subclasses, so these are also covered by tests.
  