### PR TITLE
Maintenance progression service

### DIFF
--- a/app/services/progress_maintenance_window.rb
+++ b/app/services/progress_maintenance_window.rb
@@ -1,0 +1,34 @@
+
+ProgressMaintenanceWindow = Struct.new(:window) do
+  def progress
+    if end_time_passed? && started?
+      window.end!
+    elsif start_time_passed?
+      start_or_expire_if_unstarted
+    end
+  end
+
+  private
+
+  delegate :confirmed?, :started?, to: :window
+
+  def end_time_passed?
+    window.requested_end.past?
+  end
+
+  def start_time_passed?
+    window.requested_start.past?
+  end
+
+  def start_or_expire_if_unstarted
+    if confirmed?
+      window.start!
+    elsif unconfirmed?
+      window.expire!
+    end
+  end
+
+  def unconfirmed?
+    window.new? || window.requested?
+  end
+end

--- a/app/services/progress_maintenance_window.rb
+++ b/app/services/progress_maintenance_window.rb
@@ -1,16 +1,20 @@
 
 ProgressMaintenanceWindow = Struct.new(:window) do
   def progress
-    if end_time_passed? && started?
-      window.end!
-    elsif start_time_passed?
-      start_or_expire_if_unstarted
-    end
+    progress_if_needed || unprogressed_message
   end
 
   private
 
   delegate :confirmed?, :started?, to: :window
+
+  def progress_if_needed
+    if end_time_passed? && started?
+      progress_state(:ended)
+    elsif start_time_passed?
+      start_or_expire_if_unstarted
+    end
+  end
 
   def end_time_passed?
     window.requested_end.past?
@@ -22,13 +26,43 @@ ProgressMaintenanceWindow = Struct.new(:window) do
 
   def start_or_expire_if_unstarted
     if confirmed?
-      window.start!
+      progress_state(:started)
     elsif unconfirmed?
-      window.expire!
+      progress_state(:expired)
     end
   end
 
   def unconfirmed?
     window.new? || window.requested?
+  end
+
+  def unprogressed_message
+    progression_message("remains #{window.state}")
+  end
+
+  def progress_state(new_state)
+    old_state = window.state
+    window.update!(state: new_state)
+    progression_message("#{old_state} -> #{new_state}")
+  end
+
+  def progression_message(message)
+    "Maintenance window #{window.id} (#{window_details}): #{message}"
+  end
+
+  def window_details
+    "#{window.associated_model.name} | #{start_date} - #{end_date}"
+  end
+
+  def start_date
+    format_datetime(window.requested_start)
+  end
+
+  def end_date
+    format_datetime(window.requested_end)
+  end
+
+  def format_datetime(datetime)
+    datetime.to_formatted_s(:short)
   end
 end

--- a/spec/services/progress_maintenance_window_spec.rb
+++ b/spec/services/progress_maintenance_window_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe ProgressMaintenanceWindow do
+  describe '#progress' do
+    RSpec.shared_examples 'progresses unstarted windows' do
+      it 'progresses confirmed window to started' do
+        window = create_window(state: :confirmed)
+
+        described_class.new(window).progress
+
+        expect(window).to be_started
+      end
+
+      it 'progresses new window to expired' do
+        window = create_window(state: :new)
+
+        described_class.new(window).progress
+
+        expect(window).to be_expired
+      end
+
+      it 'progresses requested window to expired' do
+        window = create_window(state: :requested)
+
+        described_class.new(window).progress
+
+        expect(window).to be_expired
+      end
+    end
+
+    context 'when requested_start and requested_end in future' do
+      it 'does not progress window in any state' do
+        MaintenanceWindow.possible_states.each do |state|
+          window = create(
+            :maintenance_window,
+            state: state,
+            requested_start: DateTime.current.advance(days: 1),
+            requested_end: DateTime.current.advance(days: 2),
+          )
+
+          described_class.new(window).progress
+
+          expect(window.state.to_sym).to eq state
+        end
+      end
+    end
+
+    context 'when just requested_start passed' do
+      def create_window(state:)
+        create(
+          :maintenance_window,
+          state: state,
+          requested_start: 1.hours.ago,
+          requested_end: DateTime.current.advance(days: 1)
+        )
+      end
+
+      include_examples 'progresses unstarted windows'
+
+      it 'does not progress window in other states' do
+        other_states = MaintenanceWindow.possible_states - [:confirmed, :new, :requested]
+
+        other_states.each do |state|
+          window = create_window(state: state)
+
+          described_class.new(window).progress
+
+          expect(window.state.to_sym).to eq state
+        end
+      end
+    end
+
+    context 'when requested_start and requested_end passed' do
+      def create_window(state:)
+        create(
+          :maintenance_window,
+          state: state,
+          requested_start: 2.hours.ago,
+          requested_end: 1.hours.ago
+        )
+      end
+
+      # If both `requested_start` and `requested_end` have passed and a window
+      # has still not transitioned from an unstarted state (e.g. if the
+      # maintenance period is very short or we have not progressed
+      # MaintenanceWindows for a while for some reason), then we still want to
+      # ensure the window is appropriately transitioned out of the unstarted
+      # state so that any actions which should occur when this happens do still
+      # occur. The window will still be ended if needed soon enough, as soon as
+      # we next progress MaintenanceWindows.
+      include_examples 'progresses unstarted windows'
+
+      it 'progresses started window to ended' do
+        window = create_window(state: :started)
+
+        described_class.new(window).progress
+
+        expect(window).to be_ended
+      end
+
+      it 'does not progress window in other states' do
+        other_states = MaintenanceWindow.possible_states - [:started, :confirmed, :new, :requested]
+
+        other_states.each do |state|
+          window = create_window(state: state)
+
+          described_class.new(window).progress
+
+          expect(window.state.to_sym).to eq state
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on #77. This PR implements a new object, `ProgressMaintenanceWindow`, which takes a MaintenanceWindow as an argument and then progresses its state or not as needed when its `progress` method is called, based on the current time and the `requested_start` and `requested_end` of the maintenance. This method also returns an appropriate message about this change or lack of it, so this can later be logged. Actually using this new object anywhere is still to come in a future PR.