### PR TITLE
Create the `ClusterLog` model

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -22,6 +22,7 @@ class Case < ApplicationRecord
   belongs_to :user
   has_one :credit_charge, required: false
   has_many :maintenance_windows
+  has_and_belongs_to_many :cluster_log
 
   delegate :category, :chargeable, to: :issue
   delegate :site, to: :cluster, allow_nil: true

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -1,5 +1,6 @@
 
 class ClusterLog < ApplicationRecord
+  has_one :site, through: :cluster
   belongs_to :cluster
   belongs_to :engineer, class_name: 'User', foreign_key: "user_id"
   has_and_belongs_to_many :cases

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -4,5 +4,14 @@ class ClusterLog < ApplicationRecord
   belongs_to :engineer, class_name: 'User', foreign_key: "user_id"
 
   validates :details, presence: true
+  validate :engineer_is_a_admin
+
+  private
+
+  def engineer_is_a_admin
+    unless engineer&.admin?
+      errors.add(:engineer, 'must be an admin')
+    end
+  end
 end
 

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -20,7 +20,7 @@ class ClusterLog < ApplicationRecord
   def cases_belong_to_cluster
     cases.each do |kase|
       unless kase.cluster == cluster
-        msg = "##{kase.rt_ticket_id} is for a different cluster"
+        msg = "ticket ##{kase.rt_ticket_id} is for a different cluster"
         errors.add(:cases, msg)
       end
     end

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -1,2 +1,8 @@
+
 class ClusterLog < ApplicationRecord
+  belongs_to :cluster
+  belongs_to :engineer, class_name: 'User', foreign_key: "user_id"
+
+  validates :details, presence: true
 end
+

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -6,12 +6,22 @@ class ClusterLog < ApplicationRecord
 
   validates :details, presence: true
   validate :engineer_is_a_admin
+  validate :cases_belong_to_cluster
 
   private
 
   def engineer_is_a_admin
     unless engineer&.admin?
       errors.add(:engineer, 'must be an admin')
+    end
+  end
+
+  def cases_belong_to_cluster
+    cases.each do |kase|
+      unless kase.cluster == cluster
+        msg = "##{kase.rt_ticket_id} is for a different cluster"
+        errors.add(:cases, msg)
+      end
     end
   end
 end

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -1,0 +1,2 @@
+class ClusterLog < ApplicationRecord
+end

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -2,6 +2,7 @@
 class ClusterLog < ApplicationRecord
   belongs_to :cluster
   belongs_to :engineer, class_name: 'User', foreign_key: "user_id"
+  has_and_belongs_to_many :cases
 
   validates :details, presence: true
   validate :engineer_is_a_admin

--- a/db/migrate/20180208121324_add_cluster_log.rb
+++ b/db/migrate/20180208121324_add_cluster_log.rb
@@ -1,0 +1,12 @@
+class AddClusterLog < ActiveRecord::Migration[5.1]
+  def change
+    create_table :cluster_logs do |t|
+      t.text :details, null: false
+      t.references :cluster, null: false
+      t.references :user, null: false
+      t.timestamps
+    end
+
+    create_join_table :cases, :cluster_logs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,11 +72,26 @@ ActiveRecord::Schema.define(version: 20180209125114) do
     t.index ["user_id"], name: "index_cases_on_user_id"
   end
 
+  create_table "cases_cluster_logs", id: false, force: :cascade do |t|
+    t.bigint "case_id", null: false
+    t.bigint "cluster_log_id", null: false
+  end
+
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "cluster_logs", force: :cascade do |t|
+    t.text "details", null: false
+    t.bigint "cluster_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cluster_id"], name: "index_cluster_logs_on_cluster_id"
+    t.index ["user_id"], name: "index_cluster_logs_on_user_id"
   end
 
   create_table "clusters", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,8 +1,11 @@
 
 FactoryBot.define do
   factory :cluster_log do
-    
+    details 'I am the factory default details'
+    cluster
+    engineer { create :admin }
   end
+
   sequence :email do |n|
     "a.scientist.#{n}@liverpool.ac.uk"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,8 @@
 
 FactoryBot.define do
+  factory :cluster_log do
+    
+  end
   sequence :email do |n|
     "a.scientist.#{n}@liverpool.ac.uk"
   end

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe ClusterLog, type: :model do
   context 'with an invalid engineer' do
     it 'errors without an engineer' do
       log = build(:cluster_log, engineer: nil)
-      expect(log).not_to be_valid
 
+      log.valid? # Required otherwise the errors haven't been generated
       expected_error = 'Engineer must exist'
       actual_errors = log.errors.full_messages.join("\n")
+
+      expect(log).not_to be_valid
       expect(actual_errors).to include(expected_error)
     end
 
@@ -50,13 +52,15 @@ RSpec.describe ClusterLog, type: :model do
     end
 
     it 'validates that all cases belong to its cluster' do
+      other_cluster = create(:cluster, name: 'other-cluster')
+      bad_case = create(:case, cluster: other_cluster, subject: 'Bad Case')
+
       ['other-case1', 'other-case2', 'other-case3'].each do |case_msg|
         create_case(case_msg)
       end
-      other_cluster = create(:cluster, name: 'other-cluster')
-      bad_case = create(:case, cluster: other_cluster, subject: 'Bad Case')
       subject.cases << bad_case
       subject.reload
+
       expect_single_error subject, "#{bad_case.rt_ticket_id}"
     end
   end

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ClusterLog, type: :model do
       bad_case = create(:case, cluster: other_cluster, subject: 'Bad Case')
       subject.cases << bad_case
       subject.reload
-      expect_single_error subject, 'different cluster'
+      expect_single_error subject, "#{bad_case.rt_ticket_id}"
     end
   end
 end

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -32,5 +32,20 @@ RSpec.describe ClusterLog, type: :model do
       expect_single_error log, 'admin'
     end
   end
+
+  describe '#cases' do
+    subject { create(:cluster_log) }
+
+    def create_case(case_subject)
+      kase = create(:case, cluster: subject.cluster, subject: case_subject)
+      subject.cases << kase
+    end
+
+    it 'can have multiple cases' do
+      case_msgs = ['first', 'second', 'third']
+      case_msgs.each { |m| create_case(m) }
+      expect(subject.cases.map(&:subject)).to contain_exactly(*case_msgs)
+    end
+  end
 end
 

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe ClusterLog, type: :model do
     end
 
     it 'can have multiple cases' do
-      case_msgs = ['first', 'second', 'third']
-      case_msgs.each { |m| create_case(m) }
+      case_subs = ['first', 'second', 'third']
+      case_subs.each { |m| create_case(m) }
       expect(subject).to be_valid
-      expect(subject.cases.map(&:subject)).to contain_exactly(*case_msgs)
+      expect(subject.cases.map(&:subject)).to contain_exactly(*case_subs)
     end
 
     it 'validates that all cases belong to its cluster' do

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ClusterLog, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe ClusterLog, type: :model do
       other_cluster = create(:cluster, name: 'other-cluster')
       bad_case = create(:case, cluster: other_cluster, subject: 'Bad Case')
 
-      ['other-case1', 'other-case2', 'other-case3'].each do |case_msg|
-        create_case(case_msg)
-      end
+      create_case('perfectly normal case')
       subject.cases << bad_case
       subject.reload
 

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe ClusterLog, type: :model do
     expect(model.errors.full_messages.first).to include(error_text)
   end
 
-  it 'errors without an engineer' do
-    log = build(:cluster_log, engineer: nil)
-    expect_single_error log, 'Engineer'
-  end
-
   it 'errors without a cluster' do
     log = build(:cluster_log, cluster: nil)
     expect_single_error log, 'Cluster'
@@ -20,6 +15,22 @@ RSpec.describe ClusterLog, type: :model do
   it 'errors without any details' do
     log = build(:cluster_log, details: nil)
     expect_single_error log, 'Details'
+  end
+
+  context 'with an invalid engineer' do
+    it 'errors without an engineer' do
+      log = build(:cluster_log, engineer: nil)
+      expect(log).not_to be_valid
+
+      expected_error = 'Engineer must exist'
+      actual_errors = log.errors.full_messages.join("\n")
+      expect(actual_errors).to include(expected_error)
+    end
+
+    it 'errors if the engineer is not an admin' do
+      log = build(:cluster_log, engineer: create(:user))
+      expect_single_error log, 'admin'
+    end
   end
 end
 

--- a/spec/models/cluster_log_spec.rb
+++ b/spec/models/cluster_log_spec.rb
@@ -1,5 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe ClusterLog, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  def expect_single_error(model, error_text)
+    expect(model).not_to be_valid
+    expect(model.errors.size).to eq(1)
+    expect(model.errors.full_messages.first).to include(error_text)
+  end
+
+  it 'errors without an engineer' do
+    log = build(:cluster_log, engineer: nil)
+    expect_single_error log, 'Engineer'
+  end
+
+  it 'errors without a cluster' do
+    log = build(:cluster_log, cluster: nil)
+    expect_single_error log, 'Cluster'
+  end
+
+  it 'errors without any details' do
+    log = build(:cluster_log, details: nil)
+    expect_single_error log, 'Details'
+  end
 end
+


### PR DESCRIPTION
This will allow "engineers" to log events against a cluster. It is directly linked to the cluster and thus the logs do not need to be associated with an open case. The `engineer` can be any flight centre admin user.

The `ClusterLog` can also be associated with cases. This is a many-many relationship to allow for flexibility. The only constraint is all the `cases` belong to the same cluster as the log itself. This is enforced at the model level.

A `cluster_log.related_ticket_numbers` method has not been included at this time. It is essence an alias of `cluster_log.cases.map(&:rt_ticket_id)` which is of similar length. The `RT` ids are likely going to be a view issue and not something required at the model level. Any form that needs to display the `RT_id` will also need the `id` which is the actual primary key.