### PR TITLE
Improve the `UI` to utilise the tabs

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -3,12 +3,28 @@ class ComponentsController < ApplicationController
 
   def index
     @title = 'Components'
-    @components = @scope.components
     @table_tile = 'All Components' # Consider removing
+    @component_groups = component_groups_from_type
   end
 
   def show
     @title = "#{@component.name} Management Dashboard"
     @subtitle = @component.component_type.name
+  end
+
+  private
+
+  def component_groups_from_type
+    if type_param.blank?
+      @scope.component_groups
+    else
+      @scope.component_groups_by_type.find do |group_type|
+        group_type.name == type_param[:type]
+      end.component_groups
+    end
+  end
+
+  def type_param
+    params.permit(:type)
   end
 end

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -1,6 +1,12 @@
 class ComponentsController < ApplicationController
   decorates_assigned :component
 
+  def index
+    @title = 'Components'
+    @components = @scope.components
+    @table_tile = 'All Components' # Consider removing
+  end
+
   def show
     @title = "#{@component.name} Management Dashboard"
     @subtitle = @component.component_type.name

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,4 +1,8 @@
 class MaintenanceWindowsController < ApplicationController
+  def index
+    @title = 'Maintenance'
+  end
+
   def new
     assign_new_maintenance_title
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,10 @@
 class ServicesController < ApplicationController
   decorates_assigned :service
 
+  def index
+    @title = 'Services'
+  end
+
   def show
     @service = Service.find(params[:id])
     @title = "#{@service.name} Dashboard"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,6 +49,8 @@ module ApplicationHelper
   def render_tab_bar(**render_args, &b)
     if @scope.is_a? Cluster
       render('clusters/tabs', **render_args, &b)
+    else
+      render('partials/card', **render_args, &b)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,11 +47,12 @@ module ApplicationHelper
   end
 
   def render_tab_bar(**render_args, &b)
-    if @scope.is_a? Cluster
-      render('clusters/tabs', **render_args, &b)
-    else
-      render('partials/card', **render_args, &b)
-    end
+    template = if @scope.is_a? Cluster
+                 'clusters/tabs'
+               else
+                 'partials/card'
+               end
+    render(template, **render_args, &b)
   end
 
   def dark_button_classes

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,12 @@ module ApplicationHelper
     @nav_link_procs ||= []
   end
 
+  def render_tab_bar(**render_args)
+    if @scope.is_a? Cluster
+      render('clusters/tabs', **render_args)
+    end
+  end
+
   def dark_button_classes
     ['btn', 'btn-primary', 'btn-block']
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,9 +46,9 @@ module ApplicationHelper
     @nav_link_procs ||= []
   end
 
-  def render_tab_bar(**render_args)
+  def render_tab_bar(**render_args, &b)
     if @scope.is_a? Cluster
-      render('clusters/tabs', **render_args)
+      render('clusters/tabs', **render_args, &b)
     end
   end
 

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -11,7 +11,8 @@
           role: 'button'
         )
       end
-      list.push model.case_form_buttons
+      # TODO: This does not work for cluster objects
+      # list.push model.case_form_buttons
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -15,75 +15,76 @@
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>
-
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Date</th>
-        <th>Creator</th>
-        <th>Subject</th>
-        <th>Association</th>
-        <th>Ticket ID</th>
-        <% if manage_cases_page %>
-          <th>Ticket status</th>
-          <th>Chargeable</th>
-        <% else %>
-          <th>Contact support</th>
-          <th>Archive<%= archive ? '/Restore' : '' %></th>
-        <% end %>
-        <th>Credit charge</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% model.cases.order(created_at: :desc).decorate.each do |c| %>
-      <% if archive || c.open %>
-        <% if c.archived && !manage_cases_page %>
-          <tr
-            class="archived-case-row"
-            title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
-          >
-        <% elsif manage_cases_page && c.requires_credit_charge? %>
-          <tr
-            class="credit-charge-required-case-row"
-            title="This support case is chargeable and has been completed, and needs some credits associated with it."
-          >
-        <% else %>
-          <tr>
-        <% end %>
-          <td
-            title="Support case created on <%= c.created_at.to_formatted_s(:long) %>"
-          >
-            <%= c.created_at.to_formatted_s(:short) %>
-          </td>
-          <td><%= c.user.name %></td>
-          <td><%= link_to c.subject, case_path(c) %></td>
-          <td><%= c.association_info %></td>
-          <td><%= c.rt_ticket_id %></td>
+  <div class='table-responsive'>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Creator</th>
+          <th>Subject</th>
+          <th>Association</th>
+          <th>Ticket ID</th>
           <% if manage_cases_page %>
-            <td>
-              <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>
-            </td>
-            <td><%= c.chargeable_symbol %></td>
+            <th>Ticket status</th>
+            <th>Chargeable</th>
           <% else %>
-            <td><%= render 'cases/email_support_icon', support_case: c %></td>
-            <td><%= render 'cases/archive_icon', support_case: c %></td>
+            <th>Contact support</th>
+            <th>Archive<%= archive ? '/Restore' : '' %></th>
           <% end %>
-          <td>
-            <% if c.credit_charge_allowed? && manage_cases_page %>
-              <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
-              <%= form_for credit_charge, class: 'form-inline' do |f| %>
-                <%= f.hidden_field :case_id %>
-                <%= f.number_field :amount, class: 'form-control', required: true %>
-                <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
-              <% end %>
-            <% else %>
-              <%= c.credit_charge_info %>
-            <% end %>
-          </td>
+          <th>Credit charge</th>
         </tr>
+      </thead>
+
+      <tbody>
+      <% model.cases.order(created_at: :desc).decorate.each do |c| %>
+        <% if archive || c.open %>
+          <% if c.archived && !manage_cases_page %>
+            <tr
+              class="archived-case-row"
+              title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
+            >
+          <% elsif manage_cases_page && c.requires_credit_charge? %>
+            <tr
+              class="credit-charge-required-case-row"
+              title="This support case is chargeable and has been completed, and needs some credits associated with it."
+            >
+          <% else %>
+            <tr>
+          <% end %>
+            <td
+              title="Support case created on <%= c.created_at.to_formatted_s(:long) %>"
+            >
+              <%= c.created_at.to_formatted_s(:short) %>
+            </td>
+            <td><%= c.user.name %></td>
+            <td><%= link_to c.subject, case_path(c) %></td>
+            <td><%= c.association_info %></td>
+            <td><%= c.rt_ticket_id %></td>
+            <% if manage_cases_page %>
+              <td>
+                <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>
+              </td>
+              <td><%= c.chargeable_symbol %></td>
+            <% else %>
+              <td><%= render 'cases/email_support_icon', support_case: c %></td>
+              <td><%= render 'cases/archive_icon', support_case: c %></td>
+            <% end %>
+            <td>
+              <% if c.credit_charge_allowed? && manage_cases_page %>
+                <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
+                <%= form_for credit_charge, class: 'form-inline' do |f| %>
+                  <%= f.hidden_field :case_id %>
+                  <%= f.number_field :amount, class: 'form-control', required: true %>
+                  <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
+                <% end %>
+              <% else %>
+                <%= c.credit_charge_info %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
       <% end %>
-    <% end %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -11,8 +11,7 @@
           role: 'button'
         )
       end
-      # TODO: This does not work for cluster objects
-      # list.push model.case_form_buttons
+      list.push model.decorate.case_form_buttons
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,6 +1,4 @@
 
-<% if @scope.is_a? Cluster %>
-  <%= render 'clusters/tabs', activate: :cases %>
-<% end %>
-
+<%= render_tab_bar activate: :cases %>
 <%= render 'cases_table', model: @scope, archive: true %>
+

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,2 +1,6 @@
 
-<%= render 'cases_table', model: site, archive: true %>
+<% if @scope.is_a? Cluster %>
+    <%= render 'clusters/tabs' %>
+<% end %>
+
+<%= render 'cases_table', model: @scope, archive: true %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,6 +1,6 @@
 
 <% if @scope.is_a? Cluster %>
-    <%= render 'clusters/tabs' %>
+  <%= render 'clusters/tabs', activate: :cases %>
 <% end %>
 
 <%= render 'cases_table', model: @scope, archive: true %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -3,50 +3,52 @@
   <%= render 'partials/card_header_nav',
     title: 'Overview'
   %>
-  <table class="table table-responsive">
-    <tr style="width: 100%;">
-      <th>Date</th>
-      <td><%= @case.created_at.to_formatted_s(:long) %></td>
-    </tr>
-    <tr>
-      <th>Creator</th>
-      <td><%= @case.user.name %></td>
-    </tr>
-    <tr>
-      <th>Association</th>
-      <td><%= @case.association_info %></td>
-    </tr>
-    <tr>
-      <th>Ticket ID</th>
-      <td><%= @case.rt_ticket_id %></td>
-    </tr>
-    <tr>
-      <th>Category</th>
-      <td><%= @case.category&.name || 'None' %></td>
-    </tr>
-    <tr>
-      <th>Issue</th>
-      <td><%= @case.issue.name %></td>
-    </tr>
-    <tr>
-      <th>Chargeable</th>
-      <td><%= @case.chargeable_symbol %></td>
-    </tr>
-    <tr>
-      <th>Credit charge</th>
-      <td><%= @case.credit_charge_info %></td>
-    </tr>
-    <tr>
-      <th>Archived</th>
-      <td><%= boolean_symbol(@case.archived) %></td>
-    </tr>
-    <tr>
-      <th>Subject</th>
-      <td><%= @case.subject %></td>
-    </tr>
-    <tr>
-      <th>Details</th>
-      <td><%= simple_format(@case.details) %></td>
-    </tr>
-  </table>
+  <div class='table-responsive'>
+    <table class="table">
+      <tr style="width: 100%;">
+        <th>Date</th>
+        <td><%= @case.created_at.to_formatted_s(:long) %></td>
+      </tr>
+      <tr>
+        <th>Creator</th>
+        <td><%= @case.user.name %></td>
+      </tr>
+      <tr>
+        <th>Association</th>
+        <td><%= @case.association_info %></td>
+      </tr>
+      <tr>
+        <th>Ticket ID</th>
+        <td><%= @case.rt_ticket_id %></td>
+      </tr>
+      <tr>
+        <th>Category</th>
+        <td><%= @case.category&.name || 'None' %></td>
+      </tr>
+      <tr>
+        <th>Issue</th>
+        <td><%= @case.issue.name %></td>
+      </tr>
+      <tr>
+        <th>Chargeable</th>
+        <td><%= @case.chargeable_symbol %></td>
+      </tr>
+      <tr>
+        <th>Credit charge</th>
+        <td><%= @case.credit_charge_info %></td>
+      </tr>
+      <tr>
+        <th>Archived</th>
+        <td><%= boolean_symbol(@case.archived) %></td>
+      </tr>
+      <tr>
+        <th>Subject</th>
+        <td><%= @case.subject %></td>
+      </tr>
+      <tr>
+        <th>Details</th>
+        <td><%= simple_format(@case.details) %></td>
+      </tr>
+    </table>
+  </div>
 </div>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,17 +1,15 @@
 <%
   tabs = [
-    { id: :overview, text: 'Overview', path: cluster_path(@cluster) },
-    { id: :logs, text: 'Logs', path: cluster_logs_path(@cluster) },
-    { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
-
+    { id: :overview, path: cluster_path(@cluster) },
+    { id: :logs, path: cluster_logs_path(@cluster) },
+    { id: :cases, path: cluster_cases_path(@cluster) },
     {
       id: :maintenance,
-      text: 'Maintenance',
       path: cluster_maintenance_windows_path(@cluster),
       admin_dropdown: [
         {
-          text: 'Existing', path:
-          cluster_maintenance_windows_path(@cluster)
+          text: 'Existing',
+          path: cluster_maintenance_windows_path(@cluster)
         },{
           text: 'Request',
           path: new_cluster_maintenance_window_path(@cluster)
@@ -19,14 +17,10 @@
       ]
     },
     {
-      id: :services,
-      text: 'Services',
-      path: cluster_services_path(@cluster)
+      id: :services, path: cluster_services_path(@cluster)
     },
     {
-      id: :components,
-      text: 'Components',
-      path: '', # This path is ignored because of the dropdown
+      id: :components, path: '', # Path is ignored b/c dropdown
       dropdown: @cluster.component_groups_by_type.map(&:name).map do |t|
         { text: t, path: cluster_components_path(@cluster, type: t) }
       end.push(text: 'All', path: cluster_components_path(@cluster))
@@ -38,6 +32,7 @@
     <ul class="nav nav-tabs nav-justified">
       <% tabs.each do |tab| %>
         <% active = (tab[:id] == activate) %>
+        <% tab[:text] = tab[:id].to_s.capitalize unless tab[:text] %>
         <%= render 'partials/nav_link', **tab, active: active, classes: 'px-3' %>
       <% end %>
     </ul>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -15,11 +15,9 @@
       id: :components,
       text: 'Components',
       path: cluster_components_path(@cluster),
-      dropdown: [
-        { text: 'item1', path: '/' },
-        { text: 'item2', path: '/' },
-        { text: 'item3', path: '/' }
-      ]
+      dropdown: @cluster.component_groups_by_type.map(&:name).map do |t|
+        { text: t, path: cluster_components_path(@cluster, type: t) }
+      end.push(text: 'All', path: cluster_components_path(@cluster))
     }
   ]
 %>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,6 +1,7 @@
 <%
   tabs = [
     { id: :overview, text: 'Overview', path: cluster_path(@cluster) },
+    { id: :logs, text: 'Logs', path: cluster_logs_path(@cluster) },
     { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
     {
       id: :maintenance,
@@ -15,7 +16,7 @@
     {
       id: :components,
       text: 'Components',
-      path: cluster_components_path(@cluster),
+      path: '', # This path is ignored because of the dropdown
       dropdown: @cluster.component_groups_by_type.map(&:name).map do |t|
         { text: t, path: cluster_components_path(@cluster, type: t) }
       end.push(text: 'All', path: cluster_components_path(@cluster))

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,0 +1,13 @@
+<%
+  tabs = [
+    { text: 'Cases', path: '/placeholder' }
+  ]
+%>
+<div class='card-header'>
+  <ul class="nav nav-tabs">
+    <% tabs.each do |tab| %>
+      <%= render 'partials/nav_link', **tab %>
+    <% end %>
+  </ul>
+</div>
+

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -6,6 +6,11 @@
       text: 'Services',
       path: cluster_services_path(@cluster)
     },
+    {
+      id: :maintenance,
+      text: 'Maintenance',
+      path: cluster_maintenance_windows_path(@cluster)
+    }
   ]
 %>
 <div class='card'>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -44,6 +44,6 @@
       <% end %>
     </ul>
   </div>
-  <% # NOTE: Add a yield here for the card body, maybe? %>
+  <%= yield if block_given? %>
 </div>
 

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -6,18 +6,18 @@
     {
       id: :maintenance,
       text: 'Maintenance',
-      path: '', # Dropdown menu
-      dropdown: [
-        {
-          text: 'Existing',
-          path: cluster_maintenance_windows_path(@cluster)
-        },
-        {
-          text: 'Request',
-          path: new_cluster_maintenance_window_path(@cluster)
-        }
-      ]
-    },
+      path: cluster_maintenance_windows_path(@cluster)
+    }.tap do |hash|
+      if current_user.admin?
+        hash[:dropdown] = [
+          { text: 'Existing', path: hash[:path] },
+          {
+            text: 'Request',
+            path: new_cluster_maintenance_window_path(@cluster)
+          }
+        ]
+      end
+    end,
     {
       id: :services,
       text: 'Services',

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,13 +1,14 @@
 <%
   tabs = [
-    { text: 'Cases', path: cluster_cases_path(@cluster) }
+    { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) }
   ]
 %>
 <div class='card'>
   <div class='card-header'>
     <ul class="nav nav-tabs">
       <% tabs.each do |tab| %>
-        <%= render 'partials/nav_link', **tab %>
+        <% active = (tab[:id] == activate) %>
+        <%= render 'partials/nav_link', **tab, active: active %>
       <% end %>
     </ul>
   </div>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,13 +1,16 @@
 <%
   tabs = [
-    { text: 'Cases', path: '/placeholder' }
+    { text: 'Cases', path: cluster_cases_path(@cluster) }
   ]
 %>
-<div class='card-header'>
-  <ul class="nav nav-tabs">
-    <% tabs.each do |tab| %>
-      <%= render 'partials/nav_link', **tab %>
-    <% end %>
-  </ul>
+<div class='card'>
+  <div class='card-header'>
+    <ul class="nav nav-tabs">
+      <% tabs.each do |tab| %>
+        <%= render 'partials/nav_link', **tab %>
+      <% end %>
+    </ul>
+  </div>
+  <% # NOTE: Add a yield here for the card body, maybe? %>
 </div>
 

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -3,6 +3,7 @@
     { id: :overview, text: 'Overview', path: cluster_path(@cluster) },
     { id: :logs, text: 'Logs', path: cluster_logs_path(@cluster) },
     { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
+
     {
       id: :maintenance,
       text: 'Maintenance',
@@ -18,6 +19,7 @@
         ]
       end
     end,
+
     {
       id: :services,
       text: 'Services',

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,15 +1,16 @@
 <%
   tabs = [
+    { id: :overview, text: 'Overview', path: cluster_path(@cluster) },
     { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
-    {
-      id: :services,
-      text: 'Services',
-      path: cluster_services_path(@cluster)
-    },
     {
       id: :maintenance,
       text: 'Maintenance',
       path: cluster_maintenance_windows_path(@cluster)
+    },
+    {
+      id: :services,
+      text: 'Services',
+      path: cluster_services_path(@cluster)
     },
     {
       id: :components,

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -6,7 +6,17 @@
     {
       id: :maintenance,
       text: 'Maintenance',
-      path: cluster_maintenance_windows_path(@cluster)
+      path: '', # Dropdown menu
+      dropdown: [
+        {
+          text: 'Existing',
+          path: cluster_maintenance_windows_path(@cluster)
+        },
+        {
+          text: 'Request',
+          path: new_cluster_maintenance_window_path(@cluster)
+        }
+      ]
     },
     {
       id: :services,

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -10,6 +10,11 @@
       id: :maintenance,
       text: 'Maintenance',
       path: cluster_maintenance_windows_path(@cluster)
+    },
+    {
+      id: :components,
+      text: 'Components',
+      path: cluster_components_path(@cluster)
     }
   ]
 %>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -14,7 +14,12 @@
     {
       id: :components,
       text: 'Components',
-      path: cluster_components_path(@cluster)
+      path: cluster_components_path(@cluster),
+      dropdown: [
+        { text: 'item1', path: '/' },
+        { text: 'item2', path: '/' },
+        { text: 'item3', path: '/' }
+      ]
     }
   ]
 %>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -7,19 +7,17 @@
     {
       id: :maintenance,
       text: 'Maintenance',
-      path: cluster_maintenance_windows_path(@cluster)
-    }.tap do |hash|
-      if current_user.admin?
-        hash[:dropdown] = [
-          { text: 'Existing', path: hash[:path] },
-          {
-            text: 'Request',
-            path: new_cluster_maintenance_window_path(@cluster)
-          }
-        ]
-      end
-    end,
-
+      path: cluster_maintenance_windows_path(@cluster),
+      admin_dropdown: [
+        {
+          text: 'Existing', path:
+          cluster_maintenance_windows_path(@cluster)
+        },{
+          text: 'Request',
+          path: new_cluster_maintenance_window_path(@cluster)
+        }
+      ]
+    },
     {
       id: :services,
       text: 'Services',

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -35,10 +35,10 @@
 %>
 <div class='card'>
   <div class='card-header'>
-    <ul class="nav nav-tabs">
+    <ul class="nav nav-tabs nav-justified">
       <% tabs.each do |tab| %>
         <% active = (tab[:id] == activate) %>
-        <%= render 'partials/nav_link', **tab, active: active %>
+        <%= render 'partials/nav_link', **tab, active: active, classes: 'px-3' %>
       <% end %>
     </ul>
   </div>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,6 +1,11 @@
 <%
   tabs = [
-    { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) }
+    { id: :cases, text: 'Cases', path: cluster_cases_path(@cluster) },
+    {
+      id: :services,
+      text: 'Services',
+      path: cluster_services_path(@cluster)
+    },
   ]
 %>
 <div class='card'>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -60,37 +60,6 @@
   </ul>
 </div>
 
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Services' %>
-
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Support type</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% cluster.services.each do |service| %>
-      <tr>
-        <td width='40%'>
-          <%= link_to service.name, service_path(service) %>
-          <%= service.cluster_part_icons %>
-        </td>
-        <td width='30%'><%= service.readable_support_type.capitalize %></td>
-        <td width='10%'>
-          <%= service.start_maintenance_request_link %>
-        </td>
-        <td width='20%'>
-          <%= service.change_support_type_button %>
-        </td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>
-
 <% cluster.component_groups_by_type.each do |type| %>
   <div class='card'>
     <%= render 'partials/card_header_nav', title: type.name.pluralize %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,13 +1,7 @@
 
-<%= render 'clusters/tabs', activate: :overview %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav',
-             title: 'Overview',
-             list_items: cluster.start_maintenance_request_link %>
-
+<%= render 'clusters/tabs', activate: :overview do %>
   <%= render 'clusters/details', cluster: cluster %>
-</div>
+<% end %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Documents' %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,5 +1,5 @@
 
-<%= render 'clusters/tabs' %>
+<%= render 'clusters/tabs', activate: :placeholder %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav',

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,8 +1,5 @@
 
-<div class='card'>
-  <%= render 'clusters/tabs' %>
-</div>
-<%= render 'cases/cases_table', model: cluster, archive: true %>
+<%= render 'clusters/tabs' %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav',

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -29,20 +29,3 @@
   </ul>
 </div>
 
-<% cluster.component_groups_by_type.each do |type| %>
-  <div class='card'>
-    <%= render 'partials/card_header_nav', title: type.name.pluralize %>
-
-    <div class='card-body'>
-      <% type.component_groups.each do |group| %>
-        <h6 class="card-title">
-          <%= group.decorate.link %>
-        </h6>
-
-        <%= render 'partials/components_table', group: group %>
-
-      <% end %>
-    </div>
-
-  </div>
-<% end %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -18,37 +18,6 @@
 </div>
 
 <div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Maintenance' %>
-
-  <table class="maintenance table table-responsive">
-    <thead>
-      <tr>
-        <th>For</th>
-        <th>Maintenance period</th>
-        <th>Requested</th>
-        <th>Confirmed</th>
-        <th>Associated case</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% cluster.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
-      <tr>
-        <td><%= window.associated_model.links %></td>
-        <td><%= window.scheduled_period %></td>
-        <td><%= window.transition_info(:requested) %></td>
-        <td>
-          <%= window.transition_info(:confirmed) ||
-            render('maintenance_windows/unconfirmed_buttons', window: window) %>
-        </td>
-        <td><%= window.case.ticket_link %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>
-
-<div class='card'>
   <%= render 'partials/card_header_nav', title: 'Documents' %>
 
   <ul class="list-group list-group-flush">

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,5 +1,5 @@
 
-<%= render 'clusters/tabs', activate: :placeholder %>
+<%= render 'clusters/tabs', activate: :overview %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav',

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,4 +1,7 @@
 
+<div class='card'>
+  <%= render 'clusters/tabs' %>
+</div>
 <%= render 'cases/cases_table', model: cluster, archive: true %>
 
 <div class='card'>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -20,7 +20,7 @@
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Maintenance' %>
 
-  <table class="table table-responsive">
+  <table class="maintenance table table-responsive">
     <thead>
       <tr>
         <th>For</th>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -4,15 +4,7 @@
 <div class='card'>
   <%= render 'partials/card_header_nav',
              title: 'Overview',
-             list_items: [
-               cluster.start_maintenance_request_link,
-               link_to(
-                 'Logs',
-                 cluster_logs_path(cluster),
-                 role: 'button',
-                 class: dark_button_classes
-               )
-             ] %>
+             list_items: cluster.start_maintenance_request_link %>
 
   <%= render 'clusters/details', cluster: cluster %>
 </div>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,0 +1,9 @@
+
+<%= render_tab_bar activate: :components %>
+
+<div class='card'>
+  <%= render 'partials/card_header_nav', title: @table_tile %>
+  <div class='card-body'>
+    <%= render 'partials/components_table' %>
+  </div>
+</div>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -4,6 +4,9 @@
 <div class='card'>
   <%= render 'partials/card_header_nav', title: @table_tile %>
   <div class='card-body'>
-    <%= render 'partials/components_table' %>
+    <% @component_groups.each do |group| %>
+      <h6><%= group.decorate.link %></h6>
+      <%= render 'partials/components_table', group: group %>
+    <% end %>
   </div>
 </div>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,12 +1,9 @@
 
-<%= render_tab_bar activate: :components %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: @table_tile %>
+<%= render_tab_bar activate: :components do %>
   <div class='card-body'>
     <% @component_groups.each do |group| %>
       <h6><%= group.decorate.link %></h6>
       <%= render 'partials/components_table', group: group %>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,3 +1,6 @@
+
+<%= render_tab_bar activate: :logs %>
+
 <% if current_user.admin? %>
   <div class='card'>
     <%= render 'partials/card_header_nav', title: 'Add Log' %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,5 +1,28 @@
 
-<%= render_tab_bar activate: :logs %>
+<%= render_tab_bar activate: :logs do %>
+  <div class='table-responsive'>
+    <table class='table'>
+      <thead>
+        <th>Date Created</th>
+        <th>Engineer</th>
+        <th>Details</th>
+        <th>Related Ticket(s)</th>
+      </thead>
+      <% @logs.each do |log| %>
+        <tr>
+          <td><%= log.created_at.to_formatted_s(:long) %></td>
+          <td><%= log.engineer.name %></td>
+          <td><%= log.details %></td>
+          <td>
+            <% log.cases.each do |kase| %>
+              <%= link_to kase.rt_ticket_id, kase %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+<% end %>
 
 <% if current_user.admin? %>
   <div class='card'>
@@ -43,30 +66,4 @@
     </div>
   </div>
 <% end %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Entries' %>
-  <div class='table-responsive'>
-    <table class='table'>
-      <thead>
-        <th>Date Created</th>
-        <th>Engineer</th>
-        <th>Details</th>
-        <th>Related Ticket(s)</th>
-      </thead>
-      <% @logs.each do |log| %>
-        <tr>
-          <td><%= log.created_at.to_formatted_s(:long) %></td>
-          <td><%= log.engineer.name %></td>
-          <td><%= log.details %></td>
-          <td>
-            <% log.cases.map(&:decorate).each do |kase| %>
-              <%= kase.ticket_link %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-  </div>
-</div>
 

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -14,8 +14,8 @@
           <td><%= log.engineer.name %></td>
           <td><%= log.details %></td>
           <td>
-            <% log.cases.each do |kase| %>
-              <%= link_to kase.rt_ticket_id, kase %>
+            <% log.cases.map(&:decorate).each do |kase| %>
+              <%= kase.ticket_link %>
             <% end %>
           </td>
         </tr>

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,9 +1,5 @@
 
-<%= render_tab_bar activate: :maintenance %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Maintenance' %>
-
+<%= render_tab_bar activate: :maintenance do %>
   <div class='table-responsive'>
     <table class="maintenance table">
       <thead>
@@ -32,5 +28,5 @@
       </tbody>
     </table>
   </div>
-</div>
+<% end %>
 

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,0 +1,36 @@
+
+<%= render_tab_bar activate: :maintenance %>
+
+<div class='card'>
+  <%= render 'partials/card_header_nav', title: 'Maintenance' %>
+
+  <div class='table-responsive'>
+    <table class="maintenance table">
+      <thead>
+        <tr>
+          <th>For</th>
+          <th>Maintenance period</th>
+          <th>Requested</th>
+          <th>Confirmed</th>
+          <th>Associated case</th>
+        </tr>
+      </thead>
+
+      <tbody>
+      <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
+        <tr>
+          <td><%= window.associated_model.links %></td>
+          <td><%= window.scheduled_period %></td>
+          <td><%= window.transition_info(:requested) %></td>
+          <td>
+            <%= window.transition_info(:confirmed) ||
+              render('maintenance_windows/unconfirmed_buttons', window: window) %>
+          </td>
+          <td><%= window.case.ticket_link %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -1,33 +1,33 @@
 
-<%= render_tab_bar activate: :maintenance %>
+<%= render_tab_bar activate: :maintenance do %>
+  <%= form_for @maintenance_window,
+    url: request.original_fullpath,
+    html: { novalidate: true, class: 'card-body' } do |f| %>
+    <%= f.hidden_field :cluster_id %>
+    <%= f.hidden_field :component_id %>
+    <%= f.hidden_field :service_id %>
 
-<%= form_for @maintenance_window,
-  url: request.original_fullpath,
-  html: { novalidate: true, class: 'card-body' } do |f| %>
-  <%= f.hidden_field :cluster_id %>
-  <%= f.hidden_field :component_id %>
-  <%= f.hidden_field :service_id %>
+    <div class="form-group">
+      <%= f.label :case_id, 'Case to associate this maintenance with' %>
+      <%= f.collection_select(
+        :case_id,
+        @maintenance_window.associated_cluster.cases.order(created_at: :desc).decorate,
+        :id,
+        :case_select_details,
+        {},
+        {class: ['form-control is-valid']}
+      ) %>
+    </div>
 
-  <div class="form-group">
-    <%= f.label :case_id, 'Case to associate this maintenance with' %>
-    <%= f.collection_select(
-      :case_id,
-      @maintenance_window.associated_cluster.cases.order(created_at: :desc).decorate,
-      :id,
-      :case_select_details,
-      {},
-      {class: ['form-control is-valid']}
-    ) %>
-  </div>
+    <%= render 'partials/date_time_select',
+      model: @maintenance_window,
+      datetime_field_name: 'requested_start'
+    %>
+    <%= render 'partials/date_time_select',
+      model: @maintenance_window,
+      datetime_field_name: 'requested_end'
+    %>
 
-  <%= render 'partials/date_time_select',
-    model: @maintenance_window,
-    datetime_field_name: 'requested_start'
-  %>
-  <%= render 'partials/date_time_select',
-    model: @maintenance_window,
-    datetime_field_name: 'requested_end'
-  %>
-
-  <%= f.submit "Request Maintenance", class: 'btn btn-primary btn-block' %>
+    <%= f.submit "Request Maintenance", class: 'btn btn-primary btn-block' %>
+  <% end %>
 <% end %>

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -1,4 +1,6 @@
 
+<%= render_tab_bar activate: :maintenance %>
+
 <%= form_for @maintenance_window,
   url: request.original_fullpath,
   html: { novalidate: true, } do |f| %>

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_for @maintenance_window,
   url: request.original_fullpath,
-  html: { novalidate: true, } do |f| %>
+  html: { novalidate: true, class: 'card-body' } do |f| %>
   <%= f.hidden_field :cluster_id %>
   <%= f.hidden_field :component_id %>
   <%= f.hidden_field :service_id %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -4,46 +4,48 @@
   <%= render('partials/card_header_nav', title: 'Asset Record') %>
 
   <%= form_tag decorated_model.asset_record_path, method: 'PATCH' do %>
-    <table class="table table-responsive m-0">
-      <thead>
-        <tr>
-          <th>Field</th>
-          <th>Value</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>Component Make</td>
-          <td><% if (model.is_a? ComponentGroup) && (action == 'edit') %>
-            <% makes = ComponentMake.where(component_type: model.component_type) %>
-            <%= collection_select :component_make,
-                                  :id,
-                                  makes,
-                                  :id,
-                                  :name,
-                                  { selected: model.component_make.id } %>
-          <% else %>
-            <%= model.component_make.name %>
-          <% end %></td>
-        </tr>
-        <% model.asset_record.each do |field| %>
-          <tr class="form-group">
-            <td width="50%">
-              <%= label_tag(field.definition.id, field.name) %>
-            </td>
-
-            <td width="50%">
-              <% if action == 'edit' %>
-                <%= field.decorate.form_input(model) %>
-              <% else %>
-                <%= field.value %>
-              <% end %>
-            </td>
+    <div class='table-responsive'>
+      <table class="table m-0">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Value</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>Component Make</td>
+            <td><% if (model.is_a? ComponentGroup) && (action == 'edit') %>
+              <% makes = ComponentMake.where(component_type: model.component_type) %>
+              <%= collection_select :component_make,
+                                    :id,
+                                    makes,
+                                    :id,
+                                    :name,
+                                    { selected: model.component_make.id } %>
+            <% else %>
+              <%= model.component_make.name %>
+            <% end %></td>
+          </tr>
+          <% model.asset_record.each do |field| %>
+            <tr class="form-group">
+              <td width="50%">
+                <%= label_tag(field.definition.id, field.name) %>
+              </td>
+
+              <td width="50%">
+                <% if action == 'edit' %>
+                  <%= field.decorate.form_input(model) %>
+                <% else %>
+                  <%= field.value %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
     <%= render 'partials/edit_submit_button',
                action: action,
                edit_path: decorated_model.edit_asset_record_path %>

--- a/app/views/partials/_card.html.erb
+++ b/app/views/partials/_card.html.erb
@@ -1,0 +1,5 @@
+<% if block_given? %>
+  <div class='card'>
+     <%= yield %>
+  </div>
+<% end %>

--- a/app/views/partials/_components_table.html.erb
+++ b/app/views/partials/_components_table.html.erb
@@ -10,7 +10,8 @@
     </thead>
 
     <tbody>
-      <% group.decorate.components.each do |component| %>
+      <% @components ||= group.components %>
+      <% @components.map(&:decorate).each do |component| %>
         <tr>
           <td width='40%'>
             <%= link_to component.name, component_path(component) %>

--- a/app/views/partials/_components_table.html.erb
+++ b/app/views/partials/_components_table.html.erb
@@ -1,10 +1,12 @@
 
-  <table class="table table-responsive">
+<div class='table-responsive'>
+  <table class="table">
 
     <thead>
       <tr>
         <th>Name</th>
         <th>Support type</th>
+        <th></th>
         <th></th>
       </tr>
     </thead>
@@ -28,5 +30,5 @@
         </tr>
       <% end %>
     </tbody>
-
   </table>
+</div>

--- a/app/views/partials/_components_table.html.erb
+++ b/app/views/partials/_components_table.html.erb
@@ -10,8 +10,7 @@
     </thead>
 
     <tbody>
-      <% @components ||= group.components %>
-      <% @components.map(&:decorate).each do |component| %>
+      <% group.decorate.components.each do |component| %>
         <tr>
           <td width='40%'>
             <%= link_to component.name, component_path(component) %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -57,6 +57,7 @@
       <% if current_user.admin? %>
         <ul class="navbar-nav justify-content-end">
           <%= render 'partials/nav_link',
+                     active: false,
                      text: 'Admin Interface',
                      path: rails_admin_path,
                      nav_icon: 'fa-database' %>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,9 +1,22 @@
 <% path ||= model %>
 <% text ||= model.name %>
 <% nav_icon ||= '' %>
-<li class='nav-item'>
+<% dropdown ||= false # Defines the variable %>
+<%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
+  <% class_string = "nav-link".tap do |str|
+    str << ' nav-link--active' if active
+    str << ' dropdown-toggle' if dropdown
+  end %>
+  <% options = { class: class_string }.tap do |opt|
+    opt[:'data-toggle'] = 'dropdown' if dropdown
+  end %>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
-              path,
-              class: "nav-link #{ 'nav-link--active' if active }"
-  %>
+              path, options %>
+  <% if dropdown %>
+    <div class='dropdown-menu'>
+      <% dropdown.each do |dropitem| %>
+        <%= link_to dropitem[:text], dropitem[:path], class: 'dropdown-item' %>
+      <% end %>
+    </div>
+  <% end %>
 </li>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,6 +1,7 @@
 <% path ||= model %>
 <% text ||= model.name %>
 <% active ||= false %>
+<% nav_icon ||= '' %>
 <li class='nav-item'>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
               path,

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,6 +1,5 @@
 <% path ||= model %>
 <% text ||= model.name %>
-<% active ||= false %>
 <% nav_icon ||= '' %>
 <li class='nav-item'>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -5,10 +5,12 @@
   <% dropdown = admin_dropdown %>
 <% end %>
 <% dropdown ||= false # Defines the variable %>
+<% classes ||= false %>
 <%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
   <% class_string = "nav-link".tap do |str|
     str << ' nav-link--active' if active
     str << ' dropdown-toggle' if dropdown
+    str << ' ' + classes if classes
   end %>
   <% options = { class: class_string }.tap do |opt|
     opt[:'data-toggle'] = 'dropdown' if dropdown

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,6 +1,9 @@
 <% path ||= model %>
 <% text ||= model.name %>
 <% nav_icon ||= '' %>
+<% if current_user.admin? && (admin_dropdown ||= false) %>
+  <% dropdown = admin_dropdown %>
+<% end %>
 <% dropdown ||= false # Defines the variable %>
 <%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
   <% class_string = "nav-link".tap do |str|

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,29 +1,31 @@
 
 <%= render_tab_bar activate: :services do %>
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Support type</th>
-      </tr>
-    </thead>
+  <div class='table-responsive'>
+    <table class='table'>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Support type</th>
+        </tr>
+      </thead>
 
-    <tbody>
-    <% @scope.services.map(&:decorate).each do |service| %>
-      <tr>
-        <td width='40%'>
-          <%= link_to service.name, service_path(service) %>
-          <%= service.cluster_part_icons %>
-        </td>
-        <td width='30%'><%= service.readable_support_type.capitalize %></td>
-        <td width='10%'>
-          <%= service.start_maintenance_request_link %>
-        </td>
-        <td width='20%'>
-          <%= service.change_support_type_button %>
-        </td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
+      <tbody>
+      <% @scope.services.map(&:decorate).each do |service| %>
+        <tr>
+          <td width='40%'>
+            <%= link_to service.name, service_path(service) %>
+            <%= service.cluster_part_icons %>
+          </td>
+          <td width='30%'><%= service.readable_support_type.capitalize %></td>
+          <td width='10%'>
+            <%= service.start_maintenance_request_link %>
+          </td>
+          <td width='20%'>
+            <%= service.change_support_type_button %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,7 +1,5 @@
 
-<% if @scope.is_a? Cluster %>
-  <%= render 'clusters/tabs', activate: :services %>
-<% end %>
+<%= render_tab_bar activate: :services %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Services' %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,9 +1,5 @@
 
-<%= render_tab_bar activate: :services %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Services' %>
-
+<%= render_tab_bar activate: :services do %>
   <table class="table table-responsive">
     <thead>
       <tr>
@@ -30,5 +26,4 @@
     <% end %>
     </tbody>
   </table>
-</div>
-
+<% end %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,0 +1,36 @@
+
+<% if @scope.is_a? Cluster %>
+  <%= render 'clusters/tabs', activate: :services %>
+<% end %>
+
+<div class='card'>
+  <%= render 'partials/card_header_nav', title: 'Services' %>
+
+  <table class="table table-responsive">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Support type</th>
+      </tr>
+    </thead>
+
+    <tbody>
+    <% @scope.services.map(&:decorate).each do |service| %>
+      <tr>
+        <td width='40%'>
+          <%= link_to service.name, service_path(service) %>
+          <%= service.cluster_part_icons %>
+        </td>
+        <td width='30%'><%= service.readable_support_type.capitalize %></td>
+        <td width='10%'>
+          <%= service.start_maintenance_request_link %>
+        </td>
+        <td width='20%'>
+          <%= service.change_support_type_button %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,7 @@ Rails.application.routes.draw do
       resources :cases, only: [:index, :new]
       resources :services, only: :index
       resources :consultancy, only: :new
-      resources :maintenance_windows, path: 'maintenance', only: :index
+      resources :maintenance_windows, only: :index
       resources :components, only: :index
       logs.call
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
     end
 
     resources :clusters, only: :show do
-      resources :cases, only: :new
+      resources :cases, only: [:index, :new]
       resources :consultancy, only: :new
       logs.call
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,12 @@ Rails.application.routes.draw do
   maintenance_form = Proc.new do
     resources :maintenance_windows, only: :new do
       collection do
-        post 'new', action: :create
+        # Do not define route helper (by passing `as: nil`) as otherwise this
+        # will overwrite the `${model}_maintenance_windows_path` helper, as by
+        # default `resources` expects `new` and `index` to use the same route.
+        # However we do not want this, and this route can be accessed using the
+        # `new_${model}_maintenance_windows_path` helper.
+        post 'new', action: :create, as: nil
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
       resources :cases, only: [:index, :new]
       resources :services, only: :index
       resources :consultancy, only: :new
+      resources :maintenance_windows, path: 'maintenance', only: :index
       logs.call
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
       resources :services, only: :index
       resources :consultancy, only: :new
       resources :maintenance_windows, path: 'maintenance', only: :index
+      resources :components, only: :index
       logs.call
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
 
     resources :clusters, only: :show do
       resources :cases, only: [:index, :new]
+      resources :services, only: :index
       resources :consultancy, only: :new
       logs.call
     end

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -1,0 +1,39 @@
+
+require 'rails_helper'
+
+RSpec.describe 'cluster tabs', type: :feature do
+  let :cluster { create(:cluster) }
+
+  let :tabs { page.find('ul.nav-tabs') }
+  let :maintenance_tab { tabs.find('li', text: /Maintenance/) }
+
+  before :each do
+    # Prevent attempting to retrieve documents from S3 when Cluster page
+    # visited.
+    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
+  end
+
+  context 'when visiting the cluster page' do
+    before :each { visit cluster_path(cluster, as: user) }
+
+    context 'with an admin user' do
+      let :user { create(:admin) }
+
+      it 'has a dropdown menu for maintenance tab' do
+        expect(maintenance_tab).to match_css('.dropdown')
+        expect(maintenance_tab.first('div')).to match_css('.dropdown-menu')
+      end
+
+      it 'has a link to the existing maintenance' do
+        path = cluster_maintenance_windows_path(cluster)
+        expect(maintenance_tab).to have_link(href: path)
+      end
+
+      it 'has a link to request maintenance' do
+        path = new_cluster_maintenance_window_path(cluster)
+        expect(maintenance_tab).to have_link(href: path)
+      end
+    end
+  end
+end
+

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'cluster tabs', type: :feature do
       end
     end
 
-    context 'with an contact user' do
+    context 'with a contact user' do
       let :user { create(:contact, site: cluster.site) }
 
       it 'does not have dropdown menu for maintenance tab' do
@@ -54,4 +54,3 @@ RSpec.describe 'cluster tabs', type: :feature do
     end
   end
 end
-

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe 'cluster tabs', type: :feature do
         expect(maintenance_tab).to have_link(href: path)
       end
     end
+
+    context 'with an contact user' do
+      let :user { create(:contact, site: cluster.site) }
+
+      it 'does not have dropdown menu for maintenance tab' do
+        expect(maintenance_tab).not_to match_css('.dropdown')
+      end
+
+      it 'has a link to the existing maintenance' do
+        path = cluster_maintenance_windows_path(cluster)
+        expect(maintenance_tab).to have_link(href: path)
+      end
+
+      it 'does not have a link to request maintenance' do
+        path = new_cluster_maintenance_window_path(cluster)
+        expect(maintenance_tab).not_to have_link(href: path)
+      end
+    end
   end
 end
 

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -155,7 +155,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       expect(window).to be_confirmed
       expect(window.confirmed_by).to eq(user)
       expect(page).not_to have_button(button_text)
-      expect(page.all('table')[1]).to have_text(user_name)
+      expect(page.first('table.maintenance')).to have_text(user_name)
       expect(find('.alert')).to have_text(/maintenance confirmed/)
     end
 

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'can cancel requested maintenance' do
       window = create(:requested_maintenance_window, cluster: cluster)
 
-      visit cluster_path(cluster, as: user)
+      visit cluster_maintenance_windows_path(cluster, as: user)
       button_text = 'Cancel'
       click_button(button_text)
 
@@ -147,16 +147,18 @@ RSpec.feature "Maintenance windows", type: :feature do
         case: support_case
       )
 
-      visit cluster_path(component.cluster, as: user)
+      visit cluster_maintenance_windows_path(component.cluster, as: user)
       button_text = "Unconfirmed"
       click_button(button_text)
+      expect(find('.alert')).to have_text(/maintenance confirmed/)
 
       window.reload
       expect(window).to be_confirmed
       expect(window.confirmed_by).to eq(user)
+
+      visit cluster_maintenance_windows_path(component.cluster, as: user)
       expect(page).not_to have_button(button_text)
       expect(page.first('table.maintenance')).to have_text(user_name)
-      expect(find('.alert')).to have_text(/maintenance confirmed/)
     end
 
     it 'can reject requested maintenance' do
@@ -166,7 +168,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         case: support_case
       )
 
-      visit cluster_path(cluster, as: user)
+      visit cluster_maintenance_windows_path(cluster, as: user)
       button_text = 'Reject'
 
       click_button(button_text)

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature "Maintenance windows", type: :feature do
       new_component_maintenance_window_path(component)
     end
 
-    it 'can navigate to maintenance request form from Cluster dashboard' do
-      visit cluster_path(cluster, as: user)
+    it 'can navigate to maintenance request form from Cluster dashboard Components tab' do
+      visit cluster_components_path(cluster, as: user)
 
       component_maintenance_link = page.find_link(
         href: component_maintenance_path

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ApplicationHelper do
       before :each { @scope = nil }
 
       it 'nothing is rendered' do
-        expect(helper).not_to receive(:render)
+        expect_render_tabs('partials/card')
         subject
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -38,4 +38,35 @@ RSpec.describe ApplicationHelper do
       expect(boolean_symbol(false)).to eq(raw('&cross;'))
     end
   end
+
+  describe '#render_tab_bar' do
+    subject { render_tab_bar }
+
+    # It has to return a string. Returning nil breaks the render
+    def expect_render_tabs(template)
+      expect(helper).to \
+        receive(:render).with(template, instance_of(Hash))
+                        .once.and_return('')
+    end
+
+    context 'without a scope set' do
+      before :each { @scope = nil }
+
+      it 'nothing is rendered' do
+        expect(helper).not_to receive(:render)
+        subject
+      end
+    end
+
+    context 'within a cluster scope' do
+      let :cluster { create(:cluster) }
+      before :each { @scope = cluster }
+
+      it 'renders the cluster nav bar' do
+        expect_render_tabs('clusters/tabs')
+        subject
+      end
+    end
+  end
 end
+


### PR DESCRIPTION
Based on #92, please merge it first.

The major change in this PR is rendering the tab pages content in the card created by the tab bar. This removes the same between the tab bar and the content. For this to work, the content also needed to be rendered on pages without a tab bar. In these cases, it is rendered within a simple `div.card`.

The navigation to the maintenance page has also been updated. Instead of having a link on the overview page, it has been moved into a `maintenance` dropdown menu. As regular uses can not request maintenance, the dropdown needs to be toggled on and off. This is why a `admin_dropdown` key has been added  to the `nav_link` template.

The same could probably be done for adding a new log and the cases table, however other pages still rely on these templates at this point in time.