### PR TITLE
Fix selects not causing messages in some browsers (fixes #39)

### DIFF
--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -9,6 +9,7 @@ import FieldValidation exposing (FieldValidation(..))
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
+import Json.Decode as D
 import SelectList exposing (Position(..), SelectList)
 import String.Extra
 
@@ -44,7 +45,7 @@ selectField fieldName items toId toOptionLabel validate changeMsg =
         (SelectList.selected items)
         validatedField
         select
-        [ onInput changeMsg ]
+        [ Html.Events.on "change" (D.map changeMsg Html.Events.targetValue) ]
         options
 
 


### PR DESCRIPTION
The previous behaviour worked fine in Chrome and Firefox, which fire an 'input' event whenever a `select` is changed. However IE and Edge don't do this, because apparently the spec is not entirely clear that they should do so; therefore when any select in the form was changed in these browsers no 'input' event would be fired and so no messages would be sent, and so the form appeared not to respond to this interaction.

The solution is to have the `select`s listen for any 'change' event, which appears to cause the desired messages to be sent in all these browsers.

Relevant issue: https://github.com/elm-lang/html/issues/71.
Relevant comment on this issue with suggested fix:
https://github.com/elm-lang/html/issues/71#issuecomment-242363580.