### PR TITLE
Implement a scope to be used by the nav bar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,20 +44,19 @@ class ApplicationController < ActionController::Base
     case request.path
     when /^\/sites/
       id = params[:site_id] || params[:id]
-      @site = Site.find(id) if current_user.admin?
+      @scope = @site = Site.find(id) if current_user.admin?
     when /^\/clusters/
       id = params[:cluster_id] || params[:id]
-      @cluster = Cluster.find(id)
+      @scope = @cluster = Cluster.find(id)
     when /^\/components/
       id = params[:component_id] || params[:id]
-      @component = Component.find(id)
-      @cluster_part = @component
+      @scope = @cluster_part = @component = Component.find(id)
     when /^\/component-groups/
       id = params[:component_group_id] || params[:id]
-      @component_group = ComponentGroup.find(id)
+      @scope = @component_group = ComponentGroup.find(id)
     when /^\/services/
       id = params[:service_id] || params[:id]
-      @cluster_part = Service.find(id)
+      @scope = @cluster_part = Service.find(id)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,8 +41,6 @@ class ApplicationController < ActionController::Base
   def define_navigation_variables
     return unless current_user
 
-    @site = current_user.site
-
     case request.path
     when /^\/sites/
       id = params[:site_id] || params[:id]
@@ -61,16 +59,6 @@ class ApplicationController < ActionController::Base
       id = params[:service_id] || params[:id]
       @cluster_part = Service.find(id)
     end
-
-    @cluster ||= if @cluster_part
-                   @cluster_part.cluster
-                 elsif @component_group
-                   @component_group.cluster
-                 end
-    if @cluster_part.respond_to?(:component_group)
-      @component_group = @cluster_part.component_group
-    end
-    @site = @cluster.site if @cluster && current_user.admin?
   end
 
   def format_errors(model)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,10 @@ class ApplicationController < ActionController::Base
     raise ActionController::RoutingError.new('Not Found')
   end
 
+  def scope_id_params(id_method)
+    params[id_method] || params[:id]
+  end
+
   def define_navigation_variables
     return unless current_user
 
@@ -50,19 +54,19 @@ class ApplicationController < ActionController::Base
 
     @scope = case request.path
              when /^\/sites/
-               id = params[:site_id] || params[:id]
+               id = scope_id_params(:site_id)
                @site = Site.find(id) if current_user.admin?
              when /^\/clusters/
-               id = params[:cluster_id] || params[:id]
+               id = scope_id_params(:cluster_id)
                @cluster = Cluster.find(id)
              when /^\/components/
-               id = params[:component_id] || params[:id]
+               id = scope_id_params(:component_id)
                @component = @cluster_part = Component.find(id)
              when /^\/component-groups/
-               id = params[:component_group_id] || params[:id]
+               id = scope_id_params(:component_group_id)
                @component_group = ComponentGroup.find(id)
              when /^\/services/
-               id = params[:service_id] || params[:id]
+               id = scope_id_params(:service_id)
                @service = @cluster_part = Service.find(id)
              end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
     raise ActionController::RoutingError.new('Not Found')
   end
 
-  def scope_id_params(id_method)
+  def scope_id_param(id_method)
     params[id_method] || params[:id]
   end
 
@@ -47,19 +47,19 @@ class ApplicationController < ActionController::Base
 
     @scope = case request.path
              when /^\/sites/
-               id = scope_id_params(:site_id)
+               id = scope_id_param(:site_id)
                @site = Site.find(id)
              when /^\/clusters/
-               id = scope_id_params(:cluster_id)
+               id = scope_id_param(:cluster_id)
                @cluster = Cluster.find(id)
              when /^\/components/
-               id = scope_id_params(:component_id)
+               id = scope_id_param(:component_id)
                @component = @cluster_part = Component.find(id)
              when /^\/component-groups/
-               id = scope_id_params(:component_group_id)
+               id = scope_id_param(:component_group_id)
                @component_group = ComponentGroup.find(id)
              when /^\/services/
-               id = scope_id_params(:service_id)
+               id = scope_id_param(:service_id)
                @service = @cluster_part = Service.find(id)
              else
                @site = current_user.site unless current_user.admin?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_site
-    @site || @scope.site
+    @scope.site
   end
 
   # From https://stackoverflow.com/a/4983354/2620402.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,9 +46,6 @@ class ApplicationController < ActionController::Base
     return unless current_user
 
     @scope = case request.path
-             when /^\/sites/
-               id = scope_id_param(:site_id)
-               @site = Site.find(id)
              when /^\/clusters/
                id = scope_id_param(:cluster_id)
                @cluster = Cluster.find(id)
@@ -62,7 +59,12 @@ class ApplicationController < ActionController::Base
                id = scope_id_param(:service_id)
                @service = @cluster_part = Service.find(id)
              else
-               @site = current_user.site unless current_user.admin?
+               @site = if request.path =~ /^\/sites/
+                         id = scope_id_param(:site_id)
+                         Site.find(id)
+                       elsif current_user.contact?
+                         current_user.site
+                       end
              end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,10 @@ class ApplicationController < ActionController::Base
   def define_navigation_variables
     return unless current_user
 
+    if request.path == '/' && !current_user.admin?
+      return @scope = @site = current_user.site
+    end
+
     case request.path
     when /^\/sites/
       id = params[:site_id] || params[:id]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,23 +45,23 @@ class ApplicationController < ActionController::Base
       return @scope = @site = current_user.site
     end
 
-    case request.path
-    when /^\/sites/
-      id = params[:site_id] || params[:id]
-      @scope = @site = Site.find(id) if current_user.admin?
-    when /^\/clusters/
-      id = params[:cluster_id] || params[:id]
-      @scope = @cluster = Cluster.find(id)
-    when /^\/components/
-      id = params[:component_id] || params[:id]
-      @scope = @cluster_part = @component = Component.find(id)
-    when /^\/component-groups/
-      id = params[:component_group_id] || params[:id]
-      @scope = @component_group = ComponentGroup.find(id)
-    when /^\/services/
-      id = params[:service_id] || params[:id]
-      @scope = @cluster_part = Service.find(id)
-    end
+    @scope = case request.path
+             when /^\/sites/
+               id = params[:site_id] || params[:id]
+               @site = Site.find(id) if current_user.admin?
+             when /^\/clusters/
+               id = params[:cluster_id] || params[:id]
+               @cluster = Cluster.find(id)
+             when /^\/components/
+               id = params[:component_id] || params[:id]
+               @cluster_part = @component = Component.find(id)
+             when /^\/component-groups/
+               id = params[:component_group_id] || params[:id]
+               @component_group = ComponentGroup.find(id)
+             when /^\/services/
+               id = params[:service_id] || params[:id]
+               @cluster_part = Service.find(id)
+             end
   end
 
   def format_errors(model)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,13 +54,13 @@ class ApplicationController < ActionController::Base
                @cluster = Cluster.find(id)
              when /^\/components/
                id = params[:component_id] || params[:id]
-               @cluster_part = @component = Component.find(id)
+               @component = @cluster_part = Component.find(id)
              when /^\/component-groups/
                id = params[:component_group_id] || params[:id]
                @component_group = ComponentGroup.find(id)
              when /^\/services/
                id = params[:service_id] || params[:id]
-               @cluster_part = @service = Service.find(id)
+               @service = @cluster_part = Service.find(id)
              end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,9 @@ class ApplicationController < ActionController::Base
     RequestStore.store[:current_user] = current_user
   end
 
+  # NOTE: The switch to using @scope has not caused any tests to fail
+  # on this method. It might be worth changing it or removing it
+  # completely
   def current_site
     @site
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
                @component_group = ComponentGroup.find(id)
              when /^\/services/
                id = params[:service_id] || params[:id]
-               @cluster_part = Service.find(id)
+               @cluster_part = @service = Service.find(id)
              end
   end
 

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -99,13 +99,13 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     include_examples 'cluster and part variable assignment'
 
     describe "get '/'" do
-      subject { nil }
+      subject { site }
       before :each do
         get root_path(as: user)
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables
+        assigns_navigation_variables(:site)
       end
     end
   end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       component: nil,
       cluster_part: nil,
       component_group: nil,
+      service: nil,
     }
   end
 
@@ -75,7 +76,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(:cluster_part)
+        assigns_navigation_variables(:cluster_part, :service)
       end
     end
   end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
   context 'when no user' do
     describe "get '/'" do
+      subject { nil }
       before :each do
         get root_path
       end
@@ -98,12 +99,13 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     include_examples 'cluster and part variable assignment'
 
     describe "get '/'" do
+      subject { nil }
       before :each do
         get root_path(as: user)
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(:site)
+        assigns_navigation_variables
       end
     end
   end
@@ -114,6 +116,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     include_examples 'cluster and part variable assignment'
 
     describe "get '/'" do
+      subject { nil }
       before :each do
         get root_path(as: user)
       end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -24,61 +24,57 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
   RSpec.shared_examples 'cluster and part variable assignment' do
     describe "get '/cluster/*'" do
+      subject { cluster }
       before :each do
         get cluster_path(cluster.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
           cluster: cluster,
-          cluster_part: nil,
-          component_group: nil
+          scope: cluster
         )
       end
     end
 
     describe "get /components/*" do
+      subject { component }
       before :each do
         get component_path(component.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: cluster,
-          cluster_part: component,
-          component_group: component_group
+          cluster_part: subject,
+          component: subject,
+          scope: subject
         )
       end
     end
 
     describe "get /component_group/*" do
+      subject { component_group }
       before :each do
         get component_group_path(component_group.id, as: user)
       end
 
       it 'assigns the correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: cluster,
           cluster_part: nil,
-          component_group: component_group
+          component_group: subject
         )
       end
     end
 
     describe "get /services/*" do
+      subject { service }
       before :each do
         get service_path(service.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: cluster,
-          cluster_part: service,
-          component_group: nil
+          cluster_part: subject,
         )
       end
     end
@@ -143,13 +139,14 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     end
 
     describe "get '/sites/*'" do
+      subject { site }
       before :each do
         get site_path(site.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
+          site: subject,
           cluster: nil,
           cluster_part: nil,
           component_group: nil

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -16,8 +16,19 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     allow_any_instance_of(Cluster).to receive(:documents).and_return []
   end
 
+  let :default_nav_variables do
+    {
+      scope: subject,
+      site: nil,
+      cluster: nil,
+      component: nil,
+      cluster_part: nil,
+      component_group: nil,
+    }
+  end
+
   def assigns_navigation_variables(vars)
-    vars.each do |var, value|
+    default_nav_variables.merge(vars).each do |var, value|
       expect(assigns(var)).to eq value
     end
   end
@@ -30,10 +41,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          cluster: cluster,
-          scope: cluster
-        )
+        assigns_navigation_variables(cluster: subject)
       end
     end
 
@@ -47,7 +55,6 @@ RSpec.describe 'Navigation variable assignments', type: :request do
         assigns_navigation_variables(
           cluster_part: subject,
           component: subject,
-          scope: subject
         )
       end
     end
@@ -60,7 +67,6 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
       it 'assigns the correct navigation variables' do
         assigns_navigation_variables(
-          cluster_part: nil,
           component_group: subject
         )
       end
@@ -87,12 +93,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: nil,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
-        )
+        assigns_navigation_variables({})
       end
     end
   end
@@ -109,10 +110,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
+          site: site
         )
       end
     end
@@ -129,12 +127,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: nil,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
-        )
+        assigns_navigation_variables({})
       end
     end
 
@@ -145,12 +138,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: subject,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
-        )
+        assigns_navigation_variables(site: subject)
       end
     end
   end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     }
   end
 
-  def assigns_navigation_variables(vars)
-    default_nav_variables.merge(vars).each do |var, value|
+  def assigns_navigation_variables(*subject_keys)
+    subject_hash = (subject_keys.map { |k| [k, subject] }).to_h
+    default_nav_variables.merge(subject_hash).each do |var, value|
       expect(assigns(var)).to eq value
     end
   end
@@ -41,7 +42,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(cluster: subject)
+        assigns_navigation_variables(:cluster)
       end
     end
 
@@ -52,10 +53,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          cluster_part: subject,
-          component: subject,
-        )
+        assigns_navigation_variables(:cluster_part, :component)
       end
     end
 
@@ -66,9 +64,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns the correct navigation variables' do
-        assigns_navigation_variables(
-          component_group: subject
-        )
+        assigns_navigation_variables(:component_group)
       end
     end
 
@@ -79,9 +75,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          cluster_part: subject,
-        )
+        assigns_navigation_variables(:cluster_part)
       end
     end
   end
@@ -93,7 +87,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables({})
+        assigns_navigation_variables
       end
     end
   end
@@ -109,9 +103,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: site
-        )
+        assigns_navigation_variables(:site)
       end
     end
   end
@@ -127,7 +119,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables({})
+        assigns_navigation_variables
       end
     end
 
@@ -138,7 +130,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(site: subject)
+        assigns_navigation_variables(:site)
       end
     end
   end


### PR DESCRIPTION
Previously a bunch of navigation variables need to be set in order for the navigation bar to constructed. The problem with this is it makes it hard for other controllers to know if the nav variable is the model for the current page.

Instead a `scope` variable has been set instead. This makes it clear which model belongs to the current page and can be used by other controller (e.g. `LogController` - eventually). This PR implements the `scope` and updates the navigation variable spec.

Almost all the extraneous variables have been removed with exception of the `cluster_part` which is still required.

This PR does completely break the nav bar. This will be fixed in the next PR which focuses on refactoring it.