### PR TITLE
Add migration to add back missing Issue Categories

### DIFF
--- a/db/data_migrations/20180201182222_add_back_missing_issue_categories.rb
+++ b/db/data_migrations/20180201182222_add_back_missing_issue_categories.rb
@@ -1,0 +1,24 @@
+class AddBackMissingIssueCategories < ActiveRecord::DataMigration
+  def up
+    app_management = Category.find_by_name!('Application Management')
+    end_user_assistance = Category.find_by_name!('End User Assistance')
+
+    [
+      'Custom open-source',
+      'Custom commercial',
+      'From available Alces Gridware',
+    ].each do |name|
+      Issue.find_by_name!(name).update!(category: app_management)
+    end
+
+    [
+      'Self application install assistance',
+      'Application problems/bugs',
+      'Job running how-to/assistance',
+      'Job script how-to/assistance',
+      'Problem jobs',
+    ].each do |name|
+      Issue.find_by_name!(name).update!(category: end_user_assistance)
+    end
+  end
+end


### PR DESCRIPTION
We recently changed Issues to be related to Services, and make Issue
Categories not required (in order to make the Case form read more
intuitively and not include unnecessary Category fields containing only
one or two Issues). At some point in this process we lost the
relationship between Issues and Categories that we did still want to
keep, to split up the Issues for the 'HPC Environment' Service as there
are quite a lot of these. This migration adds these back appropriately.

Trello: https://trello.com/c/qpgoO4WZ/151-categories-dont-exist-correctly-in-production-data.