### PR TITLE
Create the edit page for asset record and the associated routes

### DIFF
--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -2,5 +2,24 @@ class AssetRecordsController < ApplicationController
   def edit
     @title = "Title"
     @subtitle = "Subtitle"
+    asset
+  end
+
+  private
+
+  VALID_ASSET_IDS = [:component_id, :component_group_id]
+
+  def asset
+    ensure_single_asset_only
+  end
+
+  def ensure_single_asset_only
+    (asset_params.keys & VALID_ASSET_IDS.map(&:to_s)).tap do |ids|
+      raise 'Can not determine asset' unless ids.length == 1
+    end
+  end
+
+  def asset_params
+    params.permit(*VALID_ASSET_IDS)
   end
 end

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -1,0 +1,6 @@
+class AssetRecordsController < ApplicationController
+  def edit
+    @title = "Title"
+    @subtitle = "Subtitle"
+  end
+end

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -1,8 +1,8 @@
 class AssetRecordsController < ApplicationController
   def edit
-    @title = "Title"
-    @subtitle = "Subtitle"
-    asset
+    @asset = asset
+    @title = "Edit Asset Record"
+    @subtitle = "#{@asset.name}"
   end
 
   private
@@ -10,16 +10,14 @@ class AssetRecordsController < ApplicationController
   VALID_ASSET_IDS = [:component_id, :component_group_id]
 
   def asset
-    ensure_single_asset_only
+    id_key = id_param.keys.first
+    id_key.to_s.chomp('_id').classify.constantize.find(id_param[id_key])
   end
 
-  def ensure_single_asset_only
-    (asset_params.keys & VALID_ASSET_IDS.map(&:to_s)).tap do |ids|
-      raise 'Can not determine asset' unless ids.length == 1
+  def id_param
+    id = (params.keys & VALID_ASSET_IDS.map(&:to_s)).tap do |keys|
+      raise 'Can not determine asset' unless keys.length == 1
     end
-  end
-
-  def asset_params
-    params.permit(*VALID_ASSET_IDS)
+    params.permit(*id)
   end
 end

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -2,7 +2,6 @@ class AssetRecordsController < ApplicationController
   def edit
     @asset = asset
     @title = "Edit Asset Record"
-    @subtitle = "#{@asset.name}"
   end
 
   def update

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -10,17 +10,7 @@ class AssetRecordsController < ApplicationController
 
   private
 
-  VALID_ASSET_IDS = [:component_id, :component_group_id]
-
   def asset
-    id_key = id_param.keys.first
-    id_key.to_s.chomp('_id').classify.constantize.find(id_param[id_key])
-  end
-
-  def id_param
-    id = (params.keys & VALID_ASSET_IDS.map(&:to_s)).tap do |keys|
-      raise 'Can not determine asset' unless keys.length == 1
-    end
-    params.permit(*id)
+    @cluster_part || @component_group
   end
 end

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -5,6 +5,10 @@ class AssetRecordsController < ApplicationController
     @subtitle = "#{@asset.name}"
   end
 
+  def update
+    redirect_to asset
+  end
+
   private
 
   VALID_ASSET_IDS = [:component_id, :component_group_id]

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -3,6 +3,12 @@
 # just a bit of a dumping ground. At some point should pull things out to
 # better places.
 class ApplicationDecorator < Draper::Decorator
+  # Includes the AssetRecord Decorator implicitly
+  def initialize(*a)
+    super
+    extend AssetRecordDecorator if object.respond_to? :asset_record
+  end
+
   # Define methods for all decorated objects.
   # Helpers are accessed through `helpers` (aka `h`). For example:
   #

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -3,12 +3,6 @@
 # just a bit of a dumping ground. At some point should pull things out to
 # better places.
 class ApplicationDecorator < Draper::Decorator
-  # Includes the AssetRecord Decorator implicitly
-  def initialize(*a)
-    super
-    extend AssetRecordDecorator if object.respond_to? :asset_record
-  end
-
   # Define methods for all decorated objects.
   # Helpers are accessed through `helpers` (aka `h`). For example:
   #

--- a/app/decorators/asset_record_decorator.rb
+++ b/app/decorators/asset_record_decorator.rb
@@ -1,0 +1,15 @@
+module AssetRecordDecorator
+  def edit_asset_record_path
+    File.join(asset_record_path, 'edit')
+  end
+
+  def asset_record_path
+    File.join(model_id_path, 'asset_record')
+  end
+
+  private
+
+  def model_id_path
+    File.join('', object.class.to_s.tableize, object.id.to_s)
+  end
+end

--- a/app/decorators/asset_record_decorator.rb
+++ b/app/decorators/asset_record_decorator.rb
@@ -10,6 +10,6 @@ module AssetRecordDecorator
   private
 
   def model_id_path
-    File.join('', object.class.to_s.tableize, object.id.to_s)
+    File.join('', object.class.to_s.tableize.gsub('_', '-'), object.id.to_s)
   end
 end

--- a/app/decorators/asset_record_decorator.rb
+++ b/app/decorators/asset_record_decorator.rb
@@ -1,15 +1,19 @@
 module AssetRecordDecorator
   def edit_asset_record_path
-    File.join(asset_record_path, 'edit')
+    h.public_send "edit_#{asset_record_path_method_string}", object
   end
 
   def asset_record_path
-    File.join(model_id_path, 'asset_record')
+    h.public_send asset_record_path_method_string, object
   end
 
   private
 
-  def model_id_path
-    File.join('', object.class.to_s.tableize.gsub('_', '-'), object.id.to_s)
+  def asset_record_path_method_string
+    "#{asset_model_name}_asset_record_path"
+  end
+
+  def asset_model_name
+    object.class.to_s.tableize.singularize
   end
 end

--- a/app/decorators/component_decorator.rb
+++ b/app/decorators/component_decorator.rb
@@ -1,4 +1,6 @@
 class ComponentDecorator < ClusterPartDecorator
+  include AssetRecordDecorator
+
   alias :case_form_buttons :cluster_part_case_form_buttons
 
   def change_support_type_button

--- a/app/decorators/component_group_decorator.rb
+++ b/app/decorators/component_group_decorator.rb
@@ -1,5 +1,8 @@
 class ComponentGroupDecorator < ApplicationDecorator
+  include AssetRecordDecorator
+
   delegate_all
+
   decorates_association :components
 
   def path

--- a/app/models/component_type.rb
+++ b/app/models/component_type.rb
@@ -12,9 +12,10 @@ class ComponentType < ApplicationRecord
     true
   end
 
-  def asset_record
+  def asset_record_hash
     asset_record_field_definitions.map do |definition|
-      AssetRecordField.new(definition: definition, value: '')
-    end
+      new_field = AssetRecordField.new(definition: definition, value: '')
+      [definition.id, new_field]
+    end.to_h
   end
 end

--- a/app/models/component_type.rb
+++ b/app/models/component_type.rb
@@ -12,7 +12,7 @@ class ComponentType < ApplicationRecord
     true
   end
 
-  def asset_records
+  def asset_record
     asset_record_field_definitions.map do |definition|
       AssetRecordField.new(definition: definition, value: '')
     end

--- a/app/models/component_type.rb
+++ b/app/models/component_type.rb
@@ -12,7 +12,7 @@ class ComponentType < ApplicationRecord
     true
   end
 
-  def combined_asset_record_fields
+  def asset_records
     asset_record_field_definitions.map do |definition|
       AssetRecordField.new(definition: definition, value: '')
     end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -5,14 +5,14 @@ module HasAssetRecord
   # Method to be called from AdminConfig to format Component asset record for
   # displaying to admins.
   def asset_record_view
-    asset_records.map do |field|
+    asset_record.map do |field|
       [field.name, field.value]
     end.to_h.to_json
   end
 
-  def asset_records
+  def asset_record
     new_asset_ids = asset_record_fields.map { |m| m.definition.id }
-    parent_asset_records.inject(asset_record_fields) do |memo, r|
+    parent_asset_record.inject(asset_record_fields) do |memo, r|
       memo << r unless new_asset_ids.include? r.definition.id
       memo
     end
@@ -20,7 +20,7 @@ module HasAssetRecord
 
   private
 
-  def parent_asset_records
-    asset_record_parent&.asset_records || []
+  def parent_asset_record
+    asset_record_parent&.asset_record || []
   end
 end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -11,16 +11,20 @@ module HasAssetRecord
   end
 
   def asset_record
-    new_asset_ids = asset_record_fields.map { |m| m.definition.id }
-    parent_asset_record.inject(asset_record_fields) do |memo, r|
-      memo << r unless new_asset_ids.include? r.definition.id
-      memo
-    end
+    asset_record_hash.values
+  end
+
+  def asset_record_hash
+    parent_asset_record_hash.merge new_asset_record_hash
   end
 
   private
 
-  def parent_asset_record
-    asset_record_parent&.asset_record || []
+  def new_asset_record_hash
+    asset_record_fields.map { |f| [f.definition.id, f] }.to_h
+  end
+
+  def parent_asset_record_hash
+    asset_record_parent&.asset_record_hash || {}
   end
 end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -5,17 +5,12 @@ module HasAssetRecord
   # Method to be called from AdminConfig to format Component asset record for
   # displaying to admins.
   def asset_record_view
-    asset_record.to_json
+    asset_records.map do |field|
+      [field.name, field.value]
+    end.to_h.to_json
   end
 
-  def asset_record
-    @asset_record ||=
-      combined_asset_record_fields.map do |field|
-        [field.name, field.value]
-      end.to_h
-  end
-
-  def combined_asset_record_fields
+  def asset_records
     hashify_asset_record_fields(parent_asset_record_fields)
       .merge(hashify_asset_record_fields(asset_record_fields))
       .values
@@ -30,6 +25,6 @@ module HasAssetRecord
   end
 
   def parent_asset_record_fields
-    asset_record_parent&.combined_asset_record_fields
+    asset_record_parent&.asset_records
   end
 end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -11,20 +11,16 @@ module HasAssetRecord
   end
 
   def asset_records
-    hashify_asset_record_fields(parent_asset_record_fields)
-      .merge(hashify_asset_record_fields(asset_record_fields))
-      .values
+    new_asset_ids = asset_record_fields.map { |m| m.definition.id }
+    parent_asset_records.inject(asset_record_fields) do |memo, r|
+      memo << r unless new_asset_ids.include? r.definition.id
+      memo
+    end
   end
 
   private
 
-  def hashify_asset_record_fields(records)
-    (records || []).map do |field|
-      [field.definition.id, field]
-    end.to_h
-  end
-
-  def parent_asset_record_fields
-    asset_record_parent&.asset_records
+  def parent_asset_records
+    asset_record_parent&.asset_records || []
   end
 end

--- a/app/views/asset_records/edit.html.erb
+++ b/app/views/asset_records/edit.html.erb
@@ -1,6 +1,6 @@
 
 <%= render 'partials/asset_record_table',
   model: @asset,
-  scope: 'edit'
+  action: 'edit'
 %>
 

--- a/app/views/asset_records/edit.html.erb
+++ b/app/views/asset_records/edit.html.erb
@@ -1,0 +1,6 @@
+
+<%= render 'partials/asset_record_table',
+  model: @asset,
+  scope: 'edit'
+%>
+

--- a/app/views/component_groups/show.html.erb
+++ b/app/views/component_groups/show.html.erb
@@ -1,5 +1,5 @@
 
 <%# <%= render 'cases/cases_table', model: component_group, archive: true %1> %>
 
-<%= render 'partials/asset_record_table', model: component_group %>
+<%= render 'partials/asset_record_table', model: component_group, scope: 'show' %>
 

--- a/app/views/component_groups/show.html.erb
+++ b/app/views/component_groups/show.html.erb
@@ -3,6 +3,6 @@
 
 <%= render 'partials/asset_record_table',
   model: component_group,
-  scope: 'show'
+  action: 'show'
 %>
 

--- a/app/views/component_groups/show.html.erb
+++ b/app/views/component_groups/show.html.erb
@@ -3,8 +3,6 @@
 
 <%= render 'partials/asset_record_table',
   model: component_group,
-  scope: 'show',
-  edit_model_asset_record_path: \
-    edit_component_group_asset_record_path(component_group)
+  scope: 'show'
 %>
 

--- a/app/views/component_groups/show.html.erb
+++ b/app/views/component_groups/show.html.erb
@@ -1,5 +1,10 @@
 
 <%# <%= render 'cases/cases_table', model: component_group, archive: true %1> %>
 
-<%= render 'partials/asset_record_table', model: component_group, scope: 'show' %>
+<%= render 'partials/asset_record_table',
+  model: component_group,
+  scope: 'show',
+  edit_model_asset_record_path: \
+    edit_component_group_asset_record_path(component_group)
+%>
 

--- a/app/views/component_groups/show.html.erb
+++ b/app/views/component_groups/show.html.erb
@@ -1,32 +1,5 @@
 
 <%# <%= render 'cases/cases_table', model: component_group, archive: true %1> %>
 
-<div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Asset Record
-        </span>
-      </li>
-    </ul>
-  </div>
+<%= render 'partials/asset_record_table', model: component_group %>
 
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Value</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% component_group.asset_record.each do |name, value| %>
-      <tr>
-        <td><%= name %></td>
-        <td><%= value %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -20,32 +20,5 @@
   </ul>
 </div>
 
-<div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Asset Record
-        </span>
-      </li>
-    </ul>
-  </div>
+<%= render 'partials/asset_record_table', model: component %>
 
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Value</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% component.asset_record.each do |name, value| %>
-      <tr>
-        <td><%= name %></td>
-        <td><%= value %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -20,5 +20,5 @@
   </ul>
 </div>
 
-<%= render 'partials/asset_record_table', model: component %>
+<%= render 'partials/asset_record_table', model: component, scope: 'show' %>
 

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -22,8 +22,6 @@
 
 <%= render 'partials/asset_record_table',
   model: component,
-  scope: 'show',
-  edit_model_asset_record_path: \
-    edit_component_asset_record_path(component)
+  scope: 'show'
 %>
 

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -22,6 +22,6 @@
 
 <%= render 'partials/asset_record_table',
   model: component,
-  scope: 'show'
+  action: 'show'
 %>
 

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -20,5 +20,10 @@
   </ul>
 </div>
 
-<%= render 'partials/asset_record_table', model: component, scope: 'show' %>
+<%= render 'partials/asset_record_table',
+  model: component,
+  scope: 'show',
+  edit_model_asset_record_path: \
+    edit_component_asset_record_path(component)
+%>
 

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -5,15 +5,7 @@
     <ul class="nav">
       <li class="nav-item">
         <span class="navbar-brand">
-          Asset Record <%=
-            if action == 'show' && current_user.admin?
-              link_to 'Edit',
-                decorated_model.edit_asset_record_path,
-                style: 'display:inline-block;',
-                class: ['nav-link', 'btn', 'btn-dark'],
-                role: 'button'
-            end
-          %>
+          Asset Record
         </span>
       </li>
     </ul>
@@ -39,10 +31,14 @@
         <% end %>
       </tbody>
     </table>
+    <% button_class = { class: ['btn', 'btn-dark', 'btn-block'] } %>
     <%= if action == 'edit'
-          submit_tag "Submit",
-            style: 'display:inline-block;',
-            class: ['nav-link', 'btn', 'btn-dark']
+          submit_tag "Submit", **button_class
+        elsif current_user.admin?
+          link_to 'Edit',
+                  decorated_model.edit_asset_record_path,
+                  role: 'button',
+                  **button_class
         end %>
   <% end %>
 </div>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -1,13 +1,11 @@
 
-<% scope ||= 'show' #Default to show scope %>
-
 <div class='card'>
   <div class='card-header'>
     <ul class="nav">
       <li class="nav-item">
         <span class="navbar-brand">
           Asset Record <%=
-            if scope == 'show' && current_user.admin?
+            if action == 'show' && current_user.admin?
               button_to 'edit',
                 model.decorate.edit_asset_record_path,
                 method: 'get',
@@ -34,12 +32,12 @@
             <% definition_id = record.definition.id %>
             <td><%= label_tag(definition_id, record.name) %></td>
             <% input = text_field_tag(definition_id, record.value) %>
-            <td><%= scope == 'show' ? record.value : input %></td>
+            <td><%= action == 'show' ? record.value : input %></td>
           </tr>
         <% end %>
       </tbody>
     </table>
-    <%= submit_tag("Submit") if scope == 'edit' %>
+    <%= submit_tag("Submit") if action == 'edit' %>
   <% end %>
 </div>
 

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -6,10 +6,11 @@
         <span class="navbar-brand">
           Asset Record <%=
             if action == 'show' && current_user.admin?
-              button_to 'edit',
+              link_to 'Edit',
                 model.decorate.edit_asset_record_path,
-                method: 'get',
-                form: { style: 'display:inline-block;' }
+                style: 'display:inline-block;',
+                class: ['nav-link', 'btn', 'btn-dark'],
+                role: 'button'
             end
           %>
         </span>
@@ -37,7 +38,11 @@
         <% end %>
       </tbody>
     </table>
-    <%= submit_tag("Submit") if action == 'edit' %>
+    <%= if action == 'edit'
+          submit_tag "Submit",
+            style: 'display:inline-block;',
+            class: ['nav-link', 'btn', 'btn-dark']
+        end %>
   <% end %>
 </div>
 

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -1,3 +1,4 @@
+<% decorated_model = model.decorate %>
 
 <div class='card'>
   <div class='card-header'>
@@ -7,7 +8,7 @@
           Asset Record <%=
             if action == 'show' && current_user.admin?
               link_to 'Edit',
-                model.decorate.edit_asset_record_path,
+                decorated_model.edit_asset_record_path,
                 style: 'display:inline-block;',
                 class: ['nav-link', 'btn', 'btn-dark'],
                 role: 'button'
@@ -18,7 +19,7 @@
     </ul>
   </div>
 
-  <%= form_tag model.decorate.asset_record_path, method: 'PATCH' do %>
+  <%= form_tag decorated_model.asset_record_path, method: 'PATCH' do %>
     <table class="table table-responsive">
       <thead>
         <tr>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -29,7 +29,7 @@
       </thead>
 
       <tbody>
-        <% model.asset_records.each do |record| %>
+        <% model.asset_record.each do |record| %>
           <tr>
             <% definition_id = record.definition.id %>
             <td><%= label_tag(definition_id, record.name) %></td>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -9,7 +9,7 @@
           Asset Record <%=
             if scope == 'show' && current_user.admin?
               button_to 'edit',
-                edit_model_asset_record_path,
+                model.decorate.edit_asset_record_path,
                 method: 'get',
                 form: { style: 'display:inline-block;' }
             end
@@ -19,7 +19,7 @@
     </ul>
   </div>
 
-  <%= form_tag do %>
+  <%= form_tag model.decorate.asset_record_path, method: 'PATCH' do %>
     <table class="table table-responsive">
       <thead>
         <tr>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -19,16 +19,16 @@
     </ul>
   </div>
 
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Value</th>
-      </tr>
-    </thead>
+  <%= form_tag do %>
+    <table class="table table-responsive">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Value</th>
+        </tr>
+      </thead>
 
-    <tbody>
-      <%= form_tag do %>
+      <tbody>
         <% model.asset_records.each do |record| %>
           <tr>
             <% definition_id = record.definition.id %>
@@ -37,8 +37,9 @@
             <td><%= scope == 'show' ? record.value : input %></td>
           </tr>
         <% end %>
-      <% end %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+    <%= submit_tag("Submit") if scope == 'edit' %>
+  <% end %>
 </div>
 

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -1,3 +1,6 @@
+
+<% scope ||= 'show' #Default to show scope %>
+
 <div class='card'>
   <div class='card-header'>
     <ul class="nav">

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -1,13 +1,19 @@
 
 <% scope ||= 'show' #Default to show scope %>
 
-
 <div class='card'>
   <div class='card-header'>
     <ul class="nav">
       <li class="nav-item">
         <span class="navbar-brand">
-          Asset Record <%= button_to 'edit', edit_model_asset_record_path, method: 'get', form: { style: 'display:inline-block;' } %>
+          Asset Record <%=
+            if scope == 'show' && current_user.admin?
+              button_to 'edit',
+                edit_model_asset_record_path,
+                method: 'get',
+                form: { style: 'display:inline-block;' }
+            end
+          %>
         </span>
       </li>
     </ul>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -1,12 +1,13 @@
 
 <% scope ||= 'show' #Default to show scope %>
 
+
 <div class='card'>
   <div class='card-header'>
     <ul class="nav">
       <li class="nav-item">
         <span class="navbar-brand">
-          Asset Record
+          Asset Record <%= button_to 'edit', edit_model_asset_record_path, method: 'get', form: { style: 'display:inline-block;' } %>
         </span>
       </li>
     </ul>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -28,12 +28,16 @@
     </thead>
 
     <tbody>
-    <% model.asset_records.each do |record| %>
-      <tr>
-        <td><%= record.name %></td>
-        <td><%= record.value %></td>
-      </tr>
-    <% end %>
+      <%= form_tag do %>
+        <% model.asset_records.each do |record| %>
+          <tr>
+            <% definition_id = record.definition.id %>
+            <td><%= label_tag(definition_id, record.name) %></td>
+            <% input = text_field_tag(definition_id, record.value) %>
+            <td><%= scope == 'show' ? record.value : input %></td>
+          </tr>
+        <% end %>
+      <% end %>
     </tbody>
   </table>
 </div>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -1,0 +1,30 @@
+<div class='card'>
+  <div class='card-header'>
+    <ul class="nav">
+      <li class="nav-item">
+        <span class="navbar-brand">
+          Asset Record
+        </span>
+      </li>
+    </ul>
+  </div>
+
+  <table class="table table-responsive">
+    <thead>
+      <tr>
+        <th>Field</th>
+        <th>Value</th>
+      </tr>
+    </thead>
+
+    <tbody>
+    <% model.asset_record.each do |name, value| %>
+      <tr>
+        <td><%= name %></td>
+        <td><%= value %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -28,10 +28,10 @@
     </thead>
 
     <tbody>
-    <% model.asset_record.each do |name, value| %>
+    <% model.asset_records.each do |record| %>
       <tr>
-        <td><%= name %></td>
-        <td><%= value %></td>
+        <td><%= record.name %></td>
+        <td><%= record.value %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -22,24 +22,42 @@
 
       <tbody>
         <% model.asset_record.each do |record| %>
-          <tr>
+          <tr class="form-group">
             <% definition_id = record.definition.id %>
-            <td><%= label_tag(definition_id, record.name) %></td>
-            <% input = text_field_tag(definition_id, record.value) %>
-            <td><%= action == 'show' ? record.value : input %></td>
+            <td width="50%">
+              <%= label_tag(definition_id, record.name) %>
+            </td>
+
+            <% input = text_field_tag(
+              definition_id,
+              record.value,
+              class: 'form-control'
+            ) %>
+            <td width="50%">
+              <%= action == 'show' ? record.value : input %>
+            </td>
+          </tr>
+        <% end %>
+
+        <% if current_user.admin? %>
+          <% button_class = { class: ['btn', 'btn-dark', 'btn-block'] } %>
+
+          <tr>
+            <td colspan="2">
+              <%= if action == 'edit'
+                    submit_tag "Submit", **button_class
+                  else
+                    link_to 'Edit',
+                      decorated_model.edit_asset_record_path,
+                      role: 'button',
+                      **button_class
+                  end %>
+            </td>
           </tr>
         <% end %>
       </tbody>
     </table>
-    <% button_class = { class: ['btn', 'btn-dark', 'btn-block'] } %>
-    <%= if action == 'edit'
-          submit_tag "Submit", **button_class
-        elsif current_user.admin?
-          link_to 'Edit',
-                  decorated_model.edit_asset_record_path,
-                  role: 'button',
-                  **button_class
-        end %>
+
   <% end %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,14 +67,18 @@ Rails.application.routes.draw do
       resources :consultancy, only: :new
     end
 
+    asset_record = Proc.new do
+      resource :asset_record, only: [:edit, :update]
+    end
+
     resources :components, only: :show do
       resources :cases, only: :new
       resources :consultancy, only: :new
-      resource :asset_record, only: :edit
+      asset_record.call
     end
 
     resources :component_groups, path: 'component-groups', only: :show do
-      resource :asset_record, only: :edit
+      asset_record.call
     end
 
     resources :services, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
     end
 
     asset_record = Proc.new do
-      resource :asset_record, only: [:edit, :update]
+      resource :asset_record, path: 'asset-record', only: [:edit, :update]
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,9 +70,12 @@ Rails.application.routes.draw do
     resources :components, only: :show do
       resources :cases, only: :new
       resources :consultancy, only: :new
+      resource :asset_record, only: :edit
     end
 
-    resources :component_groups, path: 'component-groups', only: :show
+    resources :component_groups, path: 'component-groups', only: :show do
+      resource :asset_record, only: :edit
+    end
 
     resources :services, only: :show do
       resources :cases, only: :new

--- a/spec/features/asset_record.rb
+++ b/spec/features/asset_record.rb
@@ -24,12 +24,26 @@ RSpec.feature 'Asset Record', type: :feature   do
   context 'with a component' do
     subject { component }
     let :edit_path do
-      edit_component_asset_record_path(component, as: admin)
+      edit_component_asset_record_path(subject, as: admin)
     end
 
-    # it 'finds the component' do
-    #   visit edit_path
-    #   expect(asset).to eq(component)
-    # end
+    it 'redirect to the component' do
+      visit edit_path
+      click_button('Submit')
+      expect(current_path).to eq(component_path subject)
+    end
+  end
+
+  context 'with a component group' do
+    subject { component_group }
+    let :edit_path do
+      edit_component_group_asset_record_path(subject, as: admin)
+    end
+
+    it 'redirects to the component_group' do
+      visit edit_path
+      click_button 'Submit'
+      expect(current_path).to eq(component_group_path subject)
+    end
   end
 end

--- a/spec/features/asset_record.rb
+++ b/spec/features/asset_record.rb
@@ -20,4 +20,16 @@ RSpec.feature 'Asset Record', type: :feature   do
       end.to raise_error(RuntimeError)
     end
   end
+
+  context 'with a component' do
+    subject { component }
+    let :edit_path do
+      edit_component_asset_record_path(component, as: admin)
+    end
+
+    # it 'finds the component' do
+    #   visit edit_path
+    #   expect(asset).to eq(component)
+    # end
+  end
 end

--- a/spec/features/asset_record.rb
+++ b/spec/features/asset_record.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.feature 'Asset Record', type: :feature   do
+  let :admin { create(:admin) }
+  let :component { create(:component) }
+  let :component_group { create(:component_group) }
+
+  context 'with an invalid request' do
+    it 'errors as a non-admin user' do
+      expect do
+        visit edit_component_asset_record_path(component)
+      end.to raise_error(ActionController::RoutingError)
+    end
+
+    it 'errors if component_group is sent with a component request' do
+      expect do
+        visit edit_component_asset_record_path(
+          component, as: admin, component_group_id: component_group
+        )
+      end.to raise_error(RuntimeError)
+    end
+  end
+end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Component, type: :model do
 
       subject.reload
 
-      result_hash = subject.asset_records.map do |r|
+      result_hash = subject.asset_record.map do |r|
         [r.definition.field_name, r.value]
       end.to_h
       expect(result_hash).to eq(

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe Component, type: :model do
         )
       end
     end
-
-    it 'returns hash of asset record field names to values' do
+    it 'returns merged array of all applicable asset record fields' do
       ip_field_definition,
         model_field_definition,
         os_field_definition = asset_record_field_definitions
@@ -80,10 +79,10 @@ RSpec.describe Component, type: :model do
 
       subject.reload
 
-      result_hash = subject.asset_record.map do |r|
+      field_names_to_values = subject.asset_record.map do |r|
         [r.definition.field_name, r.value]
       end.to_h
-      expect(result_hash).to eq(
+      expect(field_names_to_values).to eq(
         'Ip' => '1.2.3.4',
         'Model/manufacturer name' => 'Dell server',
 

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -80,16 +80,20 @@ RSpec.describe Component, type: :model do
 
       subject.reload
 
-      expect(subject.asset_record).to eq('Ip' => '1.2.3.4',
-                                         'Model/manufacturer name' => 'Dell server',
+      result_hash = subject.asset_records.map do |r|
+        [r.definition.field_name, r.value]
+      end.to_h
+      expect(result_hash).to eq(
+        'Ip' => '1.2.3.4',
+        'Model/manufacturer name' => 'Dell server',
 
-                                         # Component-level field value should take precedence.
-                                         'OS deployed' => 'Windows o_O',
+        # Component-level field value should take precedence.
+        'OS deployed' => 'Windows o_O',
 
-                                         # Field definition included in definitions associated with
-                                         # ComponentType, but without an AssetRecordField associated with
-                                         # Component or ComponentGroup, should still be included.
-                                         'Comments' => '')
+        # Field definition included in definitions associated with
+        # ComponentType, but without an AssetRecordField associated with
+        # Component or ComponentGroup, should still be included.
+        'Comments' => '')
     end
   end
 

--- a/spec/models/concerns/has_asset_record_spec.rb
+++ b/spec/models/concerns/has_asset_record_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe HasAssetRecord, type: :model do
   end
 
   def asset_values(obj = subject)
-    obj.combined_asset_record_fields.map(&:value)
+    obj.asset_records.map(&:value)
   end
 
   it 'includes the asset_record_fields for the current layer' do

--- a/spec/models/concerns/has_asset_record_spec.rb
+++ b/spec/models/concerns/has_asset_record_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe HasAssetRecord, type: :model do
   end
 
   def asset_values(obj = subject)
-    obj.asset_records.map(&:value)
+    obj.asset_record.map(&:value)
   end
 
   it 'includes the asset_record_fields for the current layer' do


### PR DESCRIPTION
The majority of this PR is associated with creating the asset_record partial and embedding a form into it. By creating a partial, the majority of the view associated with showing and editing the asset record can be generalised.

The `HasAssetRecord` concern has also been simplified now that less code is dependent on it. The appropriate changes have been made in the view as well.

A `AssetRecordDecorator` has been created to assist in the routing. As multiple models use the partial, the inbuilt rails route helpers couldn't be used. Please see https://github.com/alces-software/alces-flight-center/commit/169622436dd23db23b3ad9ee94f2f7f9c849c65f for more details.

Please note this PR does not implement the updating of the asset records. Due to the complexity of the asset_record updating it is not a simply process and multiple bits of information will need to be encoded for it to work. Thus this will be done in the next PR. Instead this PR focused on getting the view and routes working.