### PR TITLE
Add page to create/edit/delete ComponentExpansions

### DIFF
--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -10,6 +10,11 @@ class ComponentExpansionsController < ApplicationController
     redirect_back fallback_location: @cluster_part
   end
 
+  def edit
+    @title = "Edit Expansions"
+    @subtitle = @cluster_part.name
+  end
+
   def update
     @cluster_part.component_expansions.each do |expansion|
       update_expansion(expansion)
@@ -17,9 +22,13 @@ class ComponentExpansionsController < ApplicationController
     redirect_update
   end
 
-  def edit
-    @title = "Edit Expansions"
-    @subtitle = @cluster_part.name
+  def destroy
+    if component_expansion_param.destroy
+      flash[:success] = 'Successfully deleted expansion'
+    else
+      flash[:error] = 'Failed to delete expansion'
+    end
+    redirect_back fallback_location: '/'
   end
 
   private
@@ -67,5 +76,9 @@ class ComponentExpansionsController < ApplicationController
       slot: raw_params[0],
       ports: raw_params[1]
     }
+  end
+
+  def component_expansion_param
+    ComponentExpansion.find_by_id params.require(:id)
   end
 end

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -71,11 +71,9 @@ class ComponentExpansionsController < ApplicationController
 
   def update_expansion_param(expansion)
     id = expansion.id
-    raw_params = params.require([:"slot#{id}", :"ports#{id}"])
-    {
-      slot: raw_params[0],
-      ports: raw_params[1]
-    }
+    params.permit([:"slot#{id}", :"ports#{id}"]).to_h.map do |k, v|
+      [k.to_s.chomp(id.to_s).to_sym, v]
+    end.to_h
   end
 
   def component_expansion_param

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -35,6 +35,7 @@ class ComponentExpansionsController < ApplicationController
 
   def redirect_update
     if expansion_errors.empty?
+      flash[:success] = 'Successfully updated the expansions'
       redirect_to @cluster_part
     else
       flash_error 'Errors updating expansions:'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,10 @@ module ApplicationHelper
     )
   end
 
+  def dark_button_class
+    { class: ['btn', 'btn-dark', 'btn-block'] }
+  end
+
   private
 
   # Map function with given name over enumerable collection of objects, then

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -13,11 +13,7 @@
       end
       list.push model.case_form_buttons
     end),
-    title: <<-EOF.strip
-      #{archive ? 'All' : 'Open'}
-      support cases &mdash;
-      #{model.name}
-    EOF
+    title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>
 
   <table class="table table-responsive">

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -6,7 +6,7 @@
       url: component_component_expansion_path(@cluster_part)
     } %>
     <%= form_for :component_expansion, **form_opts do |f| %>
-      <table class="table m-0">
+      <table class="table table-responsive m-0">
         <thead>
           <tr>
             <th>Type</th>
@@ -15,12 +15,12 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
+          <tr class='form-group'>
             <td>
-              <%= collection_select :expansion_type, :id, ExpansionType.all, :id, :name %>
+              <%= collection_select :expansion_type, :id, ExpansionType.all, :id, :name, class: 'form-control'%>
             </td>
-            <td><%= f.text_field :slot %></td>
-            <td><%= f.text_field :ports %></td>
+            <td><%= f.text_field :slot, class: 'form-control' %></td>
+            <td><%= f.text_field :ports, class: 'form-control' %></td>
           </tr>
         </tbody>
       </table>

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -6,6 +6,24 @@
       url: component_component_expansion_path(@cluster_part)
     } %>
     <%= form_for :component_expansions, **form_opts do |f| %>
+      <table class="table m-0">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Slot</th>
+            <th>No. Ports</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <%= collection_select :expansion_type, :id, ExpansionType.all, :id, :name %>
+            </td>
+            <td><%= f.text_field :slot %></td>
+            <td><%= f.text_field :ports %></td>
+          </tr>
+        </tbody>
+      </table>
       <div class='pb-3 px-3'>
         <%= f.submit 'Add Expansion', **dark_button_class %>
       </div>

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -6,24 +6,26 @@
       url: component_component_expansion_path(@cluster_part)
     } %>
     <%= form_for :component_expansion, **form_opts do |f| %>
-      <table class="table table-responsive m-0">
-        <thead>
-          <tr>
-            <th>Type</th>
-            <th>Slot</th>
-            <th>No. Ports</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class='form-group'>
-            <td>
-              <%= collection_select :expansion_type, :id, ExpansionType.all, :id, :name, class: 'form-control'%>
-            </td>
-            <td><%= f.text_field :slot, class: 'form-control' %></td>
-            <td><%= f.text_field :ports, class: 'form-control' %></td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="table-responsive">
+        <table class="table m-0">
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Slot</th>
+              <th>No. Ports</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class='form-group'>
+              <td>
+                <%= collection_select :expansion_type, :id, ExpansionType.all, :id, :name, class: 'form-control'%>
+              </td>
+              <td><%= f.text_field :slot, class: 'form-control' %></td>
+              <td><%= f.text_field :ports, class: 'form-control' %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
       <div class='pb-3 px-3'>
         <%= f.submit 'Add Expansion', **dark_button_class %>
       </div>

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -1,6 +1,14 @@
 
 <div class="card">
   <%= render('partials/card_header_nav', title: 'New Expansion') %>
+  <div class='card-block'>
+    <% form_opts = {
+      url: component_component_expansion_path(@cluster_part)
+    } %>
+    <%= form_for :component_expansions, **form_opts do |f| %>
+      <%= f.submit 'Add Expansion', **dark_button_class %>
+    <% end %>
+  </div>
 </div>
 
 <div class="card">

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -5,7 +5,7 @@
     <% form_opts = {
       url: component_component_expansion_path(@cluster_part)
     } %>
-    <%= form_for :component_expansions, **form_opts do |f| %>
+    <%= form_for :component_expansion, **form_opts do |f| %>
       <table class="table m-0">
         <thead>
           <tr>

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -6,7 +6,9 @@
       url: component_component_expansion_path(@cluster_part)
     } %>
     <%= form_for :component_expansions, **form_opts do |f| %>
-      <%= f.submit 'Add Expansion', **dark_button_class %>
+      <div class='pb-3 px-3'>
+        <%= f.submit 'Add Expansion', **dark_button_class %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -4,7 +4,7 @@
   <%= render('partials/card_header_nav', title: 'Asset Record') %>
 
   <%= form_tag decorated_model.asset_record_path, method: 'PATCH' do %>
-    <table class="table table-responsive">
+    <table class="table table-responsive m-0">
       <thead>
         <tr>
           <th>Field</th>
@@ -42,12 +42,11 @@
             </td>
           </tr>
         <% end %>
-
-        <%= render 'partials/edit_submit_button',
-                   action: action,
-                   edit_path: decorated_model.edit_asset_record_path %>
       </tbody>
     </table>
+    <%= render 'partials/edit_submit_button',
+               action: action,
+               edit_path: decorated_model.edit_asset_record_path %>
   <% end %>
 </div>
 

--- a/app/views/partials/_edit_submit_button.html.erb
+++ b/app/views/partials/_edit_submit_button.html.erb
@@ -1,16 +1,14 @@
 
-<% button_class = { class: ['btn', 'btn-dark', 'btn-block'] } %>
-
 <% if current_user.admin? %>
   <tr>
     <td colspan="<%= colspan ||= 2 %>">
       <%= case action
-          when 'edit'; submit_tag "Submit", **button_class
+          when 'edit'; submit_tag "Submit", **dark_button_class
           when 'show'
             link_to 'Edit',
               edit_path,
               role: 'button',
-              **button_class
+              **dark_button_class
           end %>
     </td>
   </tr>

--- a/app/views/partials/_edit_submit_button.html.erb
+++ b/app/views/partials/_edit_submit_button.html.erb
@@ -1,16 +1,14 @@
 
 <% if current_user.admin? %>
-  <tr>
-    <td colspan="<%= colspan ||= 2 %>">
-      <%= case action
-          when 'edit'; submit_tag "Submit", **dark_button_class
-          when 'show'
-            link_to 'Edit',
-              edit_path,
-              role: 'button',
-              **dark_button_class
-          end %>
-    </td>
-  </tr>
+  <div class='px-3 pb-3' >
+    <%= case action
+        when 'edit'; submit_tag "Submit", **dark_button_class
+        when 'show'
+          link_to 'Edit',
+            edit_path,
+            role: 'button',
+            **dark_button_class
+        end %>
+  </div>
 <% end %>
 

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -7,6 +7,7 @@
           <th>Type</th>
           <th>Slot</th>
           <th>No. Ports</th>
+          <%== '<th>Delete</th>' if action == 'edit' %>
         </tr>
       </thead>
       <tbody>
@@ -27,6 +28,13 @@
                 <%= text_field_tag 'ports' + expansion.id.to_s,
                                    expansion.ports,
                                    class: 'form-control' %>
+              </td>
+              <td>
+                <%= link_to 'X',
+                            component_expansion_path(expansion),
+                            role: 'button',
+                            method: 'delete',
+                            **dark_button_class %>
               </td>
             <% end %>
           </tr>

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -30,11 +30,15 @@
                                    class: 'form-control' %>
               </td>
               <td>
+<% confirm_msg =\
+  "A you sure you want to delete the component? Any unsaved changes will be lost."
+%>
                 <%= link_to 'X',
                             component_expansion_path(expansion),
                             role: 'button',
                             method: 'delete',
-                            **dark_button_class %>
+                            **dark_button_class,
+                            data: { confirm: confirm_msg }%>
               </td>
             <% end %>
           </tr>

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -1,7 +1,7 @@
 <% submit_path = component_component_expansion_path @cluster_part %>
 <%= form_tag submit_path, method: 'PATCH' do %>
-  <div class="table-responsive">
-    <table class="table">
+  <div class="card-block table-responsive">
+    <table class="table m-0">
       <thead>
         <tr>
           <th>Type</th>
@@ -31,13 +31,14 @@
             <% end %>
           </tr>
         <% end %>
-        <% edit_path = edit_component_component_expansion_path model %>
-        <%= render 'partials/edit_submit_button',
-                   action: action,
-                   colspan: 3,
-                   edit_path: edit_path %>
       </tbody>
     </table>
+  </div>
+  <div class='card-block'>
+    <% edit_path = edit_component_component_expansion_path model %>
+    <%= render 'partials/edit_submit_button',
+               action: action,
+               edit_path: edit_path %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
       asset_record.call
     end
 
+    resources :component_expansions, only: [:destroy]
+
     resources :component_groups, path: 'component-groups', only: [] do
       asset_record.call
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
       resources :maintenance_windows, only: :new
       resource :component_expansion,
                path: 'expansions',
-               only: [:edit, :update]
+               only: [:edit, :update, :create]
       asset_record.call
     end
 


### PR DESCRIPTION
Based on #38, please merge it first

This PR is a tad long as it contains a few internal changes to `AssetRecord` code. This is part breaking out the different form elements into `partials` and `decorators` (https://github.com/alces-software/alces-flight-center/commit/04d291c3b35fdfb8e092295b906c14d213d4948f, https://github.com/alces-software/alces-flight-center/commit/5d8a1581527c2cd7adab8c46eb98ab34b3dab31d, https://github.com/alces-software/alces-flight-center/commit/756a27c87ed99295f82dad9ea765cb448c09d7f7) and subsequent changes to how they function. This is to make it easier generate the different common features used by the forms.

There was also a bug fix in which any user could update the asset record due to a bad test. It has been fixed in https://github.com/alces-software/alces-flight-center/commit/0994b82203d49398b3b1a302644d41f2ce56dfb3 and https://github.com/alces-software/alces-flight-center/commit/a067bcd168d7954e9f54db8f7c2abfa7618cc365.

There are various other miscellaneous changes concerning the view and layout, see commit messages for details.

Otherwise the major addition is the expansions table https://github.com/alces-software/alces-flight-center/commit/4f8604d94bbcee0f055b6153d60d9cca6cd34281. It is shown on the component page and performs a bulk edit for all the `ComponentExpansions` associated with the component. It is modelled after the `AssetRecordTable` except it DOES NOT inherit anything from a higher level. `ComponentExpansions` are associated with a single `component` and are independent from the `ComponentGroup/Make`.

The remaining commits add the `update` (https://github.com/alces-software/alces-flight-center/commit/312809d5d2d1d5e1c4da1d80c361899701f08496), `create` (https://github.com/alces-software/alces-flight-center/commit/5ab7fa6e30fb56ee13bee1f48e8156f66984319b), and `destroy` (https://github.com/alces-software/alces-flight-center/commit/641b5b93451fb2696f422077e45473996d6779c2) actions for `ComponentExpansions`.

Note, `edit/update` actions are bulk edits and will update all the expansions associated with the component. The `create/destroy` actions apply to individual components.