### PR TITLE
Additional UI features for `AssetRecord` table

### DIFF
--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -5,13 +5,13 @@ class AssetRecordsController < ApplicationController
   end
 
   def update
-    asset.update_asset_record(update_param.to_h)
+    asset.update_asset_record(asset_record_param.to_h)
     redirect_to asset
   end
 
   private
 
-  def update_param
+  def asset_record_param
     definition_ids = asset.asset_record.map { |r| r.definition.id.to_s }
     params.permit(*definition_ids)
   end

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -15,11 +15,6 @@ class AssetRecordsController < ApplicationController
   def update_component_make
     return unless asset.is_a? ComponentGroup
     new_make = ComponentMake.find_by_id component_make_id_param
-    unless new_make.component_type == asset.component_type
-      # This error isn't expected as the form only contains valid Makes
-      # However an invalid rouge request will result in an error
-      raise 'Can not change the ComponentMake to a different ComponentType'
-    end
     asset.component_make = new_make
     asset.save!
   end

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -6,10 +6,27 @@ class AssetRecordsController < ApplicationController
 
   def update
     asset.update_asset_record(asset_record_param.to_h)
+    update_component_make
     redirect_to asset
   end
 
   private
+
+  def update_component_make
+    return unless asset.is_a? ComponentGroup
+    new_make = ComponentMake.find_by_id component_make_id_param
+    unless new_make.component_type == asset.component_type
+      # This error isn't expected as the form only contains valid Makes
+      # However an invalid rouge request will result in an error
+      raise 'Can not change the ComponentMake to a different ComponentType'
+    end
+    asset.component_make = new_make
+    asset.save!
+  end
+
+  def component_make_id_param
+    params.require(:component_make).require(:id)
+  end
 
   def asset_record_param
     definition_ids = asset.asset_record.map { |r| r.definition.id.to_s }

--- a/app/models/component_make.rb
+++ b/app/models/component_make.rb
@@ -5,6 +5,10 @@ class ComponentMake < ApplicationRecord
 
   validates :manufacturer, :model, :knowledgebase_url, presence: true
 
+  def name
+    "#{manufacturer} : #{model}"
+  end
+
   def self.globally_available?
     true
   end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -29,9 +29,9 @@ module HasAssetRecord
     asset_record.each do |field|
       updated_value = definition_hash[field.definition.id.to_s.to_sym]
       next if field.value == updated_value
-      if field.asset == self && (updated_value.nil? || updated_value.empty?)
+      if updated_value.nil? || updated_value.empty?
         # Delete an existing field
-        field.destroy!
+        field.destroy! if field.asset == self
       elsif field.asset == self
         # When updating a field associated with the asset
         field.value = updated_value

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -14,6 +14,10 @@ module HasAssetRecord
     asset_record_hash.values
   end
 
+  def find_parent_asset_record(definition)
+    parent_asset_record_hash[definition.id]
+  end
+
   def asset_record_hash
     parent_asset_record_hash.merge new_asset_record_hash
   end

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -28,7 +28,6 @@ module HasAssetRecord
     end.to_h
     asset_record.each do |field|
       updated_value = definition_hash[field.definition.id.to_s.to_sym]
-      next if field.value == updated_value
       if updated_value.nil? || updated_value.empty?
         # Delete an existing field
         field.destroy! if field.asset == self

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -144,37 +144,8 @@
           <%= group.decorate.link %>
         </h6>
 
-        <table class="table table-responsive">
+        <%= render 'partials/components_table', group: group %>
 
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Support type</th>
-              <th></th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <% group.decorate.components.each do |component| %>
-              <tr>
-                <td width='40%'>
-                  <%= link_to component.name, component_path(component) %>
-                  <%= component.cluster_part_icons %>
-                </td>
-                <td width='30%'>
-                  <%= component.readable_support_type.capitalize %>
-                </td>
-                <td width='10%'>
-                  <%= component.start_maintenance_request_link %>
-                </td>
-                <td width='20%'>
-                  <%= component.change_support_type_button %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-
-        </table>
       <% end %>
     </div>
 

--- a/app/views/component_groups/show.html.erb
+++ b/app/views/component_groups/show.html.erb
@@ -1,6 +1,21 @@
 
 <%# <%= render 'cases/cases_table', model: component_group, archive: true %1> %>
 
+<div class='card'>
+  <div class='card-header'>
+    <ul class="nav">
+      <li class="nav-item">
+        <span class="navbar-brand">
+          Components
+        </span>
+      </li>
+    </ul>
+  </div>
+
+  <%= render 'partials/components_table', group: component_group %>
+
+</div>
+
 <%= render 'partials/asset_record_table',
   model: component_group,
   action: 'show'

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -30,11 +30,15 @@
 
             <% placeholder = model.find_parent_asset_record(record.definition)
                                   .value %>
+            <% is_component_level = (record.definition.level == 'component') %>
+            <% model_is_a_component = model.is_a?(Component) %>
+            <% readonly = is_component_level && !model_is_a_component %>
             <% form_input = text_field_tag(
               definition_id,
               (record.asset == model ? record.value : ''),
               class: 'form-control',
-              placeholder: placeholder
+              placeholder: placeholder,
+              readonly: readonly
             ) %>
             <td width="50%">
               <%= action == 'show' ? record.value : form_input %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -29,7 +29,8 @@
                                   :id,
                                   makes,
                                   :id,
-                                  :name %>
+                                  :name,
+                                  { selected: model.component_make.id } %>
           <% else %>
             <%= model.component_make.name %>
           <% end %></td>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -32,7 +32,7 @@
                                   .value %>
             <% form_input = text_field_tag(
               definition_id,
-              record.value,
+              (record.asset == model ? record.value : ''),
               class: 'form-control',
               placeholder: placeholder
             ) %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -21,6 +21,19 @@
       </thead>
 
       <tbody>
+        <tr>
+          <td>Component Make</td>
+          <td><% if (model.is_a? ComponentGroup) && (action == 'edit') %>
+            <% makes = ComponentMake.where(component_type: model.component_type) %>
+            <%= collection_select :component_make,
+                                  :id,
+                                  makes,
+                                  :id,
+                                  :name %>
+          <% else %>
+            <%= model.component_make.name %>
+          <% end %></td>
+        </tr>
         <% model.asset_record.each do |record| %>
           <tr class="form-group">
             <% definition_id = record.definition.id %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -28,10 +28,13 @@
               <%= label_tag(definition_id, record.name) %>
             </td>
 
+            <% placeholder = model.find_parent_asset_record(record.definition)
+                                  .value %>
             <% form_input = text_field_tag(
               definition_id,
               record.value,
-              class: 'form-control'
+              class: 'form-control',
+              placeholder: placeholder
             ) %>
             <td width="50%">
               <%= action == 'show' ? record.value : form_input %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -28,13 +28,13 @@
               <%= label_tag(definition_id, record.name) %>
             </td>
 
-            <% input = text_field_tag(
+            <% form_input = text_field_tag(
               definition_id,
               record.value,
               class: 'form-control'
             ) %>
             <td width="50%">
-              <%= action == 'show' ? record.value : input %>
+              <%= action == 'show' ? record.value : form_input %>
             </td>
           </tr>
         <% end %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -33,12 +33,17 @@
             <% is_component_level = (record.definition.level == 'component') %>
             <% model_is_a_component = model.is_a?(Component) %>
             <% readonly = is_component_level && !model_is_a_component %>
+            <% readonly_msg = \
+              'This field can only be set at the individual Component level'
+            %>
             <% form_input = text_field_tag(
               definition_id,
               (record.asset == model ? record.value : ''),
               class: 'form-control',
               placeholder: placeholder,
-              readonly: readonly
+              readonly: readonly,
+              style: (readonly ? 'background-color:lightgray' : ''),
+              title: (readonly ? readonly_msg : '')
             ) %>
             <td width="50%">
               <%= action == 'show' ? record.value : form_input %>
@@ -64,7 +69,6 @@
         <% end %>
       </tbody>
     </table>
-
   <% end %>
 </div>
 

--- a/app/views/partials/_components_table.html.erb
+++ b/app/views/partials/_components_table.html.erb
@@ -1,0 +1,32 @@
+
+  <table class="table table-responsive">
+
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Support type</th>
+        <th></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% group.decorate.components.each do |component| %>
+        <tr>
+          <td width='40%'>
+            <%= link_to component.name, component_path(component) %>
+            <%= component.cluster_part_icons %>
+          </td>
+          <td width='30%'>
+            <%= component.readable_support_type.capitalize %>
+          </td>
+          <td width='10%'>
+            <%= component.start_maintenance_request_link %>
+          </td>
+          <td width='20%'>
+            <%= component.change_support_type_button %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+
+  </table>

--- a/spec/models/concerns/has_asset_record_spec.rb
+++ b/spec/models/concerns/has_asset_record_spec.rb
@@ -193,6 +193,15 @@ RSpec.describe HasAssetRecord, type: :model do
       expect(group_record.value).to eq('group')
     end
 
+    it 'does not replace higher level assets with a blank field' do
+      updated_fields = changed_fields do
+        subject.update_asset_record(
+          old_hash.merge(group_definition.id => '')
+        )
+      end
+      expect(updated_fields.length).to eq(0)
+    end
+
     shared_examples 'delete asset field' do |input|
       it "deletes the record when it is updated to: #{input.inspect}" do
         delete_field = subject.asset_record_fields.first


### PR DESCRIPTION
Based on #36, please merge it first.

A few additional `UI` features have been added to the edit `AssetRecord` table.
1. It no longer autofills the `asset_record_table` with the parent/ higher values. Instead the parent values are now a placeholder. This required the `HasAssetRecordConcern` to be modified as empty strings no longer mean delete in all circumstances. https://github.com/alces-software/alces-flight-center/pull/38/commits/264fcb822fe1447401db97f61cd11cb3a8f4815d
1. Asset records that can only be set at the component level are greyed out at the group level. Title text has been set to explain this.
1. The `ComponentMake` can now be changed for the `ComponentGroup` based on the previous `ComponentType`.
1. The `Components` are now displayed on the `ComponentGroup` page.