### PR TITLE
Update the asset records from the submitted form

### DIFF
--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -5,6 +5,7 @@ class AssetRecordsController < ApplicationController
   end
 
   def update
+    asset.update_asset_record(update_param.to_h)
     redirect_to asset
   end
 

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -10,6 +10,11 @@ class AssetRecordsController < ApplicationController
 
   private
 
+  def update_param
+    definition_ids = asset.asset_record.map { |r| r.definition.id.to_s }
+    params.permit(*definition_ids)
+  end
+
   def asset
     @cluster_part || @component_group
   end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -18,6 +18,10 @@ module HasAssetRecord
     parent_asset_record_hash.merge new_asset_record_hash
   end
 
+  def update_asset_record(definition_hash)
+    
+  end
+
   private
 
   def new_asset_record_hash

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -32,7 +32,7 @@ module HasAssetRecord
         # When updating a field associated with the asset
         field.value = updated_value
         field.save!
-      elsif updated_value
+      else
         # When updating a higher level field
         create_asset_record_field(field.definition, updated_value)
       end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -22,7 +22,10 @@ module HasAssetRecord
     asset_record.each do |field|
       updated_value = definition_hash[field.definition.id]
       next if field.value == updated_value
-      if field.asset == self
+      if field.asset == self && (updated_value.nil? || updated_value.empty?)
+        # Delete an existing field
+        field.destroy!
+      elsif field.asset
         # When updating a field associated with the asset
         field.value = updated_value
         field.save!

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -28,7 +28,7 @@ module HasAssetRecord
       if field.asset == self && (updated_value.nil? || updated_value.empty?)
         # Delete an existing field
         field.destroy!
-      elsif field.asset
+      elsif field.asset == self
         # When updating a field associated with the asset
         field.value = updated_value
         field.save!

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -24,7 +24,8 @@ module HasAssetRecord
       next if field.value == updated_value
       if field.asset == self
         # When updating a field associated with the asset
-        raise NotImplementedError
+        field.value = updated_value
+        field.save!
       elsif updated_value
         # When updating a higher level field
         create_asset_record_field(field.definition, updated_value)

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -18,9 +18,12 @@ module HasAssetRecord
     parent_asset_record_hash.merge new_asset_record_hash
   end
 
-  def update_asset_record(definition_hash)
+  def update_asset_record(raw_definition_hash)
+    definition_hash = raw_definition_hash.map do |key, value|
+      [key.to_s.to_sym, value]
+    end.to_h
     asset_record.each do |field|
-      updated_value = definition_hash[field.definition.id]
+      updated_value = definition_hash[field.definition.id.to_s.to_sym]
       next if field.value == updated_value
       if field.asset == self && (updated_value.nil? || updated_value.empty?)
         # Delete an existing field

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -19,7 +19,17 @@ module HasAssetRecord
   end
 
   def update_asset_record(definition_hash)
-    
+    asset_record.each do |field|
+      updated_value = definition_hash[field.definition.id]
+      next if field.value == updated_value
+      if field.asset == self
+        # When updating a field associated with the asset
+        raise NotImplementedError
+      elsif updated_value
+        # When updating a higher level field
+        create_asset_record_field(field.definition, updated_value)
+      end
+    end
   end
 
   private
@@ -30,5 +40,12 @@ module HasAssetRecord
 
   def parent_asset_record_hash
     asset_record_parent&.asset_record_hash || {}
+  end
+
+  def create_asset_record_field(definition, value)
+    asset_record_fields.create!(
+      asset_record_field_definition_id: definition.id,
+      value: value
+    )
   end
 end

--- a/spec/models/concerns/has_asset_record_spec.rb
+++ b/spec/models/concerns/has_asset_record_spec.rb
@@ -1,58 +1,91 @@
 require 'rails_helper'
 
 RSpec.describe HasAssetRecord, type: :model do
-  let :grand_parent do
-    create_asset(
-      fields: { 4 => 'grand_parent_field' }
-    )
-  end
-
-  let :parent do
-    create_asset(
-      parent: grand_parent,
-      fields: { 2 => 'parent_asset_field', 3 => 'parent_override_field' }
-    )
-  end
-
-  subject do
-    create_asset(
-      parent: parent,
-      fields: { 1 => 'subject_asset_field', 3 => 'subject_override_field' }
-    )
-  end
-
-  def create_asset(parent: nil, fields: {})
-    # The asset_record_fields are merged according to the Definition id
-    asset_fields = fields.each_with_object([]) do |(id, msg), memo|
-      asset_def = { definition: double(AssetRecordFieldDefinition, id: id) }
-      memo.push(double(AssetRecordField, **asset_def, value: msg.to_s))
+  describe '#asset_record' do
+    let :grand_parent do
+      create_asset(
+        fields: { 4 => 'grand_parent_field' }
+      )
     end
-    # Final test object which contains the fields and the parent
-    OpenStruct.new(
-      name: 'Component-ish',
-      asset_record_fields: asset_fields,
-      asset_record_parent: parent
-    ).tap { |x| x.extend(HasAssetRecord) }
+
+    let :parent do
+      create_asset(
+        parent: grand_parent,
+        fields: { 2 => 'parent_asset_field', 3 => 'parent_override_field' }
+      )
+    end
+
+    subject do
+      create_asset(
+        parent: parent,
+        fields: {
+          1 => 'subject_asset_field',
+          3 => 'subject_override_field'
+        }
+      )
+    end
+
+    def create_asset(parent: nil, fields: {})
+      # The asset_record_fields are merged according to the Definition id
+      asset_fields = fields.each_with_object([]) do |(id, msg), memo|
+        asset_def = { definition: double(AssetRecordFieldDefinition, id: id) }
+        memo.push(double(AssetRecordField, **asset_def, value: msg.to_s))
+      end
+      # Final test object which contains the fields and the parent
+      OpenStruct.new(
+        name: 'Component-ish',
+        asset_record_fields: asset_fields,
+        asset_record_parent: parent
+      ).tap { |x| x.extend(HasAssetRecord) }
+    end
+
+    def asset_values(obj = subject)
+      obj.asset_record.map(&:value)
+    end
+
+    it 'includes the asset_record_fields for the current layer' do
+      expect(asset_values).to include('subject_asset_field')
+    end
+
+    it 'includes its parent fields' do
+      expect(asset_values).to include('parent_asset_field')
+    end
+
+    it 'allows multiple chained asset records' do
+      expect(asset_values).to include('grand_parent_field')
+    end
+
+    it 'subject fields override their parents' do
+      expect(asset_values).to include('subject_override_field')
+      expect(asset_values).not_to include('parent_override_field')
+    end
   end
 
-  def asset_values(obj = subject)
-    obj.asset_record.map(&:value)
-  end
+  describe '#update' do
+    let :type_only_definition { create(:asset_record_field_definition) }
+    let :component_type do
+      create(
+        :component_type,
+        asset_record_field_definitions: [type_only_definition]
+      )
+    end
+    let :component_make do
+      create(:component_make, component_type: component_type)
+    end
+    let :component_group do
+      create(:component_group, component_make: component_make)
+    end
 
-  it 'includes the asset_record_fields for the current layer' do
-    expect(asset_values).to include('subject_asset_field')
-  end
+    subject { create(:component, component_group: component_group) }
 
-  it 'includes its parent fields' do
-    expect(asset_values).to include('parent_asset_field')
-  end
+    def definition_hash(obj)
+      obj.asset_record.map { |r| [r.definition.id, r.value] }
+    end
 
-  it 'allows multiple chained asset records' do
-    expect(asset_values).to include('grand_parent_field')
-  end
-
-  it 'subject fields override their parents' do
-    expect(asset_values).to include('subject_override_field')
-    expect(asset_values).not_to include('parent_override_field')
+    it 'does nothing if no values have changed' do
+      old_hash = definition_hash(subject)
+      subject.update_asset_record(old_hash.deep_dup)
+      expect(definition_hash(subject)).to eq(old_hash)
+    end
   end
 end

--- a/spec/models/concerns/has_asset_record_spec.rb
+++ b/spec/models/concerns/has_asset_record_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe HasAssetRecord, type: :model do
     # The comparison is done using inspect/ string comparison
     # This prevents issues with the tests sneakily changing the old_fields
     # making it hard to tell if it has changed
+    # WARNING!! It can not be used to test deleted fields
     def changed_fields
       old_fields = subject.asset_record_fields.to_ary.map(&:inspect)
       yield if block_given?
@@ -145,5 +146,19 @@ RSpec.describe HasAssetRecord, type: :model do
       expect(updated_fields.length).to eq(1)
       expect_update(set_definition, updated_fields.first, 'component')
     end
+
+    shared_examples 'delete asset field' do |input|
+      it "deletes the record when it is updated to: #{input.inspect}" do
+        delete_field = subject.asset_record_fields.first
+        subject.update_asset_record(
+          old_hash.merge(delete_field.definition.id => input)
+        )
+        subject.reload
+        expect(subject.asset_record_fields).not_to include(delete_field)
+      end
+    end
+
+    include_examples 'delete asset field', nil
+    include_examples 'delete asset field', ''
   end
 end


### PR DESCRIPTION
This PR is based on #35, please merge it first.

Once the edit form has been submitted, the `AssetRecordsController` passes it onto the `HasAssetRecord` which does the update. This way the update code can be reused in multiple places.

The logic behind the update is based on the following used by the admin interface. The admin interface has not been switched over to use the module as asset records will likely be edited through the new interface. This means the old admin update code will likely be removed completely at a future date.
https://github.com/alces-software/alces-flight-center/blob/530e4f9f155ce45eaf7c16f64bcad407ba7788e0/app/models/concerns/admin_config/shared/editable_asset_record_fields.rb#L109-L133

Unfortunately the spec for the admin code could not be salvaged as it relies on the admin interface meta-programming. Instead the majority of this PR is focused on recreating the spec on the models themselves. It also has the added benefit of testing `HasAssetRecord` in the manner in which it is used (e.g. `Component`->`ComponentGroup`->`ComponentType`).