### PR TITLE
Only include unfinished maintenance windows when getting open maintenance windows

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -13,7 +13,6 @@ class Cluster < ApplicationRecord
   has_many :cases
   has_many :credit_deposits
   has_many :credit_charges, through: :cases
-  has_many :maintenance_windows
   has_many :logs, dependent: :destroy
 
   validates_associated :site

--- a/app/models/concerns/cluster_part.rb
+++ b/app/models/concerns/cluster_part.rb
@@ -9,7 +9,6 @@ module ClusterPart
 
   included do
     has_many :cases
-    has_many :maintenance_windows
 
     validates :name, presence: true
     validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true

--- a/app/models/concerns/has_maintenance_windows.rb
+++ b/app/models/concerns/has_maintenance_windows.rb
@@ -2,6 +2,10 @@
 module HasMaintenanceWindows
   extend ActiveSupport::Concern
 
+  included do
+    has_many :maintenance_windows
+  end
+
   def open_maintenance_windows
     maintenance_windows.where.not(state: MaintenanceWindow.finished_states)
   end

--- a/app/models/concerns/has_maintenance_windows.rb
+++ b/app/models/concerns/has_maintenance_windows.rb
@@ -3,6 +3,6 @@ module HasMaintenanceWindows
   extend ActiveSupport::Concern
 
   def open_maintenance_windows
-    maintenance_windows.where.not(state: :ended)
+    maintenance_windows.where.not(state: MaintenanceWindow.finished_states)
   end
 end

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -63,7 +63,7 @@ class MaintenanceWindow < ApplicationRecord
     super unless symbol =~ /^([a-z]+)_(at|by)$/
     state = $1.to_sym
     property = $2.to_sym
-    super unless possible_states.include?(state)
+    super unless self.class.possible_states.include?(state)
     last_transition_property(state: state, property: property)
   end
 
@@ -95,8 +95,8 @@ class MaintenanceWindow < ApplicationRecord
     [cluster, component, service].select(&:present?).length
   end
 
-  def possible_states
-    self.class.state_machine.states.keys
+  def self.possible_states
+    state_machine.states.keys
   end
 
   def last_transition_property(state:, property:)

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -38,8 +38,19 @@ class MaintenanceWindow < ApplicationRecord
     end
   end
 
-  def self.possible_states
-    state_machine.states.keys
+  class << self
+    def possible_states
+      state_machine.states.keys
+    end
+
+    def finished_states
+      [
+        :cancelled,
+        :ended,
+        :expired,
+        :rejected,
+      ]
+    end
   end
 
   alias_method :in_progress?, :confirmed?

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -38,6 +38,10 @@ class MaintenanceWindow < ApplicationRecord
     end
   end
 
+  def self.possible_states
+    state_machine.states.keys
+  end
+
   alias_method :in_progress?, :confirmed?
 
   def associated_model
@@ -93,10 +97,6 @@ class MaintenanceWindow < ApplicationRecord
 
   def number_associated_models
     [cluster, component, service].select(&:present?).length
-  end
-
-  def self.possible_states
-    state_machine.states.keys
   end
 
   def last_transition_property(state:, property:)

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -316,4 +316,23 @@ RSpec.describe MaintenanceWindow, type: :model do
       expect { maintenance_window.requested_foo }.to raise_error(NoMethodError)
     end
   end
+
+  describe 'class' do
+    subject { described_class }
+
+    describe '#possible_states' do
+      it 'gives all possible states' do
+        expect(subject.possible_states).to match_array([
+          :cancelled,
+          :confirmed,
+          :ended,
+          :expired,
+          :new,
+          :rejected,
+          :requested,
+          :started,
+        ])
+      end
+    end
+  end
 end

--- a/spec/shared_examples/maintenance_windows.rb
+++ b/spec/shared_examples/maintenance_windows.rb
@@ -7,14 +7,20 @@ RSpec.shared_examples 'maintenance_windows' do
   describe '#open_maintenance_windows' do
     subject { create(factory) }
 
-    it 'returns non-ended associated maintenance windows' do
-      create(:requested_maintenance_window, factory => subject, id: 1)
-      create(:confirmed_maintenance_window, factory => subject, id: 2)
-      create(:ended_maintenance_window, factory => subject, id: 3)
+    it 'returns non-finished associated maintenance windows' do
+      MaintenanceWindow.possible_states.map do |state|
+        create(:maintenance_window, factory => subject, state: state)
+      end
 
-      resulting_window_ids = subject.open_maintenance_windows.map(&:id)
+      open_windows = subject.open_maintenance_windows
+      open_window_states = open_windows.map(&:state).map(&:to_sym)
 
-      expect(resulting_window_ids).to match_array([1, 2])
+      expect(open_window_states).to match_array([
+        :confirmed,
+        :new,
+        :requested,
+        :started,
+      ])
     end
   end
 end


### PR DESCRIPTION
This is a small, self-contained PR which builds upon #75 (so merge that first). It just updates the `open_maintenance_windows` method, provided for all models which can have maintenance windows, to account for and exclude MaintenanceWindows in any of the 'finished' states which are now possible; some minor other tweaks need to do this are also included.