### PR TITLE
Split the cluster pages into separate tabs

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -3,12 +3,28 @@ class ComponentsController < ApplicationController
 
   def index
     @title = 'Components'
-    @components = @scope.components
     @table_tile = 'All Components' # Consider removing
+    @component_groups = component_groups_from_type
   end
 
   def show
     @title = "#{@component.name} Management Dashboard"
     @subtitle = @component.component_type.name
+  end
+
+  private
+
+  def component_groups_from_type
+    if type_param.blank?
+      @scope.component_groups
+    else
+      @scope.component_groups_by_type.find do |group_type|
+        group_type.name == type_param[:type]
+      end.component_groups
+    end
+  end
+
+  def type_param
+    params.permit(:type)
   end
 end

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -1,6 +1,12 @@
 class ComponentsController < ApplicationController
   decorates_assigned :component
 
+  def index
+    @title = 'Components'
+    @components = @scope.components
+    @table_tile = 'All Components' # Consider removing
+  end
+
   def show
     @title = "#{@component.name} Management Dashboard"
     @subtitle = @component.component_type.name

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,4 +1,8 @@
 class MaintenanceWindowsController < ApplicationController
+  def index
+    @title = 'Maintenance'
+  end
+
   def new
     assign_new_maintenance_title
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,10 @@
 class ServicesController < ApplicationController
   decorates_assigned :service
 
+  def index
+    @title = 'Services'
+  end
+
   def show
     @service = Service.find(params[:id])
     @title = "#{@service.name} Dashboard"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,12 @@ module ApplicationHelper
     @nav_link_procs ||= []
   end
 
+  def render_tab_bar(**render_args)
+    if @scope.is_a? Cluster
+      render('clusters/tabs', **render_args)
+    end
+  end
+
   def dark_button_classes
     ['btn', 'btn-primary', 'btn-block']
   end

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -11,7 +11,8 @@
           role: 'button'
         )
       end
-      list.push model.case_form_buttons
+      # TODO: This does not work for cluster objects
+      # list.push model.case_form_buttons
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -11,8 +11,7 @@
           role: 'button'
         )
       end
-      # TODO: This does not work for cluster objects
-      # list.push model.case_form_buttons
+      list.push model.decorate.case_form_buttons
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,6 +1,4 @@
 
-<% if @scope.is_a? Cluster %>
-  <%= render 'clusters/tabs', activate: :cases %>
-<% end %>
-
+<%= render_tab_bar activate: :cases %>
 <%= render 'cases_table', model: @scope, archive: true %>
+

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,2 +1,6 @@
 
-<%= render 'cases_table', model: site, archive: true %>
+<% if @scope.is_a? Cluster %>
+    <%= render 'clusters/tabs' %>
+<% end %>
+
+<%= render 'cases_table', model: @scope, archive: true %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,6 +1,6 @@
 
 <% if @scope.is_a? Cluster %>
-    <%= render 'clusters/tabs' %>
+  <%= render 'clusters/tabs', activate: :cases %>
 <% end %>
 
 <%= render 'cases_table', model: @scope, archive: true %>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -15,11 +15,9 @@
       id: :components,
       text: 'Components',
       path: cluster_components_path(@cluster),
-      dropdown: [
-        { text: 'item1', path: '/' },
-        { text: 'item2', path: '/' },
-        { text: 'item3', path: '/' }
-      ]
+      dropdown: @cluster.component_groups_by_type.map(&:name).map do |t|
+        { text: t, path: cluster_components_path(@cluster, type: t) }
+      end.push(text: 'All', path: cluster_components_path(@cluster))
     }
   ]
 %>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,6 +1,7 @@
 <%
   tabs = [
     { id: :overview, text: 'Overview', path: cluster_path(@cluster) },
+    { id: :logs, text: 'Logs', path: cluster_logs_path(@cluster) },
     { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
     {
       id: :maintenance,
@@ -15,7 +16,7 @@
     {
       id: :components,
       text: 'Components',
-      path: cluster_components_path(@cluster),
+      path: '', # This path is ignored because of the dropdown
       dropdown: @cluster.component_groups_by_type.map(&:name).map do |t|
         { text: t, path: cluster_components_path(@cluster, type: t) }
       end.push(text: 'All', path: cluster_components_path(@cluster))

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,0 +1,13 @@
+<%
+  tabs = [
+    { text: 'Cases', path: '/placeholder' }
+  ]
+%>
+<div class='card-header'>
+  <ul class="nav nav-tabs">
+    <% tabs.each do |tab| %>
+      <%= render 'partials/nav_link', **tab %>
+    <% end %>
+  </ul>
+</div>
+

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -6,6 +6,11 @@
       text: 'Services',
       path: cluster_services_path(@cluster)
     },
+    {
+      id: :maintenance,
+      text: 'Maintenance',
+      path: cluster_maintenance_windows_path(@cluster)
+    }
   ]
 %>
 <div class='card'>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,13 +1,14 @@
 <%
   tabs = [
-    { text: 'Cases', path: cluster_cases_path(@cluster) }
+    { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) }
   ]
 %>
 <div class='card'>
   <div class='card-header'>
     <ul class="nav nav-tabs">
       <% tabs.each do |tab| %>
-        <%= render 'partials/nav_link', **tab %>
+        <% active = (tab[:id] == activate) %>
+        <%= render 'partials/nav_link', **tab, active: active %>
       <% end %>
     </ul>
   </div>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,13 +1,16 @@
 <%
   tabs = [
-    { text: 'Cases', path: '/placeholder' }
+    { text: 'Cases', path: cluster_cases_path(@cluster) }
   ]
 %>
-<div class='card-header'>
-  <ul class="nav nav-tabs">
-    <% tabs.each do |tab| %>
-      <%= render 'partials/nav_link', **tab %>
-    <% end %>
-  </ul>
+<div class='card'>
+  <div class='card-header'>
+    <ul class="nav nav-tabs">
+      <% tabs.each do |tab| %>
+        <%= render 'partials/nav_link', **tab %>
+      <% end %>
+    </ul>
+  </div>
+  <% # NOTE: Add a yield here for the card body, maybe? %>
 </div>
 

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,15 +1,16 @@
 <%
   tabs = [
+    { id: :overview, text: 'Overview', path: cluster_path(@cluster) },
     { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
-    {
-      id: :services,
-      text: 'Services',
-      path: cluster_services_path(@cluster)
-    },
     {
       id: :maintenance,
       text: 'Maintenance',
       path: cluster_maintenance_windows_path(@cluster)
+    },
+    {
+      id: :services,
+      text: 'Services',
+      path: cluster_services_path(@cluster)
     },
     {
       id: :components,

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -10,6 +10,11 @@
       id: :maintenance,
       text: 'Maintenance',
       path: cluster_maintenance_windows_path(@cluster)
+    },
+    {
+      id: :components,
+      text: 'Components',
+      path: cluster_components_path(@cluster)
     }
   ]
 %>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -14,7 +14,12 @@
     {
       id: :components,
       text: 'Components',
-      path: cluster_components_path(@cluster)
+      path: cluster_components_path(@cluster),
+      dropdown: [
+        { text: 'item1', path: '/' },
+        { text: 'item2', path: '/' },
+        { text: 'item3', path: '/' }
+      ]
     }
   ]
 %>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,6 +1,11 @@
 <%
   tabs = [
-    { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) }
+    { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
+    {
+      id: :services,
+      text: 'Services',
+      path: cluster_services_path(@cluster)
+    },
   ]
 %>
 <div class='card'>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -60,37 +60,6 @@
   </ul>
 </div>
 
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Services' %>
-
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Support type</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% cluster.services.each do |service| %>
-      <tr>
-        <td width='40%'>
-          <%= link_to service.name, service_path(service) %>
-          <%= service.cluster_part_icons %>
-        </td>
-        <td width='30%'><%= service.readable_support_type.capitalize %></td>
-        <td width='10%'>
-          <%= service.start_maintenance_request_link %>
-        </td>
-        <td width='20%'>
-          <%= service.change_support_type_button %>
-        </td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>
-
 <% cluster.component_groups_by_type.each do |type| %>
   <div class='card'>
     <%= render 'partials/card_header_nav', title: type.name.pluralize %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,5 +1,5 @@
 
-<%= render 'clusters/tabs' %>
+<%= render 'clusters/tabs', activate: :placeholder %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav',

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,8 +1,5 @@
 
-<div class='card'>
-  <%= render 'clusters/tabs' %>
-</div>
-<%= render 'cases/cases_table', model: cluster, archive: true %>
+<%= render 'clusters/tabs' %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav',

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -29,20 +29,3 @@
   </ul>
 </div>
 
-<% cluster.component_groups_by_type.each do |type| %>
-  <div class='card'>
-    <%= render 'partials/card_header_nav', title: type.name.pluralize %>
-
-    <div class='card-body'>
-      <% type.component_groups.each do |group| %>
-        <h6 class="card-title">
-          <%= group.decorate.link %>
-        </h6>
-
-        <%= render 'partials/components_table', group: group %>
-
-      <% end %>
-    </div>
-
-  </div>
-<% end %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -18,37 +18,6 @@
 </div>
 
 <div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Maintenance' %>
-
-  <table class="maintenance table table-responsive">
-    <thead>
-      <tr>
-        <th>For</th>
-        <th>Maintenance period</th>
-        <th>Requested</th>
-        <th>Confirmed</th>
-        <th>Associated case</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% cluster.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
-      <tr>
-        <td><%= window.associated_model.links %></td>
-        <td><%= window.scheduled_period %></td>
-        <td><%= window.transition_info(:requested) %></td>
-        <td>
-          <%= window.transition_info(:confirmed) ||
-            render('maintenance_windows/unconfirmed_buttons', window: window) %>
-        </td>
-        <td><%= window.case.ticket_link %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>
-
-<div class='card'>
   <%= render 'partials/card_header_nav', title: 'Documents' %>
 
   <ul class="list-group list-group-flush">

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,5 +1,5 @@
 
-<%= render 'clusters/tabs', activate: :placeholder %>
+<%= render 'clusters/tabs', activate: :overview %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav',

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,4 +1,7 @@
 
+<div class='card'>
+  <%= render 'clusters/tabs' %>
+</div>
 <%= render 'cases/cases_table', model: cluster, archive: true %>
 
 <div class='card'>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -20,7 +20,7 @@
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Maintenance' %>
 
-  <table class="table table-responsive">
+  <table class="maintenance table table-responsive">
     <thead>
       <tr>
         <th>For</th>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -4,15 +4,7 @@
 <div class='card'>
   <%= render 'partials/card_header_nav',
              title: 'Overview',
-             list_items: [
-               cluster.start_maintenance_request_link,
-               link_to(
-                 'Logs',
-                 cluster_logs_path(cluster),
-                 role: 'button',
-                 class: dark_button_classes
-               )
-             ] %>
+             list_items: cluster.start_maintenance_request_link %>
 
   <%= render 'clusters/details', cluster: cluster %>
 </div>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,0 +1,9 @@
+
+<%= render_tab_bar activate: :components %>
+
+<div class='card'>
+  <%= render 'partials/card_header_nav', title: @table_tile %>
+  <div class='card-body'>
+    <%= render 'partials/components_table' %>
+  </div>
+</div>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -4,6 +4,9 @@
 <div class='card'>
   <%= render 'partials/card_header_nav', title: @table_tile %>
   <div class='card-body'>
-    <%= render 'partials/components_table' %>
+    <% @component_groups.each do |group| %>
+      <h6><%= group.decorate.link %></h6>
+      <%= render 'partials/components_table', group: group %>
+    <% end %>
   </div>
 </div>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,3 +1,6 @@
+
+<%= render_tab_bar activate: :logs %>
+
 <% if current_user.admin? %>
   <div class='card'>
     <%= render 'partials/card_header_nav', title: 'Add Log' %>

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,0 +1,36 @@
+
+<%= render_tab_bar activate: :maintenance %>
+
+<div class='card'>
+  <%= render 'partials/card_header_nav', title: 'Maintenance' %>
+
+  <div class='table-responsive'>
+    <table class="maintenance table">
+      <thead>
+        <tr>
+          <th>For</th>
+          <th>Maintenance period</th>
+          <th>Requested</th>
+          <th>Confirmed</th>
+          <th>Associated case</th>
+        </tr>
+      </thead>
+
+      <tbody>
+      <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
+        <tr>
+          <td><%= window.associated_model.links %></td>
+          <td><%= window.scheduled_period %></td>
+          <td><%= window.transition_info(:requested) %></td>
+          <td>
+            <%= window.transition_info(:confirmed) ||
+              render('maintenance_windows/unconfirmed_buttons', window: window) %>
+          </td>
+          <td><%= window.case.ticket_link %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+

--- a/app/views/partials/_components_table.html.erb
+++ b/app/views/partials/_components_table.html.erb
@@ -10,7 +10,8 @@
     </thead>
 
     <tbody>
-      <% group.decorate.components.each do |component| %>
+      <% @components ||= group.components %>
+      <% @components.map(&:decorate).each do |component| %>
         <tr>
           <td width='40%'>
             <%= link_to component.name, component_path(component) %>

--- a/app/views/partials/_components_table.html.erb
+++ b/app/views/partials/_components_table.html.erb
@@ -10,8 +10,7 @@
     </thead>
 
     <tbody>
-      <% @components ||= group.components %>
-      <% @components.map(&:decorate).each do |component| %>
+      <% group.decorate.components.each do |component| %>
         <tr>
           <td width='40%'>
             <%= link_to component.name, component_path(component) %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -57,6 +57,7 @@
       <% if current_user.admin? %>
         <ul class="navbar-nav justify-content-end">
           <%= render 'partials/nav_link',
+                     active: false,
                      text: 'Admin Interface',
                      path: rails_admin_path,
                      nav_icon: 'fa-database' %>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,9 +1,22 @@
 <% path ||= model %>
 <% text ||= model.name %>
 <% nav_icon ||= '' %>
-<li class='nav-item'>
+<% dropdown ||= false # Defines the variable %>
+<%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
+  <% class_string = "nav-link".tap do |str|
+    str << ' nav-link--active' if active
+    str << ' dropdown-toggle' if dropdown
+  end %>
+  <% options = { class: class_string }.tap do |opt|
+    opt[:'data-toggle'] = 'dropdown' if dropdown
+  end %>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
-              path,
-              class: "nav-link #{ 'nav-link--active' if active }"
-  %>
+              path, options %>
+  <% if dropdown %>
+    <div class='dropdown-menu'>
+      <% dropdown.each do |dropitem| %>
+        <%= link_to dropitem[:text], dropitem[:path], class: 'dropdown-item' %>
+      <% end %>
+    </div>
+  <% end %>
 </li>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,6 +1,7 @@
 <% path ||= model %>
 <% text ||= model.name %>
 <% active ||= false %>
+<% nav_icon ||= '' %>
 <li class='nav-item'>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
               path,

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,6 +1,5 @@
 <% path ||= model %>
 <% text ||= model.name %>
-<% active ||= false %>
 <% nav_icon ||= '' %>
 <li class='nav-item'>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,7 +1,5 @@
 
-<% if @scope.is_a? Cluster %>
-  <%= render 'clusters/tabs', activate: :services %>
-<% end %>
+<%= render_tab_bar activate: :services %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Services' %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,0 +1,36 @@
+
+<% if @scope.is_a? Cluster %>
+  <%= render 'clusters/tabs', activate: :services %>
+<% end %>
+
+<div class='card'>
+  <%= render 'partials/card_header_nav', title: 'Services' %>
+
+  <table class="table table-responsive">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Support type</th>
+      </tr>
+    </thead>
+
+    <tbody>
+    <% @scope.services.map(&:decorate).each do |service| %>
+      <tr>
+        <td width='40%'>
+          <%= link_to service.name, service_path(service) %>
+          <%= service.cluster_part_icons %>
+        </td>
+        <td width='30%'><%= service.readable_support_type.capitalize %></td>
+        <td width='10%'>
+          <%= service.start_maintenance_request_link %>
+        </td>
+        <td width='20%'>
+          <%= service.change_support_type_button %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
     end
 
     resources :clusters, only: :show do
-      resources :cases, only: :new
+      resources :cases, only: [:index, :new]
       resources :consultancy, only: :new
       logs.call
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
       resources :cases, only: [:index, :new]
       resources :services, only: :index
       resources :consultancy, only: :new
+      resources :maintenance_windows, path: 'maintenance', only: :index
       logs.call
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
       resources :services, only: :index
       resources :consultancy, only: :new
       resources :maintenance_windows, path: 'maintenance', only: :index
+      resources :components, only: :index
       logs.call
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
 
     resources :clusters, only: :show do
       resources :cases, only: [:index, :new]
+      resources :services, only: :index
       resources :consultancy, only: :new
       logs.call
     end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -155,7 +155,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(window).to be_confirmed
       expect(window.confirmed_by).to eq(user)
       expect(page).not_to have_button(button_text)
-      expect(page.all('table')[1]).to have_text(user_name)
+      expect(page.first('table.maintenance')).to have_text(user_name)
       expect(find('.alert')).to have_text(/maintenance confirmed/)
     end
 

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'can cancel requested maintenance' do
       window = create(:requested_maintenance_window, cluster: cluster)
 
-      visit cluster_path(cluster, as: user)
+      visit cluster_maintenance_windows_path(cluster, as: user)
       button_text = 'Cancel'
       click_button(button_text)
 
@@ -147,16 +147,18 @@ RSpec.feature "Maintenance windows", type: :feature do
         case: support_case
       )
 
-      visit cluster_path(component.cluster, as: user)
+      visit cluster_maintenance_windows_path(component.cluster, as: user)
       button_text = "Unconfirmed"
       click_button(button_text)
+      expect(find('.alert')).to have_text(/maintenance confirmed/)
 
       window.reload
       expect(window).to be_confirmed
       expect(window.confirmed_by).to eq(user)
+
+      visit cluster_maintenance_windows_path(component.cluster, as: user)
       expect(page).not_to have_button(button_text)
       expect(page.first('table.maintenance')).to have_text(user_name)
-      expect(find('.alert')).to have_text(/maintenance confirmed/)
     end
 
     it 'can reject requested maintenance' do
@@ -166,7 +168,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         case: support_case
       )
 
-      visit cluster_path(cluster, as: user)
+      visit cluster_maintenance_windows_path(cluster, as: user)
       button_text = 'Reject'
 
       click_button(button_text)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -38,4 +38,35 @@ RSpec.describe ApplicationHelper do
       expect(boolean_symbol(false)).to eq(raw('&cross;'))
     end
   end
+
+  describe '#render_tab_bar' do
+    subject { render_tab_bar }
+
+    # It has to return a string. Returning nil breaks the render
+    def expect_render_tabs(template)
+      expect(helper).to \
+        receive(:render).with(template, instance_of(Hash))
+                        .once.and_return('')
+    end
+
+    context 'without a scope set' do
+      before :each { @scope = nil }
+
+      it 'nothing is rendered' do
+        expect(helper).not_to receive(:render)
+        subject
+      end
+    end
+
+    context 'within a cluster scope' do
+      let :cluster { create(:cluster) }
+      before :each { @scope = cluster }
+
+      it 'renders the cluster nav bar' do
+        expect_render_tabs('clusters/tabs')
+        subject
+      end
+    end
+  end
 end
+


### PR DESCRIPTION
Previously the cluster page was very long making it hard to use. This PR splits it up into separate tabs to reduce its length. Each tab is a different page and thus it also breaks up `db` requests so they don't need to be done in advance.

The general design pattern is a new `index` route has been added to the models. The index pages then use the `scope` to determine what needs to be rendered. A helper method has been added which renders the tab bar on these index pages (see https://github.com/alces-software/alces-flight-center/commit/002b1877a29523446ea40b70755c70cab3b01c8c).

The components are a bit different from the other tabs. To prevent the tab bar getting to long, a dropdown list is used for the components. This allows the component group types to be listed together. They all use the same controller with a special `type` parameter to differentiate them (see https://github.com/alces-software/alces-flight-center/commit/cb28f910e82ec528c49997c6bed90e606d346243).

This is only the first pass for implementing the tabs. There are still a few `UI` elements that need polishing. Also a few of the partials could probably be merged into the `index` templates.

To prevent this PR getting to much longer, these additional changes will be implemented in the next PR along with any recommendations you may have.