### PR TITLE
Dry up the views for adding the expansions table

### DIFF
--- a/app/decorators/asset_record_decorator.rb
+++ b/app/decorators/asset_record_decorator.rb
@@ -7,6 +7,38 @@ module AssetRecordDecorator
     h.public_send asset_record_path_method_string, object
   end
 
+  READ_ONLY_MSG = <<-EOF
+    This field can only be set at the individual Component level
+  EOF
+
+  def asset_record_form_inputs
+    Enumerator.new do |memo|
+      object.asset_record.each do |record|
+        is_component_level = (record.definition.level == 'component')
+        options = {
+          class: 'form-control',
+          readonly: (is_component_level && !object.is_a?(Component)),
+          placeholder: object.find_parent_asset_record(record.definition)
+                             .value
+        }.tap do |opt|
+          if opt[:readonly]
+            opt[:style] = 'background-color:lightgray'
+            opt[:title] = READ_ONLY_MSG
+          end
+        end
+
+        memo << [
+          record,
+          h.text_field_tag(
+            record.definition.id,
+            (record.asset == model ? record.value : ''),
+            **options
+          )
+        ]
+      end
+    end
+  end
+
   private
 
   def asset_record_path_method_string

--- a/app/models/concerns/has_asset_record.rb
+++ b/app/models/concerns/has_asset_record.rb
@@ -28,8 +28,14 @@ module HasAssetRecord
     end.to_h
     asset_record.each do |field|
       updated_value = definition_hash[field.definition.id.to_s.to_sym]
-      if updated_value.nil? || updated_value.empty?
-        # Delete an existing field
+      if updated_value.nil?
+        # A nil likely means the definition was not submitted in the form
+        # In this case, the record shouldn't be deleted as a form error could
+        # trigger db entries to be deleted
+        next
+      elsif updated_value.empty?
+        # Explicitly delete the entry if an empty string is received and the
+        # record belongs to the current asset, otherwise do nothing
         field.destroy! if field.asset == self
       elsif field.asset == self
         # When updating a field associated with the asset

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -2,27 +2,23 @@
 <% manage_cases_page = current_user.admin? && archive %>
 
 <div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          <%= archive ? 'All' : 'Open ' %>
-          support cases &mdash;
-          <%= model.name %>
-        </span>
-      </li>
-      <% unless archive %>
-        <li class="nav-item">
-          <%= link_to 'View all',
-            current_user.admin? ? site_cases_path(model) : cases_path,
-            class: ['nav-link', 'btn', 'btn-dark'],
-            role: 'button'
-          %>
-        </li>
-      <% end %>
-      <%= model.case_form_buttons %>
-    </ul>
-  </div>
+  <%= render 'partials/card_header_nav',
+    list_items: ([].tap do |list|
+      unless archive
+        list.push( link_to 'View all',
+          current_user.admin? ? site_cases_path(model) : cases_path,
+          class: ['nav-link', 'btn', 'btn-dark'],
+          role: 'button'
+        )
+      end
+      list.push model.case_form_buttons
+    end),
+    title: <<-EOF.strip
+      #{archive ? 'All' : 'Open'}
+      support cases &mdash;
+      #{model.name}
+    EOF
+  %>
 
   <table class="table table-responsive">
     <thead>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -2,32 +2,15 @@
 <%= render 'cases/cases_table', model: cluster, archive: true %>
 
 <div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Overview
-        </span>
-      </li>
-      <li class="nav-item">
-        <%= cluster.start_maintenance_request_link %>
-      </li>
-    </ul>
-  </div>
+  <%= render 'partials/card_header_nav',
+             title: 'Overview',
+             list_items: cluster.start_maintenance_request_link %>
 
   <%= render 'clusters/details', cluster: cluster %>
 </div>
 
 <div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Maintenance
-        </span>
-      </li>
-    </ul>
-  </div>
+  <%= render 'partials/card_header_nav', title: 'Maintenance' %>
 
   <table class="table table-responsive">
     <thead>
@@ -68,15 +51,7 @@
 </div>
 
 <div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Documents
-        </span>
-      </li>
-    </ul>
-  </div>
+  <%= render 'partials/card_header_nav', title: 'Documents' %>
 
   <ul class="list-group list-group-flush">
     <% cluster.documents.each do |document| %>
@@ -88,15 +63,7 @@
 </div>
 
 <div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Services
-        </span>
-      </li>
-    </ul>
-  </div>
+  <%= render 'partials/card_header_nav', title: 'Services' %>
 
   <table class="table table-responsive">
     <thead>
@@ -128,15 +95,7 @@
 
 <% cluster.component_groups_by_type.each do |type| %>
   <div class='card'>
-    <div class='card-header'>
-      <ul class="nav">
-        <li class="nav-item">
-          <span class="navbar-brand">
-            <%= type.name.pluralize %>
-          </span>
-        </li>
-      </ul>
-    </div>
+    <%= render 'partials/card_header_nav', title: type.name.pluralize %>
 
     <div class='card-body'>
       <% type.component_groups.each do |group| %>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -12,6 +12,17 @@
   </ul>
 </div>
 
+<div class='card'>
+  <%= render 'partials/card_header_nav', title: 'Expansions' %>
+  <ul>
+    <% component.component_expansions.each do |expansion| %>
+      <li class="list-group">
+        <%= expansion %>
+      </li>
+    <% end %>
+  </ul>
+</div>
+
 <%= render 'partials/asset_record_table',
   model: component,
   action: 'show'

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -15,11 +15,9 @@
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Expansions' %>
   <ul>
-    <% component.component_expansions.each do |expansion| %>
-      <li class="list-group">
-        <%= expansion %>
-      </li>
-    <% end %>
+    <%= render 'partials/expansion_table',
+                action: 'show',
+                model: component %>
   </ul>
 </div>
 

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -2,15 +2,7 @@
 <%= render 'cases/cases_table', model: component, archive: true %>
 
 <div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Overview
-        </span>
-      </li>
-    </ul>
-  </div>
+  <%= render('partials/card_header_nav', title: 'Overview' ) %>
 
   <ul class="list-group list-group-flush">
     <li class="list-group-item">

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -14,11 +14,9 @@
 
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Expansions' %>
-  <ul>
-    <%= render 'partials/expansion_table',
-                action: 'show',
-                model: component %>
-  </ul>
+  <%= render 'partials/expansion_table',
+              action: 'show',
+              model: component %>
 </div>
 
 <%= render 'partials/asset_record_table',

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -1,15 +1,7 @@
 <% decorated_model = model.decorate %>
 
 <div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          Asset Record
-        </span>
-      </li>
-    </ul>
-  </div>
+  <%= render('partials/card_header_nav', title: 'Asset Record') %>
 
   <%= form_tag decorated_model.asset_record_path, method: 'PATCH' do %>
     <table class="table table-responsive">

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -27,32 +27,18 @@
             <%= model.component_make.name %>
           <% end %></td>
         </tr>
-        <% model.asset_record.each do |record| %>
+        <% enum = case action
+                  when 'show'; model.asset_record.map { |r| [r, r.value] }
+                  when 'edit'; decorated_model.asset_record_form_inputs
+                  end %>
+        <% enum.each do |record, value| %>
           <tr class="form-group">
-            <% definition_id = record.definition.id %>
             <td width="50%">
-              <%= label_tag(definition_id, record.name) %>
+              <%= label_tag(record.definition.id, record.name) %>
             </td>
 
-            <% placeholder = model.find_parent_asset_record(record.definition)
-                                  .value %>
-            <% is_component_level = (record.definition.level == 'component') %>
-            <% model_is_a_component = model.is_a?(Component) %>
-            <% readonly = is_component_level && !model_is_a_component %>
-            <% readonly_msg = \
-              'This field can only be set at the individual Component level'
-            %>
-            <% form_input = text_field_tag(
-              definition_id,
-              (record.asset == model ? record.value : ''),
-              class: 'form-control',
-              placeholder: placeholder,
-              readonly: readonly,
-              style: (readonly ? 'background-color:lightgray' : ''),
-              title: (readonly ? readonly_msg : '')
-            ) %>
             <td width="50%">
-              <%= action == 'show' ? record.value : form_input %>
+              <%= value %>
             </td>
           </tr>
         <% end %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -44,20 +44,9 @@
         <% end %>
 
         <% if current_user.admin? %>
-          <% button_class = { class: ['btn', 'btn-dark', 'btn-block'] } %>
-
-          <tr>
-            <td colspan="2">
-              <%= if action == 'edit'
-                    submit_tag "Submit", **button_class
-                  else
-                    link_to 'Edit',
-                      decorated_model.edit_asset_record_path,
-                      role: 'button',
-                      **button_class
-                  end %>
-            </td>
-          </tr>
+          <%= render 'partials/edit_submit_button',
+                     action: action,
+                     edit_path: decorated_model.edit_asset_record_path %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -43,11 +43,9 @@
           </tr>
         <% end %>
 
-        <% if current_user.admin? %>
-          <%= render 'partials/edit_submit_button',
-                     action: action,
-                     edit_path: decorated_model.edit_asset_record_path %>
-        <% end %>
+        <%= render 'partials/edit_submit_button',
+                   action: action,
+                   edit_path: decorated_model.edit_asset_record_path %>
       </tbody>
     </table>
   <% end %>

--- a/app/views/partials/_card_header_nav.html.erb
+++ b/app/views/partials/_card_header_nav.html.erb
@@ -1,0 +1,15 @@
+<div class='card-header'>
+  <ul class="nav">
+    <li class="nav-item">
+      <span class="navbar-brand">
+        <%= title %>
+      </span>
+    </li>
+    <% Array.wrap(list_items ||= []).flatten.each do |item| %>
+      <li class='nav-item'>
+        <%= item %>
+      </li>
+    <% end %>
+  </ul>
+</div>
+

--- a/app/views/partials/_card_header_nav.html.erb
+++ b/app/views/partials/_card_header_nav.html.erb
@@ -6,9 +6,14 @@
       </span>
     </li>
     <% Array.wrap(list_items ||= []).flatten.each do |item| %>
-      <li class='nav-item'>
+      <% # Wrap the item in a <li> tag unless already wrapped %>
+      <% if /\A<li\s.*/.match item %>
         <%= item %>
-      </li>
+      <% else %>
+        <li class='nav-item'>
+          <%= item %>
+        </li>
+      <% end %>
     <% end %>
   </ul>
 </div>

--- a/app/views/partials/_edit_submit_button.html.erb
+++ b/app/views/partials/_edit_submit_button.html.erb
@@ -1,0 +1,16 @@
+
+<% button_class = { class: ['btn', 'btn-dark', 'btn-block'] } %>
+
+<tr>
+  <td colspan="2">
+    <%= case action
+        when 'edit'; submit_tag "Submit", **button_class
+        when 'show'
+          link_to 'Edit',
+            edit_path,
+            role: 'button',
+            **button_class
+        end %>
+  </td>
+</tr>
+

--- a/app/views/partials/_edit_submit_button.html.erb
+++ b/app/views/partials/_edit_submit_button.html.erb
@@ -3,7 +3,7 @@
 
 <% if current_user.admin? %>
   <tr>
-    <td colspan="2">
+    <td colspan="<%= colspan ||= 2 %>">
       <%= case action
           when 'edit'; submit_tag "Submit", **button_class
           when 'show'

--- a/app/views/partials/_edit_submit_button.html.erb
+++ b/app/views/partials/_edit_submit_button.html.erb
@@ -1,16 +1,18 @@
 
 <% button_class = { class: ['btn', 'btn-dark', 'btn-block'] } %>
 
-<tr>
-  <td colspan="2">
-    <%= case action
-        when 'edit'; submit_tag "Submit", **button_class
-        when 'show'
-          link_to 'Edit',
-            edit_path,
-            role: 'button',
-            **button_class
-        end %>
-  </td>
-</tr>
+<% if current_user.admin? %>
+  <tr>
+    <td colspan="2">
+      <%= case action
+          when 'edit'; submit_tag "Submit", **button_class
+          when 'show'
+            link_to 'Edit',
+              edit_path,
+              role: 'button',
+              **button_class
+          end %>
+    </td>
+  </tr>
+<% end %>
 

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -10,12 +10,16 @@
       </thead>
       <tbody>
         <% model.component_expansions.each do |expansion| %>
-          <tr>
+          <tr class="form-group">
             <td><%= expansion.expansion_type.name %></td>
             <td><%= expansion.slot %></td>
             <td><%= expansion.ports %></td>
           </tr>
         <% end %>
+        <%= render 'partials/edit_submit_button',
+                   action: action,
+                   colspan: 3,
+                   edit_path: 'tbd' %>
       </tbody>
     </table>
   </div>

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -1,6 +1,23 @@
-<% model.component_expansions.each do |expansion| %>
-  <li class="list-group">
-    <%= expansion %>
-  </li>
+<%= form_tag '/tbd', method: 'PATCH' do %>
+  <div class="table-responsive">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Expansion</th>
+          <th>Slot</th>
+          <th>No. Ports</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% model.component_expansions.each do |expansion| %>
+          <tr>
+            <td><%= expansion.expansion_type.name %></td>
+            <td><%= expansion.slot %></td>
+            <td><%= expansion.ports %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>
 

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -1,0 +1,6 @@
+<% model.component_expansions.each do |expansion| %>
+  <li class="list-group">
+    <%= expansion %>
+  </li>
+<% end %>
+

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -3,7 +3,7 @@
     <table class="table">
       <thead>
         <tr>
-          <th>Expansion</th>
+          <th>Type</th>
           <th>Slot</th>
           <th>No. Ports</th>
         </tr>

--- a/db/seeds/development/data.seeds.rb
+++ b/db/seeds/development/data.seeds.rb
@@ -34,11 +34,31 @@ site.additional_contacts.create!(
   email: 'another.contact@example.com'
 )
 
+network_expansion = ExpansionType.create!(
+  name: 'Gigabit Network Adapter'
+)
+
+memory_expansion = ExpansionType.create!(
+  name: '256GB SSD'
+)
+
 dell_server = ComponentMake.create!(
   manufacturer: 'Dell',
   model: 'zippy',
   knowledgebase_url: 'http://why.did@i-write.this/in#full',
   component_type: ComponentType.find_by_name('Server')
+)
+
+dell_server.default_expansions.create!(
+  expansion_type: network_expansion,
+  slot: '1A',
+  ports: 4
+)
+
+dell_server.default_expansions.create!(
+  expansion_type: memory_expansion,
+  slot: '2B',
+  ports: 1
 )
 
 main_cluster = site.clusters.create!(

--- a/spec/models/concerns/has_asset_record_spec.rb
+++ b/spec/models/concerns/has_asset_record_spec.rb
@@ -189,16 +189,22 @@ RSpec.describe HasAssetRecord, type: :model do
       expect(updated_fields.first.value).to eq('new value')
     end
 
-    shared_examples 'delete asset field' do |input|
-      it "deletes the record when it is updated to: #{input.inspect}" do
-        delete_field = subject.asset_record_fields.first
-        subject.update_asset_record(delete_field.definition.id => input)
-        subject.reload
-        expect(subject.asset_record_fields).not_to include(delete_field)
-      end
+    def does_value_delete_field?(value)
+      deleted_field = subject.asset_record_fields.first
+      subject.update_asset_record(deleted_field.definition.id => value)
+      subject.reload
+      !subject.asset_record_fields.include?(deleted_field)
     end
 
-    include_examples 'delete asset field', nil
-    include_examples 'delete asset field', ''
+    it "deletes the record when it is updated to an empty string" do
+      expect(does_value_delete_field?('')).to eq(true)
+    end
+
+    # This likely means that a form hasn't submitted definition correctly
+    # otherwise it would be an empty string
+    # Thus a form error shouldn't trigger a destructive action
+    it 'does not delete the record when updated to nil' do
+      expect(does_value_delete_field?(nil)).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
This PR is the first step of implementing the expansions. It focuses on updating the views to be able to show the expansions data as it is added/ updated.

It shares a commit history with #43 and should be merged first.

It DRY's up how the header bar of the tables is being created using a partial (`'partials/card_header_nav'`). For the most part, supplying a `title` to the partial is enough for it to be rendered. It does however accommodate list items to be rendered with it, as done in a few locations.

An expansions table has been added to the `component` page. This table has been inspired by `asset_record_table` and shall function in much the same way. In order for the table to be displayed, seed data has been added.

Both `asset_records` and `expansions` table need to toggle the `edit/submit` button in the same fashion. Hence the code to create it has been extracted to a partial.

A bit of work has been done to reduce the logic in the `asset_record_table` partial. This is done by creating a enumerator in a decorator. Do not review this to heavily as it is removed in latter commits.

Please note, the logic for updating the `asset_record` has bee updated as well. Refer to https://github.com/alces-software/alces-flight-center/commit/58b7c7d1314d7aaf0af9e0abb785a589242b08d5