### PR TITLE
Small bug fix making update asset record admin only

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,17 @@ Rails.application.routes.draw do
       resources :maintenance_windows, only: :new
     end
 
+    asset_record = Proc.new do
+      resource :asset_record, path: 'asset-record', only: [:edit, :update]
+    end
+
     resources :components, only: []  do
       resources :maintenance_windows, only: :new
+      asset_record.call
+    end
+
+    resources :component_groups, path: 'component-groups', only: [] do
+      asset_record.call
     end
 
     resources :services, only: []  do
@@ -67,19 +76,12 @@ Rails.application.routes.draw do
       resources :consultancy, only: :new
     end
 
-    asset_record = Proc.new do
-      resource :asset_record, path: 'asset-record', only: [:edit, :update]
-    end
-
     resources :components, only: :show do
       resources :cases, only: :new
       resources :consultancy, only: :new
-      asset_record.call
     end
 
-    resources :component_groups, path: 'component-groups', only: :show do
-      asset_record.call
-    end
+    resources :component_groups, path: 'component-groups', only: :show
 
     resources :services, only: :show do
       resources :cases, only: :new

--- a/spec/features/asset_record.rb
+++ b/spec/features/asset_record.rb
@@ -8,7 +8,8 @@ RSpec.feature 'Asset Record', type: :feature   do
   context 'with an invalid request' do
     it 'errors as a non-admin user' do
       expect do
-        visit edit_component_asset_record_path(component)
+        user = component.site.users.reject(&:admin?).first
+        visit edit_component_asset_record_path(component, as: user)
       end.to raise_error(ActionController::RoutingError)
     end
 


### PR DESCRIPTION
The tests where bad as they where from a non-logged in user which will always fail. However logged in users could access the routes to update the asset record.

This PR fixes the test and updates the routes.

It is based on #46. It should be merged before #43 