### PR TITLE
Create the route, view and controller for ClusterLog

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,8 @@ class ApplicationController < ActionController::Base
 
   def error_flash_models(models, header)
     flash[:error] = header + "\n" + models.map do |model|
-      block_given? ? (yield model) : model.errors.full_messages
+      prefix = block_given? ? ((yield model).to_s + ': ') : ''
+      prefix + model.errors.full_messages.to_s
     end.join("\n")
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,9 @@ class ApplicationController < ActionController::Base
   rescue_from ReadPermissionsError, with: :not_found
 
   def error_flash_models(models, header = 'Errors:')
-    flash[:error] = header + "\n" + (models.map { |m| yield m }).join("\n")
+    flash[:error] = header + "\n" + models.map do |model|
+      block_given? ? (yield model) : model.errors.full_messages
+    end.join("\n")
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ReadPermissionsError, with: :not_found
 
-  def error_flash_models(models, header = 'Errors:')
+  def error_flash_models(models, header)
     flash[:error] = header + "\n" + models.map do |model|
       block_given? ? (yield model) : model.errors.full_messages
     end.join("\n")

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -14,7 +14,7 @@ class AssetRecordsController < ApplicationController
     else
       header = 'The following records failed to update:'
       error_flash_models(failed_updates, header) do |model|
-        "#{model.definition.field_name}: #{model.errors.full_messages}"
+        model.definition.field_name
       end
       redirect_back fallback_location: @asset
     end

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -1,0 +1,5 @@
+class ClusterLogsController < ApplicationController
+  def index
+    @title = 'Logs'
+  end
+end

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -7,7 +7,12 @@ class ClusterLogsController < ApplicationController
   end
 
   def create
-    p log_params
+    new_log = @cluster.cluster_logs.create(**log_params)
+    if new_log.valid?
+      flash[:success] = 'Added new log entry'
+    else
+      error_flash_models [new_log], 'Could not add log entry'
+    end
     redirect_back fallback_location: @cluster
   end
 
@@ -16,7 +21,7 @@ class ClusterLogsController < ApplicationController
   def log_params
     params.require(:cluster_log)
           .permit(:details, case_ids: [])
-          .to_h
+          .to_h.symbolize_keys
           .merge(engineer: current_user)
           .tap do |h|
             h[:case_ids] = h[:case_ids].reject(&:blank?)

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -1,8 +1,8 @@
 class ClusterLogsController < ApplicationController
   def index
     @title = 'Logs'
+    @new_log = ClusterLog.new
     @logs = @cluster.cluster_logs
-    @new_log = @cluster.cluster_logs.new
     @cases = @cluster.cases.order(created_at: :desc)
   end
 

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -7,5 +7,19 @@ class ClusterLogsController < ApplicationController
   end
 
   def create
+    p log_params
+    redirect_back fallback_location: @cluster
+  end
+
+  private
+
+  def log_params
+    params.require(:cluster_log)
+          .permit(:details, case_ids: [])
+          .to_h
+          .merge(engineer: current_user)
+          .tap do |h|
+            h[:case_ids] = h[:case_ids].reject(&:blank?)
+          end
   end
 end

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -23,8 +23,5 @@ class ClusterLogsController < ApplicationController
           .permit(:details, case_ids: [])
           .to_h.symbolize_keys
           .merge(engineer: current_user)
-          .tap do |h|
-            h[:case_ids] = h[:case_ids].reject(&:blank?)
-          end
   end
 end

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -2,5 +2,10 @@ class ClusterLogsController < ApplicationController
   def index
     @title = 'Logs'
     @logs = @cluster.cluster_logs
+    @new_case = @cluster.cases.new
+    @cases = @cluster.cases.order(created_at: :desc)
+  end
+
+  def create
   end
 end

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -7,8 +7,8 @@ class ClusterLogsController < ApplicationController
   end
 
   def create
-    new_log = @cluster.cluster_logs.create(log_params)
-    if new_log.valid?
+    new_log = @cluster.cluster_logs.build(log_params)
+    if new_log.save
       flash[:success] = 'Added new log entry'
     else
       error_flash_models [new_log], 'Could not add log entry'

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -1,5 +1,6 @@
 class ClusterLogsController < ApplicationController
   def index
     @title = 'Logs'
+    @logs = @cluster.cluster_logs
   end
 end

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -7,7 +7,7 @@ class ClusterLogsController < ApplicationController
   end
 
   def create
-    new_log = @cluster.cluster_logs.create(**log_params)
+    new_log = @cluster.cluster_logs.create(log_params)
     if new_log.valid?
       flash[:success] = 'Added new log entry'
     else
@@ -21,7 +21,6 @@ class ClusterLogsController < ApplicationController
   def log_params
     params.require(:cluster_log)
           .permit(:details, case_ids: [])
-          .to_h.symbolize_keys
           .merge(engineer: current_user)
   end
 end

--- a/app/controllers/cluster_logs_controller.rb
+++ b/app/controllers/cluster_logs_controller.rb
@@ -2,7 +2,7 @@ class ClusterLogsController < ApplicationController
   def index
     @title = 'Logs'
     @logs = @cluster.cluster_logs
-    @new_case = @cluster.cases.new
+    @new_log = @cluster.cluster_logs.new
     @cases = @cluster.cases.order(created_at: :desc)
   end
 

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -49,7 +49,7 @@ class ComponentExpansionsController < ApplicationController
 
   def flash_errors(header)
     error_flash_models(expansion_errors, header) do |expansion|
-      "#{expansion.expansion_type.name}: #{expansion.errors.full_messages}"
+      expansion.expansion_type.name
     end
   end
 

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -10,6 +10,7 @@ class CaseDecorator < ApplicationDecorator
       "Created by #{user.name}"
     ].join(' | ')
   end
+  alias_method :rt_long_text, :maintenance_window_form_info
 
   def association_info
     associated_model.decorate.links

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -1,7 +1,7 @@
 class CaseDecorator < ApplicationDecorator
   delegate_all
 
-  def maintenance_window_form_info
+  def case_select_details
     [
       "RT ticket #{rt_ticket_id}",
       created_at.to_formatted_s(:long),
@@ -10,7 +10,6 @@ class CaseDecorator < ApplicationDecorator
       "Created by #{user.name}"
     ].join(' | ')
   end
-  alias_method :rt_long_text, :maintenance_window_form_info
 
   def association_info
     associated_model.decorate.links

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -14,6 +14,7 @@ class Cluster < ApplicationRecord
   has_many :credit_deposits
   has_many :credit_charges, through: :cases
   has_many :maintenance_windows
+  has_many :cluster_logs, dependent: :destroy
 
   validates_associated :site
   validates :name, presence: true

--- a/app/models/cluster_log.rb
+++ b/app/models/cluster_log.rb
@@ -1,7 +1,7 @@
 
 class ClusterLog < ApplicationRecord
-  has_one :site, through: :cluster
   belongs_to :cluster
+  has_one :site, through: :cluster
   belongs_to :engineer, class_name: 'User', foreign_key: "user_id"
   has_and_belongs_to_many :cases
 

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -24,7 +24,7 @@
   </div>
 <% end %>
 
-<div class='card  '>
+<div class='card'>
   <%= render 'partials/card_header_nav', title: 'Entries' %>
   <div class='table-responsive'>
     <table class='table'>

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -14,7 +14,11 @@
                                   :id,
                                   :case_select_details,
                                   {},
-                                  { multiple: true } %>
+                                  {
+                                    multiple: true,
+                                    class: "form-control",
+                                    style: 'overflow:scroll',
+                                  } %>
         </div>
         <div class='form-group'>
           <%= f.submit 'Submit', class: dark_button_classes %>

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -12,7 +12,7 @@
           <%= f.collection_select :case_ids,
                                   @cases.decorate,
                                   :id,
-                                  :rt_long_text,
+                                  :case_select_details,
                                   {},
                                   { multiple: true } %>
         </div>

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -34,6 +34,12 @@
         <th>Details</th>
         <th>Tickets</th>
       </thead>
+      <% @logs.each do |log| %>
+        <tr>
+          <td><%= log.created_at %></td>
+          <td><%= log.engineer.name %></td>
+        </tr>
+      <% end %>
     </table>
   </div>
 </div>

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -1,18 +1,24 @@
 <% if current_user.admin? %>
   <div class='card'>
     <%= render 'partials/card_header_nav', title: 'Add Log' %>
-    <div class='table-responsive'>
-      <%= form_for @new_case do |f| %>
-        <table class='table'>
-          <tr><td>
-            <%= f.collection_select :id,
-                                    @cases.decorate,
-                                    :id,
-                                    :rt_long_text,
-                                    {},
-                                    { multiple: true } %>
-          </td></tr>
-        </table>
+    <div class='card-body table-responsive'>
+      <%= form_for [:cluster, @new_log] do |f| %>
+        <div class='form-group'>
+          <%= f.label :details, 'Details'%>
+          <%= f.text_area :details, class: 'form-control'%>
+        </div>
+        <div class='form-group'>
+          <%= f.label :case_ids, 'Related Ticket(s)' %>
+          <%= f.collection_select :case_ids,
+                                  @cases.decorate,
+                                  :id,
+                                  :rt_long_text,
+                                  {},
+                                  { multiple: true } %>
+        </div>
+        <div class='form-group'>
+          <%= f.submit 'Submit', class: dark_button_classes %>
+        </div>
       <% end %>
     </div>
   </div>
@@ -31,3 +37,4 @@
     </table>
   </div>
 </div>
+

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -38,6 +38,12 @@
         <tr>
           <td><%= log.created_at %></td>
           <td><%= log.engineer.name %></td>
+          <td><%= log.details %></td>
+          <td>
+            <% log.cases.each do |kase| %>
+              <%= link_to kase.rt_ticket_id, kase %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </table>

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -1,14 +1,32 @@
+<% if current_user.admin? %>
+  <div class='card'>
+    <%= render 'partials/card_header_nav', title: 'Add Log' %>
+    <div class='table-responsive'>
+      <%= form_for @new_case do |f| %>
+        <table class='table'>
+          <tr><td>
+            <%= f.collection_select :id,
+                                    @cases.decorate,
+                                    :id,
+                                    :rt_long_text,
+                                    {},
+                                    { multiple: true } %>
+          </td></tr>
+        </table>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
 <div class='card  '>
   <%= render 'partials/card_header_nav', title: 'Entries' %>
   <div class='table-responsive'>
     <table class='table'>
       <thead>
-        <tr>
-          <th>Date Created</th>
-          <th>Engineer</th>
-          <th>Details</th>
-          <th>Tickets</th>
-        </tr>
+        <th>Date Created</th>
+        <th>Engineer</th>
+        <th>Details</th>
+        <th>Tickets</th>
       </thead>
     </table>
   </div>

--- a/app/views/cluster_logs/index.html.erb
+++ b/app/views/cluster_logs/index.html.erb
@@ -1,0 +1,15 @@
+<div class='card  '>
+  <%= render 'partials/card_header_nav', title: 'Entries' %>
+  <div class='table-responsive'>
+    <table class='table'>
+      <thead>
+        <tr>
+          <th>Date Created</th>
+          <th>Engineer</th>
+          <th>Details</th>
+          <th>Tickets</th>
+        </tr>
+      </thead>
+    </table>
+  </div>
+</div>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -4,7 +4,15 @@
 <div class='card'>
   <%= render 'partials/card_header_nav',
              title: 'Overview',
-             list_items: cluster.start_maintenance_request_link %>
+             list_items: [
+               cluster.start_maintenance_request_link,
+               link_to(
+                 'Logs',
+                 cluster_cluster_logs_path(cluster),
+                 role: 'button',
+                 class: dark_button_classes
+               )
+             ] %>
 
   <%= render 'clusters/details', cluster: cluster %>
 </div>

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -10,7 +10,7 @@
       :case_id,
       @cluster.cases.order(created_at: :desc).decorate,
       :id,
-      :maintenance_window_form_info,
+      :case_select_details,
       {},
       {class: ['form-control']}
     ) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
     resources :clusters, only: :show do
       resources :cases, only: :new
       resources :consultancy, only: :new
+      resources :cluster_logs, path: 'logs', only: :index
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
     resources :clusters, only: []  do
       resources :maintenance_windows, only: :new
+      resources :cluster_logs, path: 'logs', only: [:create]
     end
 
     asset_record = Proc.new do

--- a/spec/features/cluster_log.rb
+++ b/spec/features/cluster_log.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.feature 'Add Log', type: :feature do
+  let :engineer { create(:admin) }
+  let :cluster { create(:cluster) }
+  let :case_details { ['details1', 'details2', 'details3'] }
+  let! :cases do
+    case_details.map { |d| create(:case, cluster: cluster, details: d) }
+  end
+  let :case_select_details do
+    cases.map { |c| c.decorate.case_select_details }
+  end
+  let :case_select_id { 'cluster_log_case_ids' }
+  let :case_details_id { 'cluster_log_details' }
+
+  before :each do
+    visit cluster_cluster_logs_path cluster, as: engineer
+  end
+
+  def submit_log
+    click_button 'Submit'
+    ClusterLog.first
+  end
+
+  it 'has the case select box' do
+    expect(page).to have_select case_select_id,
+                                options: case_select_details
+  end
+
+  it 'adds a log by the currently logged in engineer' do
+    log_details = 'New log details to make sure the match is correct'
+    fill_in case_details_id, with: log_details
+    log = submit_log
+
+    expect(log).not_to be_nil
+    expect(log.details).to eq(log_details)
+    expect(log.engineer).to eq(engineer)
+    expect(log.cases).to be_blank
+  end
+
+  it 'can add multiple tickets/cases to the view' do
+    fill_in case_details_id, with: 'The details need to be filled'
+    log_cases = [cases.first, cases.last].each do |kase|
+      select kase.decorate.case_select_details, from: case_select_id
+    end
+
+    expect(submit_log.cases).to contain_exactly(*log_cases)
+  end
+end


### PR DESCRIPTION
This PR is based on #62, please merge it first

Most of this PR is reasonable straight forward. There was no major refactoring required in implementing the view. The `index` page is used to display all the logs for a cluster. `admins` also have an additional form (on the same page) to add a new log.