### PR TITLE
Case pages

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -14,6 +14,11 @@ class CasesController < ApplicationController
     current_site.cases.map(&:update_ticket_status!) if current_user.admin?
   end
 
+  def show
+    @case = Case.find(params[:id]).decorate
+    @title = "Support case: #{@case.subject}"
+  end
+
   def new
     @title = "Create new support case"
 

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -19,6 +19,20 @@ class CaseDecorator < ApplicationDecorator
     "http://helpdesk.alces-software.com/rt/Ticket/Display.html?id=#{rt_ticket_id}"
   end
 
+  def chargeable_symbol
+    h.raw(chargeable ? '&check;' : '&cross;')
+  end
+
+  def credit_charge_info
+    if credit_charge
+      credit_charge.amount.to_s
+    elsif chargeable
+      'Pending'
+    else
+      'N/A'
+    end
+  end
+
   private
 
   def issue_details

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -20,7 +20,7 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def chargeable_symbol
-    h.raw(chargeable ? '&check;' : '&cross;')
+    h.boolean_symbol(chargeable)
   end
 
   def credit_charge_info

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,10 @@ module ApplicationHelper
     fa_icon name, class: classes, **args
   end
 
+  def boolean_symbol(condition)
+    raw(condition ? '&check;' : '&cross;')
+  end
+
   def new_case_form(clusters:, single_part: nil)
     clusters_json = json_map(clusters, :case_form_json)
     raw(

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -67,7 +67,7 @@
             <td>
               <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>
             </td>
-            <td><%= raw(c.chargeable ? '&check;' : '&cross;') %></td>
+            <td><%= c.chargeable_symbol %></td>
             <td>
               <%# Show icon to bring Case's associated model under maintenance
                 in relation to Case, unless this is already the case.
@@ -96,23 +96,15 @@
             <td><%= render 'cases/archive_icon', support_case: c %></td>
           <% end %>
           <td>
-            <% if c.credit_charge_allowed? %>
-              <% if manage_cases_page %>
-                <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
-                <%= form_for credit_charge, class: 'form-inline' do |f| %>
-                  <%= f.hidden_field :case_id %>
-                  <%= f.number_field :amount, class: 'form-control', required: true %>
-                  <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
-                <% end %>
-              <% elsif c.credit_charge %>
-                <%= c.credit_charge.amount %>
-              <% else %>
-                <em>Pending</em>
+            <% if c.credit_charge_allowed? && manage_cases_page %>
+              <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
+              <%= form_for credit_charge, class: 'form-inline' do |f| %>
+                <%= f.hidden_field :case_id %>
+                <%= f.number_field :amount, class: 'form-control', required: true %>
+                <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
               <% end %>
-            <% elsif !c.chargeable %>
-              <em>N/A</em>
             <% else %>
-              <em>Pending</em>
+              <%= c.credit_charge_info %>
             <% end %>
           </td>
         </tr>

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -33,7 +33,7 @@
           <th>Contact support</th>
           <th>Archive<%= archive ? '/Restore' : '' %></th>
         <% end %>
-        <th>Credits</th>
+        <th>Credit charge</th>
       </tr>
     </thead>
 

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -21,10 +21,9 @@
       <tr>
         <th>Date</th>
         <th>Creator</th>
-        <th>Issue</th>
+        <th>Subject</th>
         <th>Association</th>
         <th>Ticket ID</th>
-        <th>Details</th>
         <% if manage_cases_page %>
           <th>Ticket status</th>
           <th>Chargeable</th>
@@ -59,10 +58,9 @@
             <%= c.created_at.to_formatted_s(:short) %>
           </td>
           <td><%= c.user.name %></td>
-          <td><%= c.issue.name %></td>
+          <td><%= link_to c.subject, case_path(c) %></td>
           <td><%= c.association_info %></td>
           <td><%= c.rt_ticket_id %></td>
-          <td><%= simple_format(c.details) %></td>
           <% if manage_cases_page %>
             <td>
               <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,0 +1,52 @@
+
+<div class='card'>
+  <%= render 'partials/card_header_nav',
+    title: 'Overview'
+  %>
+  <table class="table table-responsive">
+    <tr style="width: 100%;">
+      <th>Date</th>
+      <td><%= @case.created_at.to_formatted_s(:long) %></td>
+    </tr>
+    <tr>
+      <th>Creator</th>
+      <td><%= @case.user.name %></td>
+    </tr>
+    <tr>
+      <th>Association</th>
+      <td><%= @case.association_info %></td>
+    </tr>
+    <tr>
+      <th>Ticket ID</th>
+      <td><%= @case.rt_ticket_id %></td>
+    </tr>
+    <tr>
+      <th>Category</th>
+      <td><%= @case.category&.name || 'None' %></td>
+    </tr>
+    <tr>
+      <th>Issue</th>
+      <td><%= @case.issue.name %></td>
+    </tr>
+    <tr>
+      <th>Chargeable</th>
+      <td><%= @case.chargeable_symbol %></td>
+    </tr>
+    <tr>
+      <th>Credit charge</th>
+      <td><%= @case.credit_charge_info %></td>
+    </tr>
+    <tr>
+      <th>Archived</th>
+      <td><%= boolean_symbol(@case.archived) %></td>
+    </tr>
+    <tr>
+      <th>Subject</th>
+      <td><%= @case.subject %></td>
+    </tr>
+    <tr>
+      <th>Details</th>
+      <td><%= simple_format(@case.details) %></td>
+    </tr>
+  </table>
+</div>

--- a/bin/import-production-data
+++ b/bin/import-production-data
@@ -45,6 +45,13 @@ import_backup() {
   bin/rake db:drop
   bin/rake db:create
 
+  # This is required so the test database is left in a usable state, as the
+  # above commands drop and recreate the test database also, and there is
+  # seemingly no way to have these only run for the development database (short
+  # of monkeypatching or writing a custom Rake task). Relevant issue:
+  # https://github.com/rails/rails/issues/27299.
+  bin/rake db:schema:load RAILS_ENV='test'
+
   log_info 'Reading development database access details...'
   dev_database_username="$(load_dev_database_config_value 'username')"
   dev_database_name="$(load_dev_database_config_value 'database')"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   constraints Clearance::Constraints::SignedIn.new { |user| user.admin? } do
     root 'sites#index'
     resources :sites, only: [:show, :index] do
-      resources :cases, only: [:new, :index]
+      resources :cases, only: [:new, :index, :show]
     end
 
     resources :cases, only: [] do
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
     root 'sites#show'
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 
-    resources :cases, only: [:new, :index, :create] do
+    resources :cases, only: [:new, :index, :show, :create] do
       member do
         post :archive
         post :restore

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -69,4 +69,27 @@ RSpec.describe CaseDecorator do
       end
     end
   end
+
+  describe '#credit_charge_info' do
+    it 'gives credit charge amount when set' do
+      support_case = create(:case)
+      create(:credit_charge, case: support_case, amount: 5)
+
+      expect(support_case.decorate.credit_charge_info).to eq '5'
+    end
+
+    it "gives 'N/A' when issue is not chargeable" do
+      issue = create(:issue, chargeable: false)
+      support_case = create(:case, issue: issue)
+
+      expect(support_case.decorate.credit_charge_info).to eq 'N/A'
+    end
+
+    it "gives 'Pending' when issue is chargeable and no credit charge" do
+      issue = create(:issue, chargeable: true)
+      support_case = create(:case, issue: issue)
+
+      expect(support_case.decorate.credit_charge_info).to eq 'Pending'
+    end
+  end
 end

--- a/spec/features/cases_table_spec.rb
+++ b/spec/features/cases_table_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe 'Cases table', type: :feature do
   let :cluster { create(:cluster, site: site) }
 
   let! :open_case do
-    create(:open_case, cluster: cluster, details: 'Open case')
+    create(:open_case, cluster: cluster, subject: 'Open case')
   end
 
   let! :archived_case do
-    create(:archived_case, cluster: cluster, details: 'Archived case')
+    create(:archived_case, cluster: cluster, subject: 'Archived case')
   end
 
   RSpec.shared_examples 'open cases table rendered' do

--- a/spec/features/cases_table_spec.rb
+++ b/spec/features/cases_table_spec.rb
@@ -83,13 +83,6 @@ RSpec.describe 'Cases table', type: :feature do
       it 'renders table of all Cases, without Contact-specific buttons/info' do
         visit site_cases_path(site, as: user)
 
-        # XXX Displaying details disabled at the moment due to space
-        # constraints - either remove these or add back after reorganizing
-        # table.
-        # cases = all('tr').map(&:text)
-        # expect(cases).to have_text('Open case')
-        # expect(cases).to have_text('Archived case')
-
         headings = all('th').map(&:text)
         expect(headings).not_to include('Contact support')
         expect(headings).not_to include('Archive/Restore')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -28,4 +28,14 @@ RSpec.describe ApplicationHelper do
       ).to eq([:not_nil].to_json)
     end
   end
+
+  describe '#boolean_symbol' do
+    it 'gives check when condition is true' do
+      expect(boolean_symbol(true)).to eq(raw('&check;'))
+    end
+
+    it 'gives cross when condition is false' do
+      expect(boolean_symbol(false)).to eq(raw('&cross;'))
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new Case page showing all user-relevant information for each Case, and then simplifies the Case table to be less busy and show less information, and link to this new page for each Case.

Trello: https://trello.com/c/dV0HHDRQ/156-show-subject-and-not-details-have-new-case-page-showing-all-case-info-including-details.