### PR TITLE
Fix develop ribbon to always show

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -74,6 +74,8 @@ body {
 #development-ribbon {
   .ribbon-holder {
     // Ribbon to indicate development site running should always appear on top.
-    z-index: 9999
+    z-index: 9999;
+    position: fixed !important;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
When combined with `pointer-events: none` this makes this both more obvious and not hide navigation buttons. As suggested at https://alces.slack.com/archives/C72GT476Y/p1517835768000174.