### PR TITLE
State machine diagram rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,8 +96,8 @@ group :development do
   # Rake tasks.
   gem 'active_record_doctor'
 
-  # Regenerate state machine graphs using `rake state_machines:draw
-  # CLASS=MaintenanceWindow TARGET=docs/state-machines`.
+  # Regenerate state machine graphs using `rake
+  # alces:generate:state_machine_diagrams`.
   gem 'state_machines-graphviz'
 end
 

--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -1,0 +1,21 @@
+
+
+namespace :alces do
+  namespace :generate do
+    STATE_MACHINE_DIAGRAMS_DIR = 'docs/state-machines'
+    MAINTENANCE_WINDOW_STATE_MACHINE_DIAGRAM = File.join(
+      STATE_MACHINE_DIAGRAMS_DIR, 'MaintenanceWindow_state.png'
+    )
+
+    desc "Generate diagrams for all state machines to #{STATE_MACHINE_DIAGRAMS_DIR}"
+    task state_machine_diagrams: MAINTENANCE_WINDOW_STATE_MACHINE_DIAGRAM
+
+    file MAINTENANCE_WINDOW_STATE_MACHINE_DIAGRAM => [
+      'app/models/maintenance_window.rb', :environment
+    ] do
+      ENV['CLASS'] = MaintenanceWindow.to_s
+      ENV['TARGET'] = STATE_MACHINE_DIAGRAMS_DIR
+      Rake::Task['state_machines:draw'].invoke
+    end
+  end
+end


### PR DESCRIPTION
Based on #78. This PR adds a small Rake task to generate the MaintenanceWindow state machine diagram. This serves 2 purposes:

1. allows us to do this slightly more simply with a single command;

2. allows me to get slightly more familiar with writing a Rake task, which I've not done before and will need for adding a larger task for progressing MaintenanceWindows (relevant resources if you're curious about Rake: https://martinfowler.com/articles/rake.html and https://rubysolutions.wordpress.com/2016/06/25/how-to-create-rake-tasks-in-rails-application/).