### PR TITLE
Add the `edit` and `update` action for `component_expansions`

### DIFF
--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -13,8 +13,14 @@ class ComponentExpansionsController < ApplicationController
 
   private
 
+  def expansion_errors
+    @errors_in_component_expansion_form_data ||= []
+  end
+
   def update_expansion(expansion)
-    expansion.update!(expansion_param(expansion))
+    unless expansion.update(expansion_param(expansion))
+      expansion_errors.push expansion
+    end
   end
 
   def expansion_param(expansion)

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -1,0 +1,4 @@
+class ComponentExpansionsController < ApplicationController
+  def edit
+  end
+end

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -1,4 +1,6 @@
 class ComponentExpansionsController < ApplicationController
   def edit
+    @title = "Edit Expansions"
+    @subtitle = @cluster_part.name
   end
 end

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -3,7 +3,7 @@ class ComponentExpansionsController < ApplicationController
     @cluster_part.component_expansions.each do |expansion|
       update_expansion(expansion)
     end
-    redirect_to @cluster_part
+    redirect_update
   end
 
   def edit
@@ -12,6 +12,26 @@ class ComponentExpansionsController < ApplicationController
   end
 
   private
+
+  def redirect_update
+    if expansion_errors.empty?
+      redirect_to @cluster_part
+    else
+      flash_update_error
+      redirect_to edit_component_component_expansion_path(@cluster_part)
+    end
+  end
+
+  def flash_update_error
+    header = "Errors updating expansions:\n"
+    flash[:error] = StringIO.new(header).tap do |io|
+      io.read
+      expansion_errors.each do |expansion|
+        io.puts "#{expansion.expansion_type.name}: #{expansion.errors.full_messages}"
+      end
+      io.rewind
+    end.read
+  end
 
   def expansion_errors
     @errors_in_component_expansion_form_data ||= []

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -1,10 +1,28 @@
 class ComponentExpansionsController < ApplicationController
   def update
+    @cluster_part.component_expansions.each do |expansion|
+      update_expansion(expansion)
+    end
     redirect_to @cluster_part
   end
 
   def edit
     @title = "Edit Expansions"
     @subtitle = @cluster_part.name
+  end
+
+  private
+
+  def update_expansion(expansion)
+    expansion.update!(expansion_param(expansion))
+  end
+
+  def expansion_param(expansion)
+    id = expansion.id
+    raw_params = params.require([:"slot#{id}", :"ports#{id}"])
+    {
+      slot: raw_params[0],
+      ports: raw_params[1]
+    }
   end
 end

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -1,4 +1,8 @@
 class ComponentExpansionsController < ApplicationController
+  def update
+    redirect_to @cluster_part
+  end
+
   def edit
     @title = "Edit Expansions"
     @subtitle = @cluster_part.name

--- a/app/models/expansion.rb
+++ b/app/models/expansion.rb
@@ -1,4 +1,8 @@
 class Expansion < ApplicationRecord
   belongs_to :expansion_type
   validates :type, :slot, :ports, presence: true
+  validates :ports, numericality: {
+    greater_than_or_equal_to: 0,
+    only_integer: true
+  }
 end

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -4,6 +4,7 @@
 </div>
 
 <div class="card">
-  <%= render('partials/card_header_nav', title: 'Existing Expansions') %>
+  <%= render 'partials/card_header_nav', title: 'Existing Expansions' %>
+  <%= render 'partials/expansion_table', model: @cluster_part,  action: 'edit' %>
 </div>
 

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -1,0 +1,9 @@
+
+<div class="card">
+  <%= render('partials/card_header_nav', title: 'New Expansion') %>
+</div>
+
+<div class="card">
+  <%= render('partials/card_header_nav', title: 'Existing Expansions') %>
+</div>
+

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -1,4 +1,5 @@
-<%= form_tag '/tbd', method: 'PATCH' do %>
+<% submit_path = component_component_expansion_path @cluster_part %>
+<%= form_tag submit_path, method: 'PATCH' do %>
   <div class="table-responsive">
     <table class="table">
       <thead>

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -16,10 +16,11 @@
             <td><%= expansion.ports %></td>
           </tr>
         <% end %>
+        <% edit_path = edit_component_component_expansion_path model %>
         <%= render 'partials/edit_submit_button',
                    action: action,
                    colspan: 3,
-                   edit_path: 'tbd' %>
+                   edit_path: edit_path %>
       </tbody>
     </table>
   </div>

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -18,8 +18,16 @@
               <td><%= expansion.slot %></td>
               <td><%= expansion.ports %></td>
             <% when 'edit' %>
-              <td>TDB</td>
-              <td>TDB</td>
+              <td>
+                <%= text_field_tag 'slot' + expansion.id.to_s,
+                                   expansion.slot,
+                                   class: 'form-control' %>
+              </td>
+              <td>
+                <%= text_field_tag 'ports' + expansion.id.to_s,
+                                   expansion.ports,
+                                   class: 'form-control' %>
+              </td>
             <% end %>
           </tr>
         <% end %>

--- a/app/views/partials/_expansion_table.html.erb
+++ b/app/views/partials/_expansion_table.html.erb
@@ -13,8 +13,14 @@
         <% model.component_expansions.each do |expansion| %>
           <tr class="form-group">
             <td><%= expansion.expansion_type.name %></td>
-            <td><%= expansion.slot %></td>
-            <td><%= expansion.ports %></td>
+            <% case action
+               when 'show' %>
+              <td><%= expansion.slot %></td>
+              <td><%= expansion.ports %></td>
+            <% when 'edit' %>
+              <td>TDB</td>
+              <td>TDB</td>
+            <% end %>
           </tr>
         <% end %>
         <% edit_path = edit_component_component_expansion_path model %>

--- a/app/views/partials/_flash_alert.html.erb
+++ b/app/views/partials/_flash_alert.html.erb
@@ -7,8 +7,9 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Dismiss">
           <span aria-hidden="true">&times;</span>
         </button>
-
-        <%= sanitize flash[flash_key], tags: ['code', 'strong'] %>
+        <% flash[flash_key].each_line do |flash_line| %>
+          <%= sanitize flash_line, tags: ['code', 'strong'] %><br>
+        <% end %>
       </div>
     </div>
     <div class="col"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
 
     resources :components, only: []  do
       resources :maintenance_windows, only: :new
+      resource :component_expansion, path: 'expansions', only: [:edit]
       asset_record.call
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,9 @@ Rails.application.routes.draw do
 
     resources :components, only: []  do
       resources :maintenance_windows, only: :new
-      resource :component_expansion, path: 'expansions', only: [:edit]
+      resource :component_expansion,
+               path: 'expansions',
+               only: [:edit, :update]
       asset_record.call
     end
 


### PR DESCRIPTION
Based on #47, please merge it first. This PR should be merged and then #43 is the final PR concerning expansions.

A new page has been added to edit component expansions. It preforms a bulk edit in which all the expansions for a single component can be edited at the same time.

All the expansions are otherwise updated independently, meaning if one update fails than the other updates still occur. Any errors will be flashed to the user.

Currently the only constraints are the port has to be a number. The constraints need to be updated to allow nil number of ports.