### PR TITLE
Scheduled maintenance window progression

### DIFF
--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -11,6 +11,8 @@ class MaintenanceWindow < ApplicationRecord
   validates_presence_of :requested_start
   validates_presence_of :requested_end
 
+  scope :unfinished, -> { where.not(state: finished_states) }
+
   attr_accessor :skip_comments
 
   state_machine initial: :new do

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -13,9 +13,18 @@
 
 5. Debug things if the script fails for some reason.
 
-6. Rename the `Done` column at
+6. Ensure shared production server `crontab` for user log in as (currently
+   `ubuntu`) includes the following:
+
+   ```crontab
+   # Flight Center tasks.
+   * * * * * dokku --rm run flight-center rake alces:cron:every_minute
+   0 */3 * * * /home/ubuntu/flight-center-backup-database
+   ```
+
+7. Rename the `Done` column at
    https://trello.com/b/EYQnm3F9/alces-flight-center appropriately and create a
    new `Done` column.
 
-7. Announce the release at https://alces.slack.com/messages/C72GT476Y/,
+8. Announce the release at https://alces.slack.com/messages/C72GT476Y/,
    mentioning where to see what's in this release (the renamed column).

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,0 +1,7 @@
+
+namespace :alces do
+  namespace :cron do
+    desc 'Tasks to run every minute'
+    task every_minute: 'alces:maintenance_windows:progress'
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,5 +1,7 @@
 
 namespace :alces do
+  # NOTE: The crontab syntax required in production for running these tasks
+  # should be documented in `docs/release-process.md`.
   namespace :cron do
     desc 'Tasks to run every minute'
     task every_minute: 'alces:maintenance_windows:progress'

--- a/lib/tasks/maintenance_windows.rake
+++ b/lib/tasks/maintenance_windows.rake
@@ -1,0 +1,22 @@
+
+namespace :alces do
+  namespace :maintenance_windows do
+    desc 'Progress each unfinished maintenance window to next needed state'
+    task progress: :environment do |task|
+      logger = create_logger('log/tasks/maintenance_windows/progress.log')
+      logger.info("#{task.name} running at #{DateTime.current.iso8601}")
+
+      MaintenanceWindow.unfinished.each do |window|
+        message = ProgressMaintenanceWindow.new(window).progress
+        logger.info(message)
+      end
+    end
+
+    private
+
+    def create_logger(log_path)
+      FileUtils.mkdir_p(File.dirname(log_path))
+      ActiveSupport::Logger.new(log_path)
+    end
+  end
+end

--- a/lib/tasks/maintenance_windows.rake
+++ b/lib/tasks/maintenance_windows.rake
@@ -16,7 +16,8 @@ namespace :alces do
 
     def create_logger(log_path)
       FileUtils.mkdir_p(File.dirname(log_path))
-      ActiveSupport::Logger.new(log_path)
+      shift_age = 'weekly'
+      ActiveSupport::Logger.new(log_path, shift_age)
     end
   end
 end

--- a/spec/lib/tasks/cron_spec.rb
+++ b/spec/lib/tasks/cron_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'alces:cron:every_minute' do
+  include_context 'rake'
+
+  it 'has alces:maintenance_windows:progress prerequisite' do
+    expect(subject.prerequisites).to include('alces:maintenance_windows:progress')
+  end
+end

--- a/spec/lib/tasks/cron_spec.rb
+++ b/spec/lib/tasks/cron_spec.rb
@@ -3,7 +3,5 @@ require 'rails_helper'
 RSpec.describe 'alces:cron:every_minute' do
   include_context 'rake'
 
-  it 'has alces:maintenance_windows:progress prerequisite' do
-    expect(subject.prerequisites).to include('alces:maintenance_windows:progress')
-  end
+  it_behaves_like 'it has prerequisite', 'alces:maintenance_windows:progress'
 end

--- a/spec/lib/tasks/maintenance_windows_spec.rb
+++ b/spec/lib/tasks/maintenance_windows_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'alces:maintenance_windows:progress' do
+  include_context 'rake'
+
+  let :unfinished_states do
+    [
+      :confirmed,
+      :new,
+      :requested,
+      :started,
+    ]
+  end
+
+  before :each do
+    MaintenanceWindow.possible_states.each do |state|
+      create(:maintenance_window, state: state)
+    end
+  end
+
+  it 'has environment prerequisite' do
+    # Required to load Rails environment so can access models etc.
+    expect(subject.prerequisites).to include('environment')
+  end
+
+  it 'attempts to progress all unfinished maintenance windows' do
+    progressed_windows = []
+    expect(
+      ProgressMaintenanceWindow
+    ).to receive(:new).exactly(4).times.and_wrap_original do |method, *args|
+      method.call(*args).tap do |progress_mw|
+        allow(progress_mw).to receive(:progress) do
+          progressed_windows << progress_mw.window
+        end
+      end
+    end
+
+    subject.invoke
+
+    progressed_window_states = progressed_windows.map(&:state).map(&:to_sym)
+    expect(progressed_window_states).to match_array(unfinished_states)
+  end
+
+  describe 'logging' do
+    let :logger { Rails.logger }
+
+    before :each do
+      expect(ActiveSupport::Logger).to receive(:new).with(
+        'log/tasks/maintenance_windows/progress.log'
+      ).and_return(logger)
+      allow(logger).to receive(:info)
+    end
+
+    it 'logs when task started' do
+      expect(logger).to receive(:info).with(
+        "#{task_name} running at #{DateTime.current.iso8601}"
+      )
+
+      subject.invoke
+    end
+
+    it 'logs result of each maintenance window progression' do
+      unfinished_states.each do |state|
+        expect(logger).to receive(:info).with(/Maintenance window.*#{state}/)
+      end
+
+      subject.invoke
+    end
+  end
+end

--- a/spec/lib/tasks/maintenance_windows_spec.rb
+++ b/spec/lib/tasks/maintenance_windows_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe 'alces:maintenance_windows:progress' do
 
     before :each do
       expect(ActiveSupport::Logger).to receive(:new).with(
-        'log/tasks/maintenance_windows/progress.log'
+        'log/tasks/maintenance_windows/progress.log',
+        'weekly',
       ).and_return(logger)
       allow(logger).to receive(:info)
     end

--- a/spec/lib/tasks/maintenance_windows_spec.rb
+++ b/spec/lib/tasks/maintenance_windows_spec.rb
@@ -18,10 +18,7 @@ RSpec.describe 'alces:maintenance_windows:progress' do
     end
   end
 
-  it 'has environment prerequisite' do
-    # Required to load Rails environment so can access models etc.
-    expect(subject.prerequisites).to include('environment')
-  end
+  it_behaves_like 'it has prerequisite', :environment
 
   it 'attempts to progress all unfinished maintenance windows' do
     progressed_windows = []

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -345,5 +345,23 @@ RSpec.describe MaintenanceWindow, type: :model do
         ])
       end
     end
+
+    describe '#unfinished' do
+      it 'returns all windows which have not reached a finished state' do
+        subject.possible_states.each do |state|
+          create(:maintenance_window, state: state)
+        end
+
+        unfinished_windows = described_class.unfinished
+
+        unfinished_window_states = unfinished_windows.map(&:state).map(&:to_sym)
+        expect(unfinished_window_states).to match_array([
+          :confirmed,
+          :new,
+          :requested,
+          :started,
+        ])
+      end
+    end
   end
 end

--- a/spec/spec/support/spec_utils_spec.rb
+++ b/spec/spec/support/spec_utils_spec.rb
@@ -1,3 +1,4 @@
+require 'rails_helper'
 
 RSpec.describe SpecUtils do
   describe '#class_factory_identifier' do

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,19 @@
+require "rake"
+
+RSpec.shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,9 +1,11 @@
 require "rake"
 
+# Adapted from https://robots.thoughtbot.com/test-rake-tasks-like-a-boss.
 RSpec.shared_context "rake" do
-  let(:rake)      { Rake::Application.new }
-  let(:task_name) { self.class.top_level_description }
-  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  let :rake      { Rake::Application.new }
+  let :task_name { self.class.top_level_description }
+  let :expected_task_file { task_name.gsub('alces:', '').split(":").first }
+  let :task_path { "lib/tasks/#{expected_task_file}" }
   subject         { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file
@@ -12,7 +14,11 @@ RSpec.shared_context "rake" do
 
   before do
     Rake.application = rake
-    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+    Rake.application.rake_require(
+      task_path,
+      [Rails.root.to_s],
+      loaded_files_excluding_current_rake_file
+    )
 
     Rake::Task.define_task(:environment)
   end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -23,3 +23,9 @@ RSpec.shared_context "rake" do
     Rake::Task.define_task(:environment)
   end
 end
+
+RSpec.shared_examples 'it has prerequisite' do |name|
+  it "has #{name} prerequisite" do
+    expect(subject.prerequisites).to include(name.to_s)
+  end
+end


### PR DESCRIPTION
This PR:

- implements a Rake task which will progress all unfinished maintenance windows;

- sets up a generic Rake task which will run every minute, to run the above and any other future similar tasks we might have;

- sets up a means of testing these and other Rake tasks;

- documents how to install the `cron` Rake task for our next deploy.

Based on #87.