### PR TITLE
Create ComponentExpansion's based off defaults

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -9,7 +9,12 @@ class Component < ApplicationRecord
   has_many :asset_record_fields
   has_many :component_expansions
 
+  has_one :component_make, through: :component_group
+  has_many :default_expansions, through: :component_make
+
   validates_associated :component_group, :asset_record_fields
+
+  after_create :create_component_expansions_from_defaults
 
   def asset_record
     # Merge asset record layers to obtain hash for this Component of all
@@ -23,6 +28,16 @@ class Component < ApplicationRecord
   end
 
   private
+
+  def create_component_expansions_from_defaults
+    default_expansions.each do |d|
+      component_expansions.create!(
+        expansion_type: d.expansion_type,
+        slot: d.slot,
+        ports: d.ports
+      )
+    end
+  end
 
   # Method to be called from AdminConfig to format Component asset record for
   # displaying to admins.

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -33,11 +33,8 @@ class Component < ApplicationRecord
 
   def create_component_expansions_from_defaults
     default_expansions.each do |d|
-      component_expansions.create!(
-        expansion_type: d.expansion_type,
-        slot: d.slot,
-        ports: d.ports
-      )
+      data = d.slice(:expansion_type, :slot, :ports)
+      component_expansions.create!(**data.symbolize_keys)
     end
   end
 

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -12,7 +12,9 @@ class Component < ApplicationRecord
   has_one :component_make, through: :component_group
   has_many :default_expansions, through: :component_make
 
-  validates_associated :component_group, :asset_record_fields
+  validates_associated :component_group,
+                       :asset_record_fields,
+                       :component_expansions
 
   after_create :create_component_expansions_from_defaults
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -55,6 +55,17 @@ FactoryBot.define do
     name 'nodes'
   end
 
+  factory :expansion_type do
+    name 'switch'
+  end
+
+  factory :default_expansion do
+    expansion_type
+    component_make
+    ports 4
+    slot 'a'
+  end
+
   factory :category do
     name 'User management'
   end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -92,4 +92,29 @@ RSpec.describe Component, type: :model do
                                          'Comments' => '')
     end
   end
+
+  describe '#create_component_expansions_from_defaults' do
+    let :expansion_names { (1..2).map { |i| "expansion#{i}" } }
+    let :default_expansions do
+      expansion_names.map { |slot| create(:default_expansion, slot: slot) }
+    end
+    let :component_make do
+      create(:component_make, default_expansions: default_expansions)
+    end
+    let :component_group do
+      create(:component_group, component_make: component_make)
+    end
+
+    subject do
+      component_group.components.create!(name: 'test').component_expansions
+    end
+
+    it 'creates the correct number of expansions' do
+      expect(subject.length).to eq(expansion_names.length)
+    end
+
+    it 'creates the component_expansions' do
+      expect(subject.map(&:slot)).to include(*expansion_names)
+    end
+  end
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Component, type: :model do
     end
   end
 
-  describe '#create_component_expansions_from_defaults' do
+  describe "create ComponentExpansion's from ComponentDefault's" do
     let :expansion_names { (1..2).map { |i| "expansion#{i}" } }
     let :default_expansions do
       expansion_names.map { |slot| create(:default_expansion, slot: slot) }


### PR DESCRIPTION
When a new component is created, it will automatically create the
default expansions. This is done by reading the DefaultExpansions
from ComponentMake.

The issue with this approach is the :ports, :slot, and :expansion_type
attributes must be manually stated. Because the Expansions use STI,
not all the attributes are ported across.

In particular the id fields must not be copied as this could easily
make an invalid ComponentExpansion. Also the :type field must not be
copied as this will screw around with the STI.

I am open to suggestions on how to do this better. However for the
time being the list needs to be maintained. There is a test for this
behaviour so future changes should be detected.