### PR TITLE
Validate MaintenanceWindow transition user

### DIFF
--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -91,7 +91,9 @@ class MaintenanceWindow < ApplicationRecord
   delegate :site, to: :case
 
   def add_transition_comment
-    maintenance_notifier.add_transition_comment(state) unless skip_comments
+    unless invalid? || skip_comments
+      maintenance_notifier.add_transition_comment(state)
+    end
   end
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/maintenance_window_state_transition.rb
+++ b/app/models/maintenance_window_state_transition.rb
@@ -6,6 +6,7 @@ class MaintenanceWindowStateTransition < ApplicationRecord
 
   validates_presence_of :user, if: :user_initiated_transition?
   validates_absence_of :user, unless: :user_initiated_transition?
+  validate :validate_user_can_initiate
 
   private
 
@@ -18,5 +19,14 @@ class MaintenanceWindowStateTransition < ApplicationRecord
 
   def user_initiated_transition?
     USER_INITIATED_STATES.include?(to.to_sym)
+  end
+
+  def validate_user_can_initiate
+    case event&.to_sym
+    when :request, :cancel
+      errors.add(:user, 'must be an admin') unless user&.admin?
+    when :reject
+      errors.add(:user, 'must be a site contact') unless user&.contact?
+    end
   end
 end

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MaintenanceWindowDecorator do
         .decorate
     end
 
-    let :requestor { create(:user, name: 'Some User') }
+    let :requestor { create(:admin, name: 'Some User') }
 
     it 'gives string with info on transition to this state' do
       info = subject.transition_info(:requested)

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe MaintenanceWindow, type: :model do
 
       it 'has RT ticket comment added when cancelled' do
         subject.component = create(:component, name: 'some_component')
-        user = create(:user, name: 'some_user')
+        user = create(:admin, name: 'some_user')
 
         expect(Case.request_tracker).to receive(
           :add_ticket_correspondence
@@ -124,7 +124,7 @@ RSpec.describe MaintenanceWindow, type: :model do
 
       it 'has RT ticket comment added when requested' do
         subject.component = create(:component, name: 'some_component')
-        requestor = create(:user, name: 'some_user')
+        requestor = create(:admin, name: 'some_user')
 
         expected_cluster_url = Rails.application.routes.url_helpers.cluster_url(
           subject.component.cluster
@@ -276,7 +276,7 @@ RSpec.describe MaintenanceWindow, type: :model do
     describe '#*_at' do
       it 'returns time transition occurred for valid state' do
         maintenance_window = create(:maintenance_window)
-        user = create(:user)
+        user = create(:admin)
         maintenance_window.request!(user)
         transition_time = 3.days.ago.at_midnight
         maintenance_window
@@ -303,7 +303,7 @@ RSpec.describe MaintenanceWindow, type: :model do
 
     describe '#*_by' do
       it 'returns the user associated with transition for valid state' do
-        user = create(:user, name: 'some_user')
+        user = create(:admin, name: 'some_user')
         maintenance_window = create(:maintenance_window)
         maintenance_window.request!(user)
 

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe MaintenanceWindow, type: :model do
 
       it { is_expected.to be_invalid }
     end
+
+    context 'after invalid transition' do
+      before :each do
+        subject.cluster = create(:cluster)
+        subject.request!
+      end
+
+      it { is_expected.to be_invalid }
+    end
   end
 
   describe 'states' do

--- a/spec/models/maintenance_window_state_transition_spec.rb
+++ b/spec/models/maintenance_window_state_transition_spec.rb
@@ -26,5 +26,64 @@ RSpec.describe MaintenanceWindowStateTransition, type: :model do
         end
       end
     end
+
+    describe 'user type' do
+      context 'when `request` event' do
+        subject do
+          build(:maintenance_window_state_transition, event: :request)
+        end
+
+        it 'can be initiated by admin' do
+          subject.user = create(:admin)
+
+          expect(subject).to be_valid
+        end
+
+        it 'cannot be initiated by contact' do
+          subject.user = create(:contact)
+
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages).to include user: [/must be an admin/]
+        end
+      end
+
+      context 'when `cancel` event' do
+        subject do
+          build(:maintenance_window_state_transition, event: :cancel)
+        end
+
+        it 'can be initiated by admin' do
+          subject.user = create(:admin)
+
+          expect(subject).to be_valid
+        end
+
+        it 'cannot be initiated by contact' do
+          subject.user = create(:contact)
+
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages).to include user: [/must be an admin/]
+        end
+      end
+
+      context 'when `reject` event' do
+        subject do
+          build(:maintenance_window_state_transition, event: :reject)
+        end
+
+        it 'cannot be initiated by admin' do
+          subject.user = create(:admin)
+
+          expect(subject).not_to be_valid
+          expect(subject.errors.messages).to include user: [/must be a site contact/]
+        end
+
+        it 'can be initiated by contact' do
+          subject.user = create(:contact)
+
+          expect(subject).to be_valid
+        end
+      end
+    end
   end
 end

--- a/spec/models/maintenance_window_state_transition_spec.rb
+++ b/spec/models/maintenance_window_state_transition_spec.rb
@@ -1,27 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe MaintenanceWindowStateTransition, type: :model do
-  describe 'user presence' do
-    user_initiated_states = [:requested, :confirmed, :rejected, :cancelled]
-    automatic_states = [:new, :started, :ended, :expired]
+  describe '#valid?' do
+    describe 'user presence' do
+      user_initiated_states = [:requested, :confirmed, :rejected, :cancelled]
+      automatic_states = [:new, :started, :ended, :expired]
 
-    user_initiated_states.each do |state|
-      context "when transition to `#{state}`" do
-        subject do
-          build(:maintenance_window_state_transition, to: state)
+      user_initiated_states.each do |state|
+        context "when transition to `#{state}`" do
+          subject do
+            build(:maintenance_window_state_transition, to: state)
+          end
+
+          it { is_expected.to validate_presence_of(:user) }
         end
-
-        it { is_expected.to validate_presence_of(:user) }
       end
-    end
 
-    automatic_states.each do |state|
-      context "when transition to `#{state}`" do
-        subject do
-          build(:maintenance_window_state_transition, to: state)
+      automatic_states.each do |state|
+        context "when transition to `#{state}`" do
+          subject do
+            build(:maintenance_window_state_transition, to: state)
+          end
+
+          it { is_expected.to validate_absence_of(:user) }
         end
-
-        it { is_expected.to validate_absence_of(:user) }
       end
     end
   end

--- a/spec/models/maintenance_window_state_transition_spec.rb
+++ b/spec/models/maintenance_window_state_transition_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MaintenanceWindowStateTransition, type: :model do
     automatic_states = [:new, :started, :ended, :expired]
 
     user_initiated_states.each do |state|
-      describe "when transition to `#{state}`" do
+      context "when transition to `#{state}`" do
         subject do
           build(:maintenance_window_state_transition, to: state)
         end
@@ -16,7 +16,7 @@ RSpec.describe MaintenanceWindowStateTransition, type: :model do
     end
 
     automatic_states.each do |state|
-      describe "when transition to `#{state}`" do
+      context "when transition to `#{state}`" do
         subject do
           build(:maintenance_window_state_transition, to: state)
         end

--- a/spec/models/maintenance_window_state_transition_spec.rb
+++ b/spec/models/maintenance_window_state_transition_spec.rb
@@ -28,11 +28,7 @@ RSpec.describe MaintenanceWindowStateTransition, type: :model do
     end
 
     describe 'user type' do
-      context 'when `request` event' do
-        subject do
-          build(:maintenance_window_state_transition, event: :request)
-        end
-
+      RSpec.shared_examples 'it must be initiated by an admin' do
         it 'can be initiated by admin' do
           subject.user = create(:admin)
 
@@ -47,30 +43,7 @@ RSpec.describe MaintenanceWindowStateTransition, type: :model do
         end
       end
 
-      context 'when `cancel` event' do
-        subject do
-          build(:maintenance_window_state_transition, event: :cancel)
-        end
-
-        it 'can be initiated by admin' do
-          subject.user = create(:admin)
-
-          expect(subject).to be_valid
-        end
-
-        it 'cannot be initiated by contact' do
-          subject.user = create(:contact)
-
-          expect(subject).not_to be_valid
-          expect(subject.errors.messages).to include user: [/must be an admin/]
-        end
-      end
-
-      context 'when `reject` event' do
-        subject do
-          build(:maintenance_window_state_transition, event: :reject)
-        end
-
+      RSpec.shared_examples 'it must be initiated by a site contact' do
         it 'cannot be initiated by admin' do
           subject.user = create(:admin)
 
@@ -83,6 +56,30 @@ RSpec.describe MaintenanceWindowStateTransition, type: :model do
 
           expect(subject).to be_valid
         end
+      end
+
+      context 'when `request` event' do
+        subject do
+          build(:maintenance_window_state_transition, event: :request)
+        end
+
+        it_behaves_like 'it must be initiated by an admin'
+      end
+
+      context 'when `cancel` event' do
+        subject do
+          build(:maintenance_window_state_transition, event: :cancel)
+        end
+
+        it_behaves_like 'it must be initiated by an admin'
+      end
+
+      context 'when `reject` event' do
+        subject do
+          build(:maintenance_window_state_transition, event: :reject)
+        end
+
+        it_behaves_like 'it must be initiated by a site contact'
       end
     end
   end


### PR DESCRIPTION
This PR validates that the user who initiated a MaintenanceWindow transition is of the appropriate type, i.e. only admins can request or cancel maintenance and only users can reject it (confirming maintenance will be only allowed by users later, once https://github.com/alces-software/alces-flight-center/issues/73 has been implemented). Also included is some refactoring of the transition tests and a fix so MaintenanceWindows do not blow up when an invalid transition occurs.

Based on #90.