### PR TITLE
Update maintenance table

### DIFF
--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -27,6 +27,13 @@ class MaintenanceWindowsController < ApplicationController
     redirect_to cluster_path(window.associated_cluster)
   end
 
+  def cancel
+    window = MaintenanceWindow.find(params[:id])
+    window.cancel!(current_user)
+    flash[:success] = 'Requested maintenance cancelled.'
+    redirect_to cluster_path(window.associated_cluster)
+  end
+
   private
 
   PARAM_NAMES = [

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -21,24 +21,15 @@ class MaintenanceWindowsController < ApplicationController
   end
 
   def confirm
-    window = MaintenanceWindow.find(params[:id])
-    window.confirm!(current_user)
-    flash[:success] = 'Requested maintenance confirmed.'
-    redirect_to cluster_path(window.associated_cluster)
+    transition_window(:confirm)
   end
 
   def reject
-    window = MaintenanceWindow.find(params[:id])
-    window.reject!(current_user)
-    flash[:success] = 'Requested maintenance rejected.'
-    redirect_to cluster_path(window.associated_cluster)
+    transition_window(:reject)
   end
 
   def cancel
-    window = MaintenanceWindow.find(params[:id])
-    window.cancel!(current_user)
-    flash[:success] = 'Requested maintenance cancelled.'
-    redirect_to cluster_path(window.associated_cluster)
+    transition_window(:cancel)
   end
 
   private
@@ -62,5 +53,12 @@ class MaintenanceWindowsController < ApplicationController
 
   def suggested_requested_end
     suggested_requested_start.advance(days: 1)
+  end
+
+  def transition_window(event)
+    window = MaintenanceWindow.find(params[:id])
+    window.public_send("#{event}!", current_user)
+    flash[:success] = "Requested maintenance #{window.state}."
+    redirect_to cluster_path(window.associated_cluster)
   end
 end

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -27,6 +27,13 @@ class MaintenanceWindowsController < ApplicationController
     redirect_to cluster_path(window.associated_cluster)
   end
 
+  def reject
+    window = MaintenanceWindow.find(params[:id])
+    window.reject!(current_user)
+    flash[:success] = 'Requested maintenance rejected.'
+    redirect_to cluster_path(window.associated_cluster)
+  end
+
   def cancel
     window = MaintenanceWindow.find(params[:id])
     window.cancel!(current_user)

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -23,6 +23,7 @@ class MaintenanceWindowsController < ApplicationController
   def confirm
     window = MaintenanceWindow.find(params[:id])
     window.confirm!(current_user)
+    flash[:success] = 'Requested maintenance confirmed.'
     redirect_to cluster_path(window.associated_cluster)
   end
 

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -1,0 +1,17 @@
+class MaintenanceWindowDecorator < ApplicationDecorator
+  delegate_all
+
+  def transition_info(state)
+    user = public_send("#{state}_by")
+    date = public_send("#{state}_at")
+    transition_info_text(user, date)
+  end
+
+  private
+
+  def transition_info_text(user, date)
+    return false unless user && date
+    formatted_date = date.to_formatted_s(:short)
+    h.raw("By <em>#{user.name}</em> on <em>#{formatted_date}</em>")
+  end
+end

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -2,6 +2,17 @@ class MaintenanceWindowDecorator < ApplicationDecorator
   delegate_all
   decorates_association :associated_model
 
+  def scheduled_period
+    h.raw(
+      [
+        format(requested_start),
+        '&mdash;',
+        format(requested_end),
+        started? ? '<strong>(in progress)</strong>' : ''
+      ].join(' ').strip
+    )
+  end
+
   def transition_info(state)
     user = public_send("#{state}_by")
     date = public_send("#{state}_at")
@@ -12,7 +23,10 @@ class MaintenanceWindowDecorator < ApplicationDecorator
 
   def transition_info_text(user, date)
     return false unless user && date
-    formatted_date = date.to_formatted_s(:short)
-    h.raw("By <em>#{user.name}</em> on <em>#{formatted_date}</em>")
+    h.raw("By <em>#{user.name}</em> on <em>#{format(date)}</em>")
+  end
+
+  def format(date_time)
+    date_time.to_formatted_s(:short)
   end
 end

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -1,5 +1,6 @@
 class MaintenanceWindowDecorator < ApplicationDecorator
   delegate_all
+  decorates_association :associated_model
 
   def transition_info(state)
     user = public_send("#{state}_by")

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -85,6 +85,14 @@ class MaintenanceWindow < ApplicationRecord
     last_transition_property(state: state, property: property)
   end
 
+  def respond_to?(symbol, include_all=false)
+    super || (
+      return false unless symbol =~ /^([a-z]+)_(at|by)$/
+      state = $1.to_sym
+      self.class.possible_states.include?(state)
+    )
+  end
+
   private
 
   delegate :site, to: :case

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -35,10 +35,18 @@
         <td><%= window.associated_model.links %></td>
         <td><%= window.transition_info(:requested) %></td>
         <td>
-          <%= window.transition_info(:confirmed) || button_to(
-            raw('Unconfirmed &mdash; click to confirm'),
-            confirm_maintenance_window_path(window),
-            class: ['btn', 'btn-success', 'btn-block'])
+          <%= window.transition_info(:confirmed) || raw([
+            button_to(
+              raw('Unconfirmed &mdash; click to confirm'),
+              confirm_maintenance_window_path(window),
+              class: ['btn', 'btn-success', 'btn-block']
+            ),
+            button_to(
+              'Cancel request for maintenance',
+              cancel_maintenance_window_path(window),
+              class: ['btn', 'btn-warning', 'btn-block']
+            )
+          ].join)
           %>
         </td>
       </tr>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -45,6 +45,11 @@
               'Cancel request for maintenance',
               cancel_maintenance_window_path(window),
               class: ['btn', 'btn-warning', 'btn-block']
+            ),
+            button_to(
+              'Reject request for maintenance',
+              reject_maintenance_window_path(window),
+              class: ['btn', 'btn-danger', 'btn-block']
             )
           ].join)
           %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -37,26 +37,8 @@
         <td><%= window.scheduled_period %></td>
         <td><%= window.transition_info(:requested) %></td>
         <td>
-          <%= window.transition_info(:confirmed) || raw([
-            button_to(
-              raw('Unconfirmed &mdash; click to confirm'),
-              confirm_maintenance_window_path(window),
-              class: ['btn', 'btn-success', 'btn-block']
-            ),
-            (current_user.contact? ?
-              button_to(
-                'Reject request for maintenance',
-                reject_maintenance_window_path(window),
-                class: ['btn', 'btn-danger', 'btn-block']
-              )
-            : button_to(
-                'Cancel request for maintenance',
-                cancel_maintenance_window_path(window),
-                class: ['btn', 'btn-warning', 'btn-block']
-              )
-            )
-          ].join)
-          %>
+          <%= window.transition_info(:confirmed) ||
+            render('maintenance_windows/unconfirmed_buttons', window: window) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -23,28 +23,23 @@
   <table class="table table-responsive">
     <thead>
       <tr>
-        <th>Date</th>
         <th>For</th>
-        <th>Requested By</th>
-        <th>Confirmed By</th>
+        <th>Requested</th>
+        <th>Confirmed</th>
       </tr>
     </thead>
 
     <tbody>
-    <% cluster.open_related_maintenance_windows.each do |window| %>
+    <% cluster.open_related_maintenance_windows.map(&:decorate).each do |window| %>
       <tr>
-        <td><%= window.created_at.to_formatted_s(:short) %></td>
-        <td><%= window.associated_model.decorate.links %></td>
-        <td><%= window.requested_by.name %></td>
+        <td><%= window.associated_model.links %></td>
+        <td><%= window.transition_info(:requested) %></td>
         <td>
-          <% if window.confirmed_by %>
-            <%= window.confirmed_by.name %>
-          <% else %>
-            <%= button_to raw('Unconfirmed &mdash; click to confirm'),
-              confirm_maintenance_window_path(window),
-              class: ['btn', 'btn-success', 'btn-block']
-            %>
-          <% end %>
+          <%= window.transition_info(:confirmed) || button_to(
+            raw('Unconfirmed &mdash; click to confirm'),
+            confirm_maintenance_window_path(window),
+            class: ['btn', 'btn-success', 'btn-block'])
+          %>
         </td>
       </tr>
     <% end %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -43,15 +43,17 @@
               confirm_maintenance_window_path(window),
               class: ['btn', 'btn-success', 'btn-block']
             ),
-            button_to(
-              'Cancel request for maintenance',
-              cancel_maintenance_window_path(window),
-              class: ['btn', 'btn-warning', 'btn-block']
-            ),
-            button_to(
-              'Reject request for maintenance',
-              reject_maintenance_window_path(window),
-              class: ['btn', 'btn-danger', 'btn-block']
+            (current_user.contact? ?
+              button_to(
+                'Reject request for maintenance',
+                reject_maintenance_window_path(window),
+                class: ['btn', 'btn-danger', 'btn-block']
+              )
+            : button_to(
+                'Cancel request for maintenance',
+                cancel_maintenance_window_path(window),
+                class: ['btn', 'btn-warning', 'btn-block']
+              )
             )
           ].join)
           %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -24,6 +24,7 @@
     <thead>
       <tr>
         <th>For</th>
+        <th>Maintenance period</th>
         <th>Requested</th>
         <th>Confirmed</th>
       </tr>
@@ -33,6 +34,7 @@
     <% cluster.open_related_maintenance_windows.map(&:decorate).each do |window| %>
       <tr>
         <td><%= window.associated_model.links %></td>
+        <td><%= window.scheduled_period %></td>
         <td><%= window.transition_info(:requested) %></td>
         <td>
           <%= window.transition_info(:confirmed) || raw([

--- a/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
+++ b/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
@@ -9,11 +9,21 @@
 <% if current_user.admin? %>
   <%= button_to 'Cancel request for maintenance',
     cancel_maintenance_window_path(window),
-    class: ['btn', 'btn-warning', 'btn-block']
+    class: ['btn', 'btn-warning', 'btn-block'],
+    data: {
+      confirm: 'Are you sure you want to cancel this requested maintenance?'
+    }
   %>
 <% else %>
   <%= button_to 'Reject request for maintenance',
     reject_maintenance_window_path(window),
-    class: ['btn', 'btn-danger', 'btn-block']
+    class: ['btn', 'btn-danger', 'btn-block'],
+    data: {
+      confirm: <<~EOF.squish
+        Are you sure you want to reject this requested maintenance? Alces
+        Software engineers will not be able to perform this maintenance until
+        you have confirmed it.
+      EOF
+    }
   %>
 <% end %>

--- a/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
+++ b/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
@@ -1,0 +1,19 @@
+
+<%= button_to(
+  raw('Unconfirmed &mdash; click to confirm'),
+  confirm_maintenance_window_path(window),
+  class: ['btn', 'btn-success', 'btn-block']
+)
+%>
+
+<% if current_user.admin? %>
+  <%= button_to 'Cancel request for maintenance',
+    cancel_maintenance_window_path(window),
+    class: ['btn', 'btn-warning', 'btn-block']
+  %>
+<% else %>
+  <%= button_to 'Reject request for maintenance',
+    reject_maintenance_window_path(window),
+    class: ['btn', 'btn-danger', 'btn-block']
+  %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,11 @@ Rails.application.routes.draw do
       resources :maintenance_windows, only: :new
     end
 
-    resources :maintenance_windows, only: :create
+    resources :maintenance_windows, only: :create do
+      member do
+        post :cancel
+      end
+    end
 
     resources :credit_charges, only: [:create, :update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
     resources :maintenance_windows, only: [] do
       member do
         post :confirm
+        post :reject
       end
     end
   end

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe MaintenanceWindowDecorator do
+  describe '#transition_info' do
+    subject do
+      create(:maintenance_window)
+        .tap { |w| w.request!(requestor) }
+        .decorate
+    end
+
+    let :requestor { create(:user, name: 'Some User') }
+
+    it 'gives string with info on transition to this state' do
+      info = subject.transition_info(:requested)
+
+      user_name = requestor.name
+      date_time = subject.requested_at.to_formatted_s(:short)
+      expect(info).to eq(
+        h.raw("By <em>#{user_name}</em> on <em>#{date_time}</em>")
+      )
+    end
+
+    it 'gives false for transition which has not occurred' do
+      info = subject.transition_info(:confirmed)
+
+      expect(info).to be false
+    end
+  end
+end

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -26,4 +26,26 @@ RSpec.describe MaintenanceWindowDecorator do
       expect(info).to be false
     end
   end
+
+  describe '#scheduled_period' do
+    it 'returns formatted time range for maintenance' do
+      requested_start = DateTime.current.advance(days: 1)
+      requested_end = DateTime.current.advance(days: 2)
+      window = create(
+        :maintenance_window,
+        requested_start: requested_start,
+        requested_end: requested_end,
+      ).decorate
+
+      from = requested_start.to_formatted_s(:short)
+      to = requested_end.to_formatted_s(:short)
+      expect(window.scheduled_period).to include h.raw("#{from} &mdash; #{to}")
+    end
+
+    it 'indicates if the maintenance is in progress' do
+      window = create(:maintenance_window, state: :started).decorate
+
+      expect(window.scheduled_period).to include '(in progress)'
+    end
+  end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -106,5 +106,24 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(window.confirmed_by).to eq(user)
       expect(find('.alert')).to have_text(/maintenance confirmed/)
     end
+
+    it 'can reject requested maintenance' do
+      window = create(
+        :requested_maintenance_window,
+        component: component,
+        case: support_case
+      )
+
+      visit cluster_path(cluster, as: user)
+      button_text = 'Reject'
+
+      click_button(button_text)
+
+      window.reload
+      expect(window).to be_rejected
+      expect(window.rejected_by).to eq user
+      expect(current_path).to eq(cluster_path(cluster))
+      expect(find('.alert')).to have_text(/maintenance rejected/)
+    end
   end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       end_maintenance_window_case_path(support_case.id)
     end
 
-    it 'can request maintenance in association with different Case for Cluster' do
+    it 'can request maintenance in association with any Case for Cluster' do
       cluster = create(:cluster)
       component = create(:component, cluster: cluster)
       case_subject = 'Unrelated case'

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -59,6 +59,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(new_window.requested_start).to eq DateTime.new(2022, 9, 10, 13, 0)
       expect(new_window.requested_end).to eq DateTime.new(2023, 9, 20, 13, 0)
       expect(current_path).to eq(cluster_path(cluster))
+      expect(find('.alert')).to have_text(/Maintenance requested/)
     end
   end
 
@@ -89,6 +90,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(page).not_to have_button(button_text)
       expect(page.all('table')[1]).to have_text(user_name)
       expect(window.confirmed_by).to eq(user)
+      expect(find('.alert')).to have_text(/maintenance confirmed/)
     end
   end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -75,6 +75,14 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(current_path).to eq(cluster_path(cluster))
       expect(find('.alert')).to have_text(/maintenance cancelled/)
     end
+
+    it 'cannot see reject button' do
+      create(:requested_maintenance_window, cluster: cluster)
+
+      visit cluster_path(cluster, as: user)
+
+      expect(page).not_to have_button('Reject')
+    end
   end
 
   context 'when user is contact' do
@@ -124,6 +132,18 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(window.rejected_by).to eq user
       expect(current_path).to eq(cluster_path(cluster))
       expect(find('.alert')).to have_text(/maintenance rejected/)
+    end
+
+    it 'cannot see cancel button' do
+      create(
+        :requested_maintenance_window,
+        component: component,
+        case: support_case
+      )
+
+      visit cluster_path(cluster, as: user)
+
+      expect(page).not_to have_button('Cancel')
     end
   end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -61,6 +61,20 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(current_path).to eq(cluster_path(cluster))
       expect(find('.alert')).to have_text(/Maintenance requested/)
     end
+
+    it 'can cancel requested maintenance' do
+      window = create(:requested_maintenance_window, cluster: cluster)
+
+      visit cluster_path(cluster, as: user)
+      button_text = 'Cancel'
+      click_button(button_text)
+
+      window.reload
+      expect(window).to be_cancelled
+      expect(window.cancelled_by).to eq user
+      expect(current_path).to eq(cluster_path(cluster))
+      expect(find('.alert')).to have_text(/maintenance cancelled/)
+    end
   end
 
   context 'when user is contact' do

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -328,6 +328,23 @@ RSpec.describe MaintenanceWindow, type: :model do
     end
   end
 
+  describe '#respond_to?' do
+    subject { create(:maintenance_window) }
+
+    # Examples of new methods it should respond to.
+    it { is_expected.to respond_to(:requested_by) }
+    it { is_expected.to respond_to(:confirmed_at) }
+
+    # Methods from parents it should still respond to.
+    it { is_expected.to respond_to(:created_at) }
+    it { is_expected.to respond_to(:updated_at) }
+
+    # Other examples of methods it shouldn't respond to.
+    it { is_expected.not_to respond_to(:exploded_at) }
+    it { is_expected.not_to respond_to(:exploded_by) }
+    it { is_expected.not_to respond_to(:some_other_method) }
+  end
+
   describe 'class' do
     subject { described_class }
 


### PR DESCRIPTION
This PR updates the maintenance table shown on the Cluster page to show new data and support new actions, following implementing the new maintenance window system. This includes:

- showing the requested time period for each requested/scheduled maintenance window;

- showing a cancel maintenance button to admins;

- showing a reject maintenance button to contacts;

- various related refactoring behind the scenes.

Based on #89.