### PR TITLE
Implement `respond_to?` for MaintenanceWindows

### DIFF
--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -85,6 +85,14 @@ class MaintenanceWindow < ApplicationRecord
     last_transition_property(state: state, property: property)
   end
 
+  def respond_to?(symbol, include_all=false)
+    super || (
+      return false unless symbol =~ /^([a-z]+)_(at|by)$/
+      state = $1.to_sym
+      self.class.possible_states.include?(state)
+    )
+  end
+
   private
 
   delegate :site, to: :case

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -328,6 +328,23 @@ RSpec.describe MaintenanceWindow, type: :model do
     end
   end
 
+  describe '#respond_to?' do
+    subject { create(:maintenance_window) }
+
+    # Examples of new methods it should respond to.
+    it { is_expected.to respond_to(:requested_by) }
+    it { is_expected.to respond_to(:confirmed_at) }
+
+    # Methods from parents it should still respond to.
+    it { is_expected.to respond_to(:created_at) }
+    it { is_expected.to respond_to(:updated_at) }
+
+    # Other examples of methods it shouldn't respond to.
+    it { is_expected.not_to respond_to(:exploded_at) }
+    it { is_expected.not_to respond_to(:exploded_by) }
+    it { is_expected.not_to respond_to(:some_other_method) }
+  end
+
   describe 'class' do
     subject { described_class }
 


### PR DESCRIPTION
This PR implements `respond_to?` for the `MaintenanceWindow` class, which is the best practice when `method_missing` is implemented and helps avoid potential odd problems when these give inconsistent results (which is what prompted me to do this after having issues in a later PR). Some related refactoring is also included. Based on #88.