### PR TITLE
Make Sentry DSN configuration optional.

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,9 @@
 
-Raven.configure do |config|
-  config.dsn = ENV.fetch('SENTRY_DSN')
+if ENV.has_key?('SENTRY_DSN')
+  Raven.configure do |config|
+    config.dsn = ENV.fetch('SENTRY_DSN')
 
-  # Do not send any filtered parameters to Sentry.
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+    # Do not send any filtered parameters to Sentry.
+    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  end
 end


### PR DESCRIPTION
If a DSN isn't set (e.g. for running in development) then Sentry won't report errors. This is probably what we want when running on dev machines.