### PR TITLE
Create more frequent database backups

### DIFF
--- a/bin/backup-database
+++ b/bin/backup-database
@@ -11,7 +11,7 @@ IFS=$'\n\t'
 # `scp bin/backup-database ubuntu@apps.alces-flight.com:/home/ubuntu/flight-center-backup-database`;
 #
 # 2. on server: ensure crontab contains the following line:
-# `0 2 * * * /home/ubuntu/flight-center-backup-database`.
+# `* */3 * * * /home/ubuntu/flight-center-backup-database`.
 
 APP_NAME='flight-center'
 BACKUPS_S3_URL='s3://alces-flight-center/backups'
@@ -24,7 +24,7 @@ main() {
   secret_key="$(dokku config:get $APP_NAME AWS_SECRET_ACCESS_KEY)"
   aws_region="$(dokku config:get $APP_NAME AWS_REGION)"
 
-  backup_file="$(date -Idate)"
+  backup_file="$(date --iso-8601=minutes)"
   backup_url="$BACKUPS_S3_URL/$backup_file"
 
   echo 'Dumping database...'

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -3,8 +3,8 @@
 
 ## Overview
 
-- Once per day, currently at 2am, the Alces Flight Center Postgres database is
-  dumped and backed up to S3.
+- Every 3 hours the Alces Flight Center Postgres database is dumped and backed
+  up to S3.
 
 - This process is handled by the [bin/backup-database](/bin/backup-database) script.
 


### PR DESCRIPTION
As requested by @mjtko, run the database backup script every 3 hours
rather than once per day to reduce the amount of data that could be lost
at any particular time.

This just involves updating the documentation and changing the file
names used for saving backups so backups on the same day do not
overwrite each other.