### PR TITLE
Migrate existing maintenance windows to new format

### DIFF
--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -11,6 +11,8 @@ class MaintenanceWindow < ApplicationRecord
   validates_presence_of :requested_start
   validates_presence_of :requested_end
 
+  attr_accessor :skip_comments
+
   state_machine initial: :new do
     audit_trail context: :user
 
@@ -85,7 +87,10 @@ class MaintenanceWindow < ApplicationRecord
   private
 
   delegate :site, to: :case
-  delegate :add_transition_comment, to: :maintenance_notifier
+
+  def add_transition_comment(new_state)
+    maintenance_notifier.add_transition_comment(new_state) unless skip_comments
+  end
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and
   # used to automatically set user who instigated the transition in created

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -33,10 +33,9 @@ class MaintenanceWindow < ApplicationRecord
     event :start { transition confirmed: :started }
     event :end { transition started: :ended }
 
-    after_transition any => any do |model, transition|
-      new_state = transition.to_name
+    after_transition any => any do |model|
       # Use send so can keep method private.
-      model.send(:add_transition_comment, new_state)
+      model.send(:add_transition_comment)
     end
   end
 
@@ -88,8 +87,8 @@ class MaintenanceWindow < ApplicationRecord
 
   delegate :site, to: :case
 
-  def add_transition_comment(new_state)
-    maintenance_notifier.add_transition_comment(new_state) unless skip_comments
+  def add_transition_comment
+    maintenance_notifier.add_transition_comment(state) unless skip_comments
   end
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/db/data_migrations/20180223150748_update_existing_maintenance_windows.rb
+++ b/db/data_migrations/20180223150748_update_existing_maintenance_windows.rb
@@ -1,0 +1,59 @@
+class UpdateExistingMaintenanceWindows < ActiveRecord::DataMigration
+  def up
+    MaintenanceWindow.all.each do |window|
+      # Don't want any comments left on RT tickets as we make changes.
+      window.skip_comments = true
+
+      # Change the state to `new` (from `requested`, what the default was set
+      # to when this column was created) so we can simulate the new maintenance
+      # request process.
+      window.state = :new
+
+      # Set `requested_start` and `requested_end` to plausible values; do this
+      # now so model is valid.
+      # Requested start can be considered to be whenever we requested the
+      # maintenance, since it would have started immediately in the past.
+      window.requested_start = window.created_at
+      # Requested end can be considered whenever the maintenance actually
+      # ended, or just in two weeks time if this hasn't happened yet.
+      window.requested_end = window.ended_at_legacy || DateTime.current.advance(weeks: 2)
+      window.save!
+
+      # Simulate requesting maintenance.
+      original_requestor = User.find(window.requested_by_id_legacy)
+      window.request!(original_requestor)
+
+      # Move onto next window, this one has only been requested.
+      next unless window.confirmed_by_id_legacy
+
+      # Simulate confirming maintenance.
+      original_confirmer = User.find(window.confirmed_by_id_legacy)
+      window.confirm!(original_confirmer)
+
+      # Simulate starting this window if needed, if this should have already
+      # happened.
+      ProgressMaintenanceWindow.new(window).progress
+
+      # We didn't previously track maintenance request, confirmation, or start
+      # times (note that the latter two would have been the same previously).
+      # Therefore just set all these transitions to have occurred at the
+      # maintenance window creation time; this will be inaccurate for some of
+      # these but is as good as any other arbitrary time we might pick.
+      MaintenanceWindowStateTransition
+        .where(maintenance_window: window)
+        .update_all(created_at: window.created_at)
+
+      # Simulate ending this window if needed, if this should have already
+      # happened.
+      ProgressMaintenanceWindow.new(window).progress
+
+      # Move onto the next window, this one is still in progress.
+      next unless window.ended?
+
+      # Update the time this window ended to the recorded ended at time.
+      MaintenanceWindowStateTransition
+        .find_by!(maintenance_window_id: window.id, to: :ended)
+        .update!(created_at: window.ended_at_legacy)
+    end
+  end
+end

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -226,6 +226,17 @@ RSpec.describe MaintenanceWindow, type: :model do
         subject.end!
       end
     end
+
+    it 'does not have transition comment added when `skip_comments` flag set on model' do
+      # This test tests this behaviour for the started -> ended transition, but
+      # any valid transition could be used.
+      window = create(:maintenance_window, state: :started)
+      window.skip_comments = true
+
+      expect(Case.request_tracker).not_to receive(:add_ticket_correspondence)
+
+      window.end!
+    end
   end
 
   describe '#in_progress?' do


### PR DESCRIPTION
This PR adds a data migration to update all existing MaintenanceWindows to be in the new format Flight Center expects. The main commit doing this is https://github.com/alces-software/alces-flight-center/commit/43962b0adc9156d3b93f000016f049c6d7630ae1, and in order to do this I also needed to add a way to skip commenting on an RT ticket when a MaintenanceWindow transitions, which is done in the earlier commits. Based on #82.