### PR TITLE
Clean up the rendering of the nav bar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,20 +44,19 @@ class ApplicationController < ActionController::Base
     case request.path
     when /^\/sites/
       id = params[:site_id] || params[:id]
-      @site = Site.find(id) if current_user.admin?
+      @scope = @site = Site.find(id) if current_user.admin?
     when /^\/clusters/
       id = params[:cluster_id] || params[:id]
-      @cluster = Cluster.find(id)
+      @scope = @cluster = Cluster.find(id)
     when /^\/components/
       id = params[:component_id] || params[:id]
-      @component = Component.find(id)
-      @cluster_part = @component
+      @scope = @cluster_part = @component = Component.find(id)
     when /^\/component-groups/
       id = params[:component_group_id] || params[:id]
-      @component_group = ComponentGroup.find(id)
+      @scope = @component_group = ComponentGroup.find(id)
     when /^\/services/
       id = params[:service_id] || params[:id]
-      @cluster_part = Service.find(id)
+      @scope = @cluster_part = Service.find(id)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,8 +41,6 @@ class ApplicationController < ActionController::Base
   def define_navigation_variables
     return unless current_user
 
-    @site = current_user.site
-
     case request.path
     when /^\/sites/
       id = params[:site_id] || params[:id]
@@ -61,16 +59,6 @@ class ApplicationController < ActionController::Base
       id = params[:service_id] || params[:id]
       @cluster_part = Service.find(id)
     end
-
-    @cluster ||= if @cluster_part
-                   @cluster_part.cluster
-                 elsif @component_group
-                   @component_group.cluster
-                 end
-    if @cluster_part.respond_to?(:component_group)
-      @component_group = @cluster_part.component_group
-    end
-    @site = @cluster.site if @cluster && current_user.admin?
   end
 
   def format_errors(model)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,10 @@ class ApplicationController < ActionController::Base
     raise ActionController::RoutingError.new('Not Found')
   end
 
+  def scope_id_params(id_method)
+    params[id_method] || params[:id]
+  end
+
   def define_navigation_variables
     return unless current_user
 
@@ -50,19 +54,19 @@ class ApplicationController < ActionController::Base
 
     @scope = case request.path
              when /^\/sites/
-               id = params[:site_id] || params[:id]
+               id = scope_id_params(:site_id)
                @site = Site.find(id) if current_user.admin?
              when /^\/clusters/
-               id = params[:cluster_id] || params[:id]
+               id = scope_id_params(:cluster_id)
                @cluster = Cluster.find(id)
              when /^\/components/
-               id = params[:component_id] || params[:id]
+               id = scope_id_params(:component_id)
                @component = @cluster_part = Component.find(id)
              when /^\/component-groups/
-               id = params[:component_group_id] || params[:id]
+               id = scope_id_params(:component_group_id)
                @component_group = ComponentGroup.find(id)
              when /^\/services/
-               id = params[:service_id] || params[:id]
+               id = scope_id_params(:service_id)
                @service = @cluster_part = Service.find(id)
              end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
     raise ActionController::RoutingError.new('Not Found')
   end
 
-  def scope_id_params(id_method)
+  def scope_id_param(id_method)
     params[id_method] || params[:id]
   end
 
@@ -47,19 +47,19 @@ class ApplicationController < ActionController::Base
 
     @scope = case request.path
              when /^\/sites/
-               id = scope_id_params(:site_id)
+               id = scope_id_param(:site_id)
                @site = Site.find(id)
              when /^\/clusters/
-               id = scope_id_params(:cluster_id)
+               id = scope_id_param(:cluster_id)
                @cluster = Cluster.find(id)
              when /^\/components/
-               id = scope_id_params(:component_id)
+               id = scope_id_param(:component_id)
                @component = @cluster_part = Component.find(id)
              when /^\/component-groups/
-               id = scope_id_params(:component_group_id)
+               id = scope_id_param(:component_group_id)
                @component_group = ComponentGroup.find(id)
              when /^\/services/
-               id = scope_id_params(:service_id)
+               id = scope_id_param(:service_id)
                @service = @cluster_part = Service.find(id)
              else
                @site = current_user.site unless current_user.admin?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_site
-    @site || @scope.site
+    @scope.site
   end
 
   # From https://stackoverflow.com/a/4983354/2620402.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,9 +46,6 @@ class ApplicationController < ActionController::Base
     return unless current_user
 
     @scope = case request.path
-             when /^\/sites/
-               id = scope_id_param(:site_id)
-               @site = Site.find(id)
              when /^\/clusters/
                id = scope_id_param(:cluster_id)
                @cluster = Cluster.find(id)
@@ -62,7 +59,12 @@ class ApplicationController < ActionController::Base
                id = scope_id_param(:service_id)
                @service = @cluster_part = Service.find(id)
              else
-               @site = current_user.site unless current_user.admin?
+               @site = if request.path =~ /^\/sites/
+                         id = scope_id_param(:site_id)
+                         Site.find(id)
+                       elsif current_user.contact?
+                         current_user.site
+                       end
              end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,10 @@ class ApplicationController < ActionController::Base
   def define_navigation_variables
     return unless current_user
 
+    if request.path == '/' && !current_user.admin?
+      return @scope = @site = current_user.site
+    end
+
     case request.path
     when /^\/sites/
       id = params[:site_id] || params[:id]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,23 +45,23 @@ class ApplicationController < ActionController::Base
       return @scope = @site = current_user.site
     end
 
-    case request.path
-    when /^\/sites/
-      id = params[:site_id] || params[:id]
-      @scope = @site = Site.find(id) if current_user.admin?
-    when /^\/clusters/
-      id = params[:cluster_id] || params[:id]
-      @scope = @cluster = Cluster.find(id)
-    when /^\/components/
-      id = params[:component_id] || params[:id]
-      @scope = @cluster_part = @component = Component.find(id)
-    when /^\/component-groups/
-      id = params[:component_group_id] || params[:id]
-      @scope = @component_group = ComponentGroup.find(id)
-    when /^\/services/
-      id = params[:service_id] || params[:id]
-      @scope = @cluster_part = Service.find(id)
-    end
+    @scope = case request.path
+             when /^\/sites/
+               id = params[:site_id] || params[:id]
+               @site = Site.find(id) if current_user.admin?
+             when /^\/clusters/
+               id = params[:cluster_id] || params[:id]
+               @cluster = Cluster.find(id)
+             when /^\/components/
+               id = params[:component_id] || params[:id]
+               @cluster_part = @component = Component.find(id)
+             when /^\/component-groups/
+               id = params[:component_group_id] || params[:id]
+               @component_group = ComponentGroup.find(id)
+             when /^\/services/
+               id = params[:service_id] || params[:id]
+               @cluster_part = Service.find(id)
+             end
   end
 
   def format_errors(model)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,13 +54,13 @@ class ApplicationController < ActionController::Base
                @cluster = Cluster.find(id)
              when /^\/components/
                id = params[:component_id] || params[:id]
-               @cluster_part = @component = Component.find(id)
+               @component = @cluster_part = Component.find(id)
              when /^\/component-groups/
                id = params[:component_group_id] || params[:id]
                @component_group = ComponentGroup.find(id)
              when /^\/services/
                id = params[:service_id] || params[:id]
-               @cluster_part = @service = Service.find(id)
+               @service = @cluster_part = Service.find(id)
              end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,9 @@ class ApplicationController < ActionController::Base
     RequestStore.store[:current_user] = current_user
   end
 
+  # NOTE: The switch to using @scope has not caused any tests to fail
+  # on this method. It might be worth changing it or removing it
+  # completely
   def current_site
     @site
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::Base
                @component_group = ComponentGroup.find(id)
              when /^\/services/
                id = params[:service_id] || params[:id]
-               @cluster_part = Service.find(id)
+               @cluster_part = @service = Service.find(id)
              end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,16 @@ module ApplicationHelper
     end
   end
 
+  def add_nav_link_proc(**inputs_to_partial)
+    nav_link_procs << Proc.new do |active|
+      render 'partials/nav_link', active: active, **inputs_to_partial
+    end
+  end
+
+  def nav_link_procs
+    @nav_link_procs ||= []
+  end
+
   def dark_button_classes
     ['btn', 'btn-primary', 'btn-block']
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,11 +27,10 @@ module ApplicationHelper
   end
 
   def model_from_scope(type)
-    klass = type.to_s.classify.constantize
-    if @scope.is_a? klass
-      @scope
-    elsif @scope.respond_to? type
+    if @scope.respond_to? type
       @scope.public_send type
+    elsif @scope.is_a?(type.to_s.classify.constantize)
+      @scope
     else
       nil
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,8 +38,8 @@ module ApplicationHelper
   end
 
   def add_nav_link_proc(**inputs_to_partial)
-    nav_link_procs << Proc.new do |active|
-      render 'partials/nav_link', active: active, **inputs_to_partial
+    nav_link_procs << Proc.new do |**additional_inputs|
+      render 'partials/nav_link', **additional_inputs, **inputs_to_partial
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,6 +26,17 @@ module ApplicationHelper
     )
   end
 
+  def model_from_scope(type)
+    klass = type.to_s.classify.constantize
+    if @scope.is_a? klass
+      @scope
+    elsif @scope.respond_to? type
+      @scope.public_send type
+    else
+      nil
+    end
+  end
+
   def dark_button_classes
     ['btn', 'btn-primary', 'btn-block']
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,95 +24,7 @@
   <body>
     <div class='initial-brand-header'></div>
     <div id='brand-header'></div>
-    <nav class="navbar navbar-expand-lg navbar-dark product-bar fixed-top">
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-toggle="collapse"
-        data-target="#navbarSupportedContent"
-        aria-controls="navbarSupportedContent"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-
-          <% if signed_in? %>
-            <% if current_user.admin? %>
-              <li class="nav-item">
-                <%= link_to (raw('<span class="fa fa-globe"></span> ') + 'All Sites'),
-                  root_path,
-                  class: "nav-link #{@site ? '' : 'nav-link--active'}"
-                %>
-              </li>
-            <% end %>
-
-            <% if @site %>
-              <li class="nav-item">
-                <%= link_to (raw('<span class="fa fa-institution"></span> ') + @site.name),
-                  (current_user.admin? ? site_path(@site) : root_path),
-                  class: "nav-link #{@cluster ? '' : 'nav-link--active'}"
-                %>
-              </li>
-
-              <% if @cluster %>
-                <li class="nav-item">
-                  <%= link_to (raw('<span class="fa fa-server"></span> ') + @cluster.name),
-                    @cluster.decorate.path,
-                    class: "nav-link #{(@cluster_part || @component_group) ? '' : 'nav-link--active'}"
-                  %>
-
-                  <% if @component_group %>
-                    <li class="nav-item">
-                      <%= link_to (raw('<span class="fa fa-cubes"></span> ') + @component_group.name),
-                        @component_group.decorate.path,
-                        class: "nav-link #{@cluster_part ? '' : 'nav-link--active'}"
-                      %>
-                    </li>
-                  <% end %>
-
-                  <% if @cluster_part %>
-                    <li class="nav-item">
-                      <%= link_to (raw('<span class="fa fa-cube"></span> ') + @cluster_part.name),
-                        @cluster_part.decorate.path,
-                        class: 'nav-link nav-link--active'
-                      %>
-                    </li>
-                  <% end %>
-
-                </li>
-              <% end %>
-            <% end %>
-
-          <% end %>
-
-        </ul>
-
-        <% if signed_in? %>
-          <% if current_user.admin? %>
-            <ul class="navbar-nav justify-content-end">
-              <li class="nav-item">
-                <%= link_to (raw('<span class="fa fa-database"></span> ') + 'Admin Interface'),
-                  rails_admin_path,
-                  class: "nav-link"
-                %>
-              </li>
-            </ul>
-          <% end %>
-
-          <span class="navbar-text text-light"><%= current_user.name %></span>
-          <%= button_to 'Sign out',
-            sign_out_path,
-            method: :delete,
-            class: ['btn', 'btn-light']
-          %>
-        <% end %>
-      </div>
-    </nav>
-
+    <%= render 'partials/nav_bar' %>
     <div class='page-content'>
 
       <% if @title %>
@@ -124,7 +36,7 @@
                 <h1 class="display-4"><%= @title %></h1>
                 <% if @subtitle %>
                   <p class="lead"><%= @subtitle %></p>
-              <% end %>
+                <% end %>
               </div>
               <div class="col"></div>
             </div>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -15,10 +15,9 @@
     <ul class="navbar-nav mr-auto">
       <% if signed_in? %>
         <% if current_user.admin? %>
-          <%= render 'partials/nav_link',
-                     text: 'All Sites',
-                     path: root_path,
-                     icon: 'fa-globe' %>
+          <% add_nav_link_proc text: 'All Sites',
+                               path: root_path,
+                               icon: 'fa-globe' %>
         <% end %>
 
         <% if @scope %>
@@ -28,34 +27,33 @@
                              else
                                root_path
                              end %>
-          <%= render 'partials/nav_link',
-                     text: site_obj.name,
-                     path: path_for_site,
-                     icon: 'fa-institution' %>
+          <% add_nav_link_proc text: site_obj.name,
+                               path: path_for_site,
+                               icon: 'fa-institution' %>
 
           <% cluster_obj = model_from_scope :cluster %>
           <% if cluster_obj %>
-            <%= render 'partials/nav_link',
-                      text: cluster_obj.name,
-                      path: cluster_obj,
-                      icon: 'fa-server' %>
+            <% add_nav_link_proc text: cluster_obj.name,
+                                 path: cluster_obj,
+                                 icon: 'fa-server' %>
           <% end %>
 
           <% component_group_obj = model_from_scope :component_group %>
           <% if component_group_obj %>
-            <%= render 'partials/nav_link',
-                       text: component_group_obj.name,
-                       path: component_group_obj,
-                       icon: 'fa-cubes' %>
+            <% add_nav_link_proc text: component_group_obj.name,
+                                 path: component_group_obj,
+                                 icon: 'fa-cubes' %>
           <% end %>
 
           <% if @cluster_part %>
-            <%= render 'partials/nav_link',
-                       text: @cluster_part.name,
-                       path: @cluster_part,
-                       icon: 'fa-cube' %>
+            <% add_nav_link_proc text: @cluster_part.name,
+                                 path: @cluster_part,
+                                 icon: 'fa-cube' %>
           <% end %>
         <% end %>
+      <% end %>
+      <% nav_link_procs.each do |nav_proc| %>
+        <%= nav_proc.call false %>
       <% end %>
     </ul>
 

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -40,16 +40,15 @@
                       path: cluster_obj.decorate.path,
                       icon: 'fa-server' %>
           <% end %>
-        <% end %>
 
-        <%#       <% if @component_group %>
-        <%#         <li class="nav-item">%>
-        <%#           <%= link_to (raw('<span class="fa fa-cubes"></span> ') + @component_group.name),%>
-        <%#             @component_group.decorate.path,%>
-        <%#             class: "nav-link #{@cluster_part ? '' : 'nav-link--active'}"%>
-        <%#           %>
-        <%#         </li>%>
-        <%#       <% end %>
+          <% component_group_obj = model_from_scope :component_group %>
+          <% if component_group_obj %>
+            <%= render 'partials/nav_link',
+                       text: component_group_obj.name,
+                       path: component_group_obj.decorate.path,
+                       icon: 'fa-cubes' %>
+          <% end %>
+        <% end %>
 
         <%#       <% if @cluster_part %>
         <%#         <li class="nav-item">%>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -24,42 +24,42 @@
           </li>
         <% end %>
 
-        <% if @site %>
-          <li class="nav-item">
-            <%= link_to (raw('<span class="fa fa-institution"></span> ') + @site.name),
-              (current_user.admin? ? site_path(@site) : root_path),
-              class: "nav-link #{@cluster ? '' : 'nav-link--active'}"
-            %>
-          </li>
+        <%# <% if @site %>
+        <%#   <li class="nav-item">%>
+        <%#     <%= link_to (raw('<span class="fa fa-institution"></span> ') + @site.name),%>
+        <%#       (current_user.admin? ? site_path(@site) : root_path),%>
+        <%#       class: "nav-link #{@cluster ? '' : 'nav-link--active'}"%>
+        <%#     %>
+        <%#   </li>%>
 
-          <% if @cluster %>
-            <li class="nav-item">
-              <%= link_to (raw('<span class="fa fa-server"></span> ') + @cluster.name),
-                @cluster.decorate.path,
-                class: "nav-link #{(@cluster_part || @component_group) ? '' : 'nav-link--active'}"
-              %>
+        <%#   <% if @cluster %>
+        <%#     <li class="nav-item">%>
+        <%#       <%= link_to (raw('<span class="fa fa-server"></span> ') + @cluster.name),%>
+        <%#         @cluster.decorate.path,%>
+        <%#         class: "nav-link #{(@cluster_part || @component_group) ? '' : 'nav-link--active'}"%>
+        <%#       %>
 
-              <% if @component_group %>
-                <li class="nav-item">
-                  <%= link_to (raw('<span class="fa fa-cubes"></span> ') + @component_group.name),
-                    @component_group.decorate.path,
-                    class: "nav-link #{@cluster_part ? '' : 'nav-link--active'}"
-                  %>
-                </li>
-              <% end %>
+        <%#       <% if @component_group %>
+        <%#         <li class="nav-item">%>
+        <%#           <%= link_to (raw('<span class="fa fa-cubes"></span> ') + @component_group.name),%>
+        <%#             @component_group.decorate.path,%>
+        <%#             class: "nav-link #{@cluster_part ? '' : 'nav-link--active'}"%>
+        <%#           %>
+        <%#         </li>%>
+        <%#       <% end %>
 
-              <% if @cluster_part %>
-                <li class="nav-item">
-                  <%= link_to (raw('<span class="fa fa-cube"></span> ') + @cluster_part.name),
-                    @cluster_part.decorate.path,
-                    class: 'nav-link nav-link--active'
-                  %>
-                </li>
-              <% end %>
+        <%#       <% if @cluster_part %>
+        <%#         <li class="nav-item">%>
+        <%#           <%= link_to (raw('<span class="fa fa-cube"></span> ') + @cluster_part.name),%>
+        <%#             @cluster_part.decorate.path,%>
+        <%#             class: 'nav-link nav-link--active'%>
+        <%#           %>
+        <%#         </li>%>
+        <%#       <% end %>
 
-            </li>
-          <% end %>
-        <% end %>
+        <%#     </li>%>
+        <%#   <% end %>
+        <%# <% end %>
 
       <% end %>
 

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -1,0 +1,89 @@
+<nav class="navbar navbar-expand-lg navbar-dark product-bar fixed-top">
+  <button
+    class="navbar-toggler"
+    type="button"
+    data-toggle="collapse"
+    data-target="#navbarSupportedContent"
+    aria-controls="navbarSupportedContent"
+    aria-expanded="false"
+    aria-label="Toggle navigation"
+  >
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav mr-auto">
+
+      <% if signed_in? %>
+        <% if current_user.admin? %>
+          <li class="nav-item">
+            <%= link_to (raw('<span class="fa fa-globe"></span> ') + 'All Sites'),
+              root_path,
+              class: "nav-link #{@site ? '' : 'nav-link--active'}"
+            %>
+          </li>
+        <% end %>
+
+        <% if @site %>
+          <li class="nav-item">
+            <%= link_to (raw('<span class="fa fa-institution"></span> ') + @site.name),
+              (current_user.admin? ? site_path(@site) : root_path),
+              class: "nav-link #{@cluster ? '' : 'nav-link--active'}"
+            %>
+          </li>
+
+          <% if @cluster %>
+            <li class="nav-item">
+              <%= link_to (raw('<span class="fa fa-server"></span> ') + @cluster.name),
+                @cluster.decorate.path,
+                class: "nav-link #{(@cluster_part || @component_group) ? '' : 'nav-link--active'}"
+              %>
+
+              <% if @component_group %>
+                <li class="nav-item">
+                  <%= link_to (raw('<span class="fa fa-cubes"></span> ') + @component_group.name),
+                    @component_group.decorate.path,
+                    class: "nav-link #{@cluster_part ? '' : 'nav-link--active'}"
+                  %>
+                </li>
+              <% end %>
+
+              <% if @cluster_part %>
+                <li class="nav-item">
+                  <%= link_to (raw('<span class="fa fa-cube"></span> ') + @cluster_part.name),
+                    @cluster_part.decorate.path,
+                    class: 'nav-link nav-link--active'
+                  %>
+                </li>
+              <% end %>
+
+            </li>
+          <% end %>
+        <% end %>
+
+      <% end %>
+
+    </ul>
+
+    <% if signed_in? %>
+      <% if current_user.admin? %>
+        <ul class="navbar-nav justify-content-end">
+          <li class="nav-item">
+            <%= link_to (raw('<span class="fa fa-database"></span> ') + 'Admin Interface'),
+              rails_admin_path,
+              class: "nav-link"
+            %>
+          </li>
+        </ul>
+      <% end %>
+
+      <span class="navbar-text text-light"><%= current_user.name %></span>
+      <%= button_to 'Sign out',
+        sign_out_path,
+        method: :delete,
+        class: ['btn', 'btn-light']
+      %>
+    <% end %>
+  </div>
+</nav>
+

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -48,21 +48,14 @@
                        path: component_group_obj.decorate.path,
                        icon: 'fa-cubes' %>
           <% end %>
+
+          <% if @cluster_part %>
+            <%= render 'partials/nav_link',
+                       text: @cluster_part.name,
+                       path: @cluster_part.decorate.path,
+                       icon: 'fa-cube' %>
+          <% end %>
         <% end %>
-
-        <%#       <% if @cluster_part %>
-        <%#         <li class="nav-item">%>
-        <%#           <%= link_to (raw('<span class="fa fa-cube"></span> ') + @cluster_part.name),%>
-        <%#             @cluster_part.decorate.path,%>
-        <%#             class: 'nav-link nav-link--active'%>
-        <%#           %>
-        <%#         </li>%>
-        <%#       <% end %>
-
-        <%#     </li>%>
-        <%#   <% end %>
-        <%# <% end %>
-
       <% end %>
 
     </ul>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -24,7 +24,7 @@
         <% if @scope %>
           <% site_obj = model_from_scope :site %>
           <% path_for_site = if current_user.admin?
-                               site_path site_obj
+                               site_obj
                              else
                                root_path
                              end %>
@@ -37,7 +37,7 @@
           <% if cluster_obj %>
             <%= render 'partials/nav_link',
                       text: cluster_obj.name,
-                      path: cluster_obj.decorate.path,
+                      path: cluster_obj,
                       icon: 'fa-server' %>
           <% end %>
 
@@ -45,19 +45,18 @@
           <% if component_group_obj %>
             <%= render 'partials/nav_link',
                        text: component_group_obj.name,
-                       path: component_group_obj.decorate.path,
+                       path: component_group_obj,
                        icon: 'fa-cubes' %>
           <% end %>
 
           <% if @cluster_part %>
             <%= render 'partials/nav_link',
                        text: @cluster_part.name,
-                       path: @cluster_part.decorate.path,
+                       path: @cluster_part,
                        icon: 'fa-cube' %>
           <% end %>
         <% end %>
       <% end %>
-
     </ul>
 
     <% if signed_in? %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -27,27 +27,24 @@
                              else
                                root_path
                              end %>
-          <% add_nav_link_proc text: site_obj.name,
+          <% add_nav_link_proc model: site_obj,
                                path: path_for_site,
                                icon: 'fa-institution' %>
 
           <% cluster_obj = model_from_scope :cluster %>
           <% if cluster_obj %>
-            <% add_nav_link_proc text: cluster_obj.name,
-                                 path: cluster_obj,
+            <% add_nav_link_proc model: cluster_obj,
                                  icon: 'fa-server' %>
           <% end %>
 
           <% component_group_obj = model_from_scope :component_group %>
           <% if component_group_obj %>
-            <% add_nav_link_proc text: component_group_obj.name,
-                                 path: component_group_obj,
+            <% add_nav_link_proc model: component_group_obj,
                                  icon: 'fa-cubes' %>
           <% end %>
 
           <% if @cluster_part %>
-            <% add_nav_link_proc text: @cluster_part.name,
-                                 path: @cluster_part,
+            <% add_nav_link_proc model: @cluster_part,
                                  icon: 'fa-cube' %>
           <% end %>
         <% end %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -32,14 +32,15 @@
                      text: site_obj.name,
                      path: path_for_site,
                      icon: 'fa-institution' %>
-        <% end %>
 
-        <%#   <% if @cluster %>
-        <%#     <li class="nav-item">%>
-        <%#       <%= link_to (raw('<span class="fa fa-server"></span> ') + @cluster.name),%>
-        <%#         @cluster.decorate.path,%>
-        <%#         class: "nav-link #{(@cluster_part || @component_group) ? '' : 'nav-link--active'}"%>
-        <%#       %>
+          <% cluster_obj = model_from_scope :cluster %>
+          <% if cluster_obj %>
+            <%= render 'partials/nav_link',
+                      text: cluster_obj.name,
+                      path: cluster_obj.decorate.path,
+                      icon: 'fa-server' %>
+          <% end %>
+        <% end %>
 
         <%#       <% if @component_group %>
         <%#         <li class="nav-item">%>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -52,9 +52,10 @@
           <% end %>
         <% end %>
       <% end %>
-      <% nav_link_procs.each do |nav_proc| %>
-        <%= nav_proc.call false %>
+      <% nav_link_procs[0..-2].each do |nav_proc| %>
+        <%= nav_proc.call %>
       <% end %>
+      <%= nav_link_procs.last.call(active: true) %>
     </ul>
 
     <% if signed_in? %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -22,13 +22,18 @@
                      icon: 'fa-globe' %>
         <% end %>
 
-        <%# <% if @site %>
-        <%#   <li class="nav-item">%>
-        <%#     <%= link_to (raw('<span class="fa fa-institution"></span> ') + @site.name),%>
-        <%#       (current_user.admin? ? site_path(@site) : root_path),%>
-        <%#       class: "nav-link #{@cluster ? '' : 'nav-link--active'}"%>
-        <%#     %>
-        <%#   </li>%>
+        <% if @scope %>
+          <% site_obj = (@scope.is_a?(Site) ? @scope : @scope.site) %>
+          <% path_for_site = if current_user.admin?
+                               site_path site_obj
+                             else
+                               root_path
+                             end %>
+          <%= render 'partials/nav_link',
+                     text: site_obj.name,
+                     path: path_for_site,
+                     icon: 'fa-institution' %>
+        <% end %>
 
         <%#   <% if @cluster %>
         <%#     <li class="nav-item">%>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -58,12 +58,10 @@
     <% if signed_in? %>
       <% if current_user.admin? %>
         <ul class="navbar-nav justify-content-end">
-          <li class="nav-item">
-            <%= link_to (raw('<span class="fa fa-database"></span> ') + 'Admin Interface'),
-              rails_admin_path,
-              class: "nav-link"
-            %>
-          </li>
+          <%= render 'partials/nav_link',
+                     text: 'Admin Interface',
+                     path: rails_admin_path,
+                     icon: 'fa-database' %>
         </ul>
       <% end %>
 

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -13,42 +13,42 @@
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
-      <% if signed_in? %>
-        <% if current_user.admin? %>
-          <% add_nav_link_proc text: 'All Sites',
-                               path: root_path,
-                               nav_icon: 'fa-globe' %>
-        <% end %>
+      <% if signed_in?
+        if current_user.admin?
+          add_nav_link_proc text: 'All Sites',
+                            path: root_path,
+                            nav_icon: 'fa-globe'
+        end
 
-        <% if @scope %>
-          <% site_obj = model_from_scope :site %>
-          <% path_for_site = if current_user.admin?
-                               site_obj
-                             else
-                               root_path
-                             end %>
-          <% add_nav_link_proc model: site_obj,
-                               path: path_for_site,
-                               nav_icon: 'fa-institution' %>
+        if @scope
+          site_obj = model_from_scope :site
+          path_for_site = if current_user.admin?
+                            site_obj
+                          else
+                            root_path
+                          end
+          add_nav_link_proc model: site_obj,
+                            path: path_for_site,
+                            nav_icon: 'fa-institution'
 
-          <% cluster_obj = model_from_scope :cluster %>
-          <% if cluster_obj %>
-            <% add_nav_link_proc model: cluster_obj,
-                                 nav_icon: 'fa-server' %>
-          <% end %>
+          cluster_obj = model_from_scope :cluster
+          if cluster_obj
+            add_nav_link_proc model: cluster_obj,
+                              nav_icon: 'fa-server'
+          end
 
-          <% component_group_obj = model_from_scope :component_group %>
-          <% if component_group_obj %>
-            <% add_nav_link_proc model: component_group_obj,
-                                 nav_icon: 'fa-cubes' %>
-          <% end %>
+          component_group_obj = model_from_scope :component_group
+          if component_group_obj
+            add_nav_link_proc model: component_group_obj,
+                              nav_icon: 'fa-cubes'
+          end
 
-          <% if @cluster_part %>
-            <% add_nav_link_proc model: @cluster_part,
-                                 nav_icon: 'fa-cube' %>
-          <% end %>
-        <% end %>
-      <% end %>
+          if @cluster_part
+            add_nav_link_proc model: @cluster_part,
+                              nav_icon: 'fa-cube'
+          end
+        end
+      end %>
       <% nav_link_procs[0..-2].each do |nav_proc| %>
         <%= nav_proc.call %>
       <% end %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -55,7 +55,7 @@
       <% nav_link_procs[0..-2].each do |nav_proc| %>
         <%= nav_proc.call %>
       <% end %>
-      <%= nav_link_procs.last.call(active: true) %>
+      <%= nav_link_procs.last&.call(active: true) %>
     </ul>
 
     <% if signed_in? %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -13,40 +13,38 @@
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
-      <% if signed_in?
-        if current_user.admin?
-          add_nav_link_proc text: 'All Sites',
-                            path: root_path,
-                            nav_icon: 'fa-globe'
+      <% if current_user&.admin?
+        add_nav_link_proc text: 'All Sites',
+                          path: root_path,
+                          nav_icon: 'fa-globe'
+      end
+
+      if @scope
+        site_obj = model_from_scope :site
+        path_for_site = if current_user.admin?
+                          site_obj
+                        else
+                          root_path
+                        end
+        add_nav_link_proc model: site_obj,
+                          path: path_for_site,
+                          nav_icon: 'fa-institution'
+
+        cluster_obj = model_from_scope :cluster
+        if cluster_obj
+          add_nav_link_proc model: cluster_obj,
+                            nav_icon: 'fa-server'
         end
 
-        if @scope
-          site_obj = model_from_scope :site
-          path_for_site = if current_user.admin?
-                            site_obj
-                          else
-                            root_path
-                          end
-          add_nav_link_proc model: site_obj,
-                            path: path_for_site,
-                            nav_icon: 'fa-institution'
+        component_group_obj = model_from_scope :component_group
+        if component_group_obj
+          add_nav_link_proc model: component_group_obj,
+                            nav_icon: 'fa-cubes'
+        end
 
-          cluster_obj = model_from_scope :cluster
-          if cluster_obj
-            add_nav_link_proc model: cluster_obj,
-                              nav_icon: 'fa-server'
-          end
-
-          component_group_obj = model_from_scope :component_group
-          if component_group_obj
-            add_nav_link_proc model: component_group_obj,
-                              nav_icon: 'fa-cubes'
-          end
-
-          if @cluster_part
-            add_nav_link_proc model: @cluster_part,
-                              nav_icon: 'fa-cube'
-          end
+        if @cluster_part
+          add_nav_link_proc model: @cluster_part,
+                            nav_icon: 'fa-cube'
         end
       end %>
       <% nav_link_procs[0..-2].each do |nav_proc| %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -47,10 +47,10 @@
                             nav_icon: 'fa-cube'
         end
       end %>
-      <% nav_link_procs[0..-2].each do |nav_proc| %>
-        <%= nav_proc.call %>
+      <% nav_link_procs.each do |nav_proc| %>
+        <% active = (nav_proc == nav_link_procs.last) %>
+        <%= nav_proc.call active: active %>
       <% end %>
-      <%= nav_link_procs.last&.call(active: true) %>
     </ul>
 
     <% if signed_in? %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -17,7 +17,7 @@
         <% if current_user.admin? %>
           <% add_nav_link_proc text: 'All Sites',
                                path: root_path,
-                               icon: 'fa-globe' %>
+                               nav_icon: 'fa-globe' %>
         <% end %>
 
         <% if @scope %>
@@ -29,23 +29,23 @@
                              end %>
           <% add_nav_link_proc model: site_obj,
                                path: path_for_site,
-                               icon: 'fa-institution' %>
+                               nav_icon: 'fa-institution' %>
 
           <% cluster_obj = model_from_scope :cluster %>
           <% if cluster_obj %>
             <% add_nav_link_proc model: cluster_obj,
-                                 icon: 'fa-server' %>
+                                 nav_icon: 'fa-server' %>
           <% end %>
 
           <% component_group_obj = model_from_scope :component_group %>
           <% if component_group_obj %>
             <% add_nav_link_proc model: component_group_obj,
-                                 icon: 'fa-cubes' %>
+                                 nav_icon: 'fa-cubes' %>
           <% end %>
 
           <% if @cluster_part %>
             <% add_nav_link_proc model: @cluster_part,
-                                 icon: 'fa-cube' %>
+                                 nav_icon: 'fa-cube' %>
           <% end %>
         <% end %>
       <% end %>
@@ -61,7 +61,7 @@
           <%= render 'partials/nav_link',
                      text: 'Admin Interface',
                      path: rails_admin_path,
-                     icon: 'fa-database' %>
+                     nav_icon: 'fa-database' %>
         </ul>
       <% end %>
 

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -16,12 +16,10 @@
 
       <% if signed_in? %>
         <% if current_user.admin? %>
-          <li class="nav-item">
-            <%= link_to (raw('<span class="fa fa-globe"></span> ') + 'All Sites'),
-              root_path,
-              class: "nav-link #{@site ? '' : 'nav-link--active'}"
-            %>
-          </li>
+          <%= render 'partials/nav_link',
+                     text: 'All Sites',
+                     path: root_path,
+                     icon: 'fa-globe' %>
         <% end %>
 
         <%# <% if @site %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -13,7 +13,6 @@
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
-
       <% if signed_in? %>
         <% if current_user.admin? %>
           <%= render 'partials/nav_link',
@@ -23,7 +22,7 @@
         <% end %>
 
         <% if @scope %>
-          <% site_obj = (@scope.is_a?(Site) ? @scope : @scope.site) %>
+          <% site_obj = model_from_scope :site %>
           <% path_for_site = if current_user.admin?
                                site_path site_obj
                              else

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,6 +1,6 @@
 <li class='nav-item'>
   <%= link_to (raw("<span class='fa #{icon}'></span> ") + text),
               path,
-              class: 'nav-link'
+              class: "nav-link #{ 'nav-link--active' if (active ||= false) }"
   %>
 </li>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,7 +1,7 @@
 <% path ||= model %>
 <% text ||= model.name %>
 <li class='nav-item'>
-  <%= link_to (raw("<span class='fa #{icon}'></span> ") + text),
+  <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
               path,
               class: "nav-link #{ 'nav-link--active' if (active ||= false) }"
   %>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,3 +1,5 @@
+<% path ||= model %>
+<% text ||= model.name %>
 <li class='nav-item'>
   <%= link_to (raw("<span class='fa #{icon}'></span> ") + text),
               path,

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,8 +1,9 @@
 <% path ||= model %>
 <% text ||= model.name %>
+<% active ||= false %>
 <li class='nav-item'>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
               path,
-              class: "nav-link #{ 'nav-link--active' if (active ||= false) }"
+              class: "nav-link #{ 'nav-link--active' if active }"
   %>
 </li>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,0 +1,6 @@
+<li class='nav-item'>
+  <%= link_to (raw("<span class='fa #{icon}'></span> ") + text),
+              path,
+              class: 'nav-link'
+  %>
+</li>

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Navigation Bar', type: :feature do
       expect(site_nav_items[0]).to have_link(href: '/')
     end
 
-    it 'only has the last link active' do
+    it 'only the last link is active' do
       active_css = '.nav-link--active'
       site_nav_items[0..-2].each do |item|
         expect(item).not_to have_css active_css

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -26,6 +26,14 @@ RSpec.feature 'Navigation Bar', type: :feature do
       expect(nav_bar.tag_name).to eq('nav')
       expect(site_nav_items[0]).to have_link(href: '/')
     end
+
+    it 'only has the last link active' do
+      active_css = '.nav-link--active'
+      site_nav_items[0..-2].each do |item|
+        expect(item).not_to have_css active_css
+      end
+      expect(site_nav_items.last).to have_css active_css
+    end
   end
 
   shared_examples 'a cluster navigation bar' do

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -99,13 +99,13 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     include_examples 'cluster and part variable assignment'
 
     describe "get '/'" do
-      subject { nil }
+      subject { site }
       before :each do
         get root_path(as: user)
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables
+        assigns_navigation_variables(:site)
       end
     end
   end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       component: nil,
       cluster_part: nil,
       component_group: nil,
+      service: nil,
     }
   end
 
@@ -75,7 +76,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(:cluster_part)
+        assigns_navigation_variables(:cluster_part, :service)
       end
     end
   end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
   context 'when no user' do
     describe "get '/'" do
+      subject { nil }
       before :each do
         get root_path
       end
@@ -98,12 +99,13 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     include_examples 'cluster and part variable assignment'
 
     describe "get '/'" do
+      subject { nil }
       before :each do
         get root_path(as: user)
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(:site)
+        assigns_navigation_variables
       end
     end
   end
@@ -114,6 +116,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     include_examples 'cluster and part variable assignment'
 
     describe "get '/'" do
+      subject { nil }
       before :each do
         get root_path(as: user)
       end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -24,61 +24,57 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
   RSpec.shared_examples 'cluster and part variable assignment' do
     describe "get '/cluster/*'" do
+      subject { cluster }
       before :each do
         get cluster_path(cluster.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
           cluster: cluster,
-          cluster_part: nil,
-          component_group: nil
+          scope: cluster
         )
       end
     end
 
     describe "get /components/*" do
+      subject { component }
       before :each do
         get component_path(component.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: cluster,
-          cluster_part: component,
-          component_group: component_group
+          cluster_part: subject,
+          component: subject,
+          scope: subject
         )
       end
     end
 
     describe "get /component_group/*" do
+      subject { component_group }
       before :each do
         get component_group_path(component_group.id, as: user)
       end
 
       it 'assigns the correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: cluster,
           cluster_part: nil,
-          component_group: component_group
+          component_group: subject
         )
       end
     end
 
     describe "get /services/*" do
+      subject { service }
       before :each do
         get service_path(service.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: cluster,
-          cluster_part: service,
-          component_group: nil
+          cluster_part: subject,
         )
       end
     end
@@ -143,13 +139,14 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     end
 
     describe "get '/sites/*'" do
+      subject { site }
       before :each do
         get site_path(site.id, as: user)
       end
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
+          site: subject,
           cluster: nil,
           cluster_part: nil,
           component_group: nil

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -16,8 +16,19 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     allow_any_instance_of(Cluster).to receive(:documents).and_return []
   end
 
+  let :default_nav_variables do
+    {
+      scope: subject,
+      site: nil,
+      cluster: nil,
+      component: nil,
+      cluster_part: nil,
+      component_group: nil,
+    }
+  end
+
   def assigns_navigation_variables(vars)
-    vars.each do |var, value|
+    default_nav_variables.merge(vars).each do |var, value|
       expect(assigns(var)).to eq value
     end
   end
@@ -30,10 +41,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          cluster: cluster,
-          scope: cluster
-        )
+        assigns_navigation_variables(cluster: subject)
       end
     end
 
@@ -47,7 +55,6 @@ RSpec.describe 'Navigation variable assignments', type: :request do
         assigns_navigation_variables(
           cluster_part: subject,
           component: subject,
-          scope: subject
         )
       end
     end
@@ -60,7 +67,6 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
       it 'assigns the correct navigation variables' do
         assigns_navigation_variables(
-          cluster_part: nil,
           component_group: subject
         )
       end
@@ -87,12 +93,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: nil,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
-        )
+        assigns_navigation_variables({})
       end
     end
   end
@@ -109,10 +110,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
 
       it 'assigns correct navigation variables' do
         assigns_navigation_variables(
-          site: site,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
+          site: site
         )
       end
     end
@@ -129,12 +127,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: nil,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
-        )
+        assigns_navigation_variables({})
       end
     end
 
@@ -145,12 +138,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: subject,
-          cluster: nil,
-          cluster_part: nil,
-          component_group: nil
-        )
+        assigns_navigation_variables(site: subject)
       end
     end
   end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     }
   end
 
-  def assigns_navigation_variables(vars)
-    default_nav_variables.merge(vars).each do |var, value|
+  def assigns_navigation_variables(*subject_keys)
+    subject_hash = (subject_keys.map { |k| [k, subject] }).to_h
+    default_nav_variables.merge(subject_hash).each do |var, value|
       expect(assigns(var)).to eq value
     end
   end
@@ -41,7 +42,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(cluster: subject)
+        assigns_navigation_variables(:cluster)
       end
     end
 
@@ -52,10 +53,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          cluster_part: subject,
-          component: subject,
-        )
+        assigns_navigation_variables(:cluster_part, :component)
       end
     end
 
@@ -66,9 +64,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns the correct navigation variables' do
-        assigns_navigation_variables(
-          component_group: subject
-        )
+        assigns_navigation_variables(:component_group)
       end
     end
 
@@ -79,9 +75,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          cluster_part: subject,
-        )
+        assigns_navigation_variables(:cluster_part)
       end
     end
   end
@@ -93,7 +87,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables({})
+        assigns_navigation_variables
       end
     end
   end
@@ -109,9 +103,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(
-          site: site
-        )
+        assigns_navigation_variables(:site)
       end
     end
   end
@@ -127,7 +119,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables({})
+        assigns_navigation_variables
       end
     end
 
@@ -138,7 +130,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
       end
 
       it 'assigns correct navigation variables' do
-        assigns_navigation_variables(site: subject)
+        assigns_navigation_variables(:site)
       end
     end
   end


### PR DESCRIPTION
Based on #85, either merge it first or skip it and merge this one. This PR fixes the errors in the previous PR.

The rendering of the nav bar has been completely overhauled to rely on the scope. This means other controllers can now set instance variables without having to worry about affecting the navigation. The nav bar has been broken out into its own partial template. The nav links also have there own partial as this prevents duplication of the code.

When rendering a nav link, the `text`, `path` and `icon` for the link are required. Alternatively, a `model` can be provided which will implicitly set the `text` and `path`.

Things get a bit tricky when trying to set the active link. Previously this was done with a bunch of logic, which isn't idea as it is more likely to be bug prone. Instead the last link is always rendered as the active link (which should always be the case).

This is a bit difficult as the number of links are not know in advance. So instead, the first pass creates an array of procs. These procs contain the code required to render each link. Then it becomes a trivial case of rendering the last proc as the active link.