### PR TITLE
Final new maintenance system tweaks

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -58,13 +58,13 @@ class ApplicationDecorator < Draper::Decorator
   def maintenance_icon(window)
     case window.state.to_sym
     when :requested
-      classNames = 'faded-icon'
+      class_names = 'faded-icon'
       title_base = "Maintenance has been requested for #{name}"
     when :confirmed
-      classNames = 'faded-icon'
+      class_names = 'faded-icon'
       title_base = "Maintenance is scheduled for #{name}"
     when :started
-      classNames = nil
+      class_names = nil
       title_base = "#{name} currently under maintenance"
     else
       return
@@ -72,7 +72,7 @@ class ApplicationDecorator < Draper::Decorator
 
     title = "#{title_base} for ticket #{window.case.rt_ticket_id}"
 
-    h.icon('wrench', inline: true, class: classNames, title: title)
+    h.icon('wrench', inline: true, class: class_names, title: title)
   end
 
   def new_maintenance_window_path

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -56,13 +56,14 @@ class ApplicationDecorator < Draper::Decorator
   end
 
   def maintenance_icon(window)
-    if window.requested?
+    case window.state.to_sym
+    when :requested
       classNames = 'faded-icon'
       title_base = "Maintenance has been requested for #{name}"
-    elsif window.confirmed?
+    when :confirmed
       classNames = 'faded-icon'
       title_base = "Maintenance is scheduled for #{name}"
-    elsif window.in_progress?
+    when :started
       classNames = nil
       title_base = "#{name} currently under maintenance"
     else

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -59,6 +59,9 @@ class ApplicationDecorator < Draper::Decorator
     if window.requested?
       classNames = 'faded-icon'
       title_base = "Maintenance has been requested for #{name}"
+    elsif window.confirmed?
+      classNames = 'faded-icon'
+      title_base = "Maintenance is scheduled for #{name}"
     elsif window.in_progress?
       classNames = nil
       title_base = "#{name} currently under maintenance"

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -19,6 +19,10 @@ class CaseDecorator < ApplicationDecorator
     "http://helpdesk.alces-software.com/rt/Ticket/Display.html?id=#{rt_ticket_id}"
   end
 
+  def ticket_link
+    h.link_to(rt_ticket_id, h.case_path(self))
+  end
+
   def chargeable_symbol
     h.boolean_symbol(chargeable)
   end

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -1,6 +1,7 @@
 class MaintenanceWindowDecorator < ApplicationDecorator
   delegate_all
   decorates_association :associated_model
+  decorates_association :case
 
   def scheduled_period
     h.raw(

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -87,7 +87,8 @@ class Cluster < ApplicationRecord
   def unfinished_related_maintenance_windows
     parts = [self, *components, *services]
     parts
-      .flat_map(&:unfinished_maintenance_windows)
+      .map(&:maintenance_windows)
+      .flat_map(&:unfinished)
       .sort_by(&:created_at)
       .reverse
   end

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -2,7 +2,6 @@ class Cluster < ApplicationRecord
   include AdminConfig::Cluster
   include HasSupportType
   include MarkdownDescription
-  include HasMaintenanceWindows
 
   SUPPORT_TYPES = SupportType::VALUES
 
@@ -11,6 +10,7 @@ class Cluster < ApplicationRecord
   has_many :components, through: :component_groups, dependent: :destroy
   has_many :services, dependent: :destroy
   has_many :cases
+  has_many :maintenance_windows
   has_many :credit_deposits
   has_many :credit_charges, through: :cases
   has_many :logs, dependent: :destroy

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -84,9 +84,12 @@ class Cluster < ApplicationRecord
     end
   end
 
-  def open_related_maintenance_windows
+  def unfinished_related_maintenance_windows
     parts = [self, *components, *services]
-    parts.flat_map(&:open_maintenance_windows).sort_by(&:created_at).reverse
+    parts
+      .flat_map(&:unfinished_maintenance_windows)
+      .sort_by(&:created_at)
+      .reverse
   end
 
   private

--- a/app/models/concerns/cluster_part.rb
+++ b/app/models/concerns/cluster_part.rb
@@ -2,13 +2,13 @@
 module ClusterPart
   extend ActiveSupport::Concern
 
-  include HasMaintenanceWindows
   include HasSupportType
 
   SUPPORT_TYPES = SupportType::VALUES + ['inherit']
 
   included do
     has_many :cases
+    has_many :maintenance_windows
 
     validates :name, presence: true
     validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true

--- a/app/models/concerns/has_maintenance_windows.rb
+++ b/app/models/concerns/has_maintenance_windows.rb
@@ -6,7 +6,7 @@ module HasMaintenanceWindows
     has_many :maintenance_windows
   end
 
-  def open_maintenance_windows
+  def unfinished_maintenance_windows
     maintenance_windows.where.not(state: MaintenanceWindow.finished_states)
   end
 end

--- a/app/models/concerns/has_maintenance_windows.rb
+++ b/app/models/concerns/has_maintenance_windows.rb
@@ -1,8 +1,0 @@
-
-module HasMaintenanceWindows
-  extend ActiveSupport::Concern
-
-  included do
-    has_many :maintenance_windows
-  end
-end

--- a/app/models/concerns/has_maintenance_windows.rb
+++ b/app/models/concerns/has_maintenance_windows.rb
@@ -7,6 +7,6 @@ module HasMaintenanceWindows
   end
 
   def unfinished_maintenance_windows
-    maintenance_windows.where.not(state: MaintenanceWindow.finished_states)
+    maintenance_windows.unfinished
   end
 end

--- a/app/models/concerns/has_maintenance_windows.rb
+++ b/app/models/concerns/has_maintenance_windows.rb
@@ -5,8 +5,4 @@ module HasMaintenanceWindows
   included do
     has_many :maintenance_windows
   end
-
-  def unfinished_maintenance_windows
-    maintenance_windows.unfinished
-  end
 end

--- a/app/models/maintenance_notifier.rb
+++ b/app/models/maintenance_notifier.rb
@@ -12,17 +12,25 @@ MaintenanceNotifier = Struct.new(:window) do
 
   def requested_comment
     <<-EOF
-      Maintenance requested for #{associated_model.name} by
-      #{window.requested_by.name}; to proceed this maintenance must be
-      confirmed on the cluster dashboard: #{cluster_dashboard_url}.
+      Maintenance requested for #{associated_model.name} from
+      #{requested_start} until #{requested_end} by #{window.requested_by.name};
+      to proceed this maintenance must be confirmed on the cluster dashboard:
+      #{cluster_dashboard_url}.
     EOF
+  end
+
+  def requested_start
+    window.requested_start.to_formatted_s(:short)
+  end
+
+  def requested_end
+    window.requested_end.to_formatted_s(:short)
   end
 
   def confirmed_comment
     <<~EOF
-      Maintenance of #{associated_model.name} confirmed by
-      #{window.confirmed_by.name}; this #{associated_model.readable_model_name}
-      is now under maintenance.
+      Request for maintenance of #{associated_model.name} confirmed by
+      #{window.confirmed_by.name}; this maintenance has been scheduled.
     EOF
   end
 
@@ -35,25 +43,31 @@ MaintenanceNotifier = Struct.new(:window) do
 
   def rejected_comment
     <<~EOF
-      Maintenance of #{associated_model.name} rejected by
-      #{window.rejected_by.name}
+      Request for maintenance of #{associated_model.name} rejected by
+      #{window.rejected_by.name}.
     EOF
   end
 
   def expired_comment
     <<~EOF
       Request for maintenance of #{associated_model.name} was not confirmed
-      before requested start; this maintenance has been automatically
+      before requested start date; this maintenance has been automatically
       cancelled.
     EOF
   end
 
   def started_comment
-    "confirmed maintenance of #{associated_model.name} started."
+    <<~EOF
+      Scheduled maintenance of #{associated_model.name} has automatically
+      started.
+    EOF
   end
 
   def ended_comment
-    "#{associated_model.name} is no longer under maintenance."
+    <<~EOF
+      Scheduled maintenance of #{associated_model.name} has automatically
+      ended.
+    EOF
   end
 
   def add_rt_ticket_correspondence(text)

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -56,7 +56,7 @@ class MaintenanceWindow < ApplicationRecord
     end
   end
 
-  alias_method :in_progress?, :confirmed?
+  alias_method :in_progress?, :started?
 
   def associated_model
     component || service || cluster

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -56,8 +56,6 @@ class MaintenanceWindow < ApplicationRecord
     end
   end
 
-  alias_method :in_progress?, :started?
-
   def associated_model
     component || service || cluster
   end

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -82,8 +82,8 @@ class MaintenanceWindow < ApplicationRecord
     query ? query.value_for(self) : super
   end
 
-  def respond_to?(symbol, include_all=false)
-    super || TransitionQuery.parse(symbol)
+  def respond_to_missing?(symbol, include_all=false)
+    TransitionQuery.parse(symbol)
   end
 
   private

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -46,6 +46,8 @@ class MaintenanceWindow < ApplicationRecord
       state_machine.states.keys
     end
 
+    # A maintenance window is 'finished' once it has reached a state which it
+    # cannot transition out of.
     def finished_states
       [
         :cancelled,

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -27,6 +27,7 @@
         <th>Maintenance period</th>
         <th>Requested</th>
         <th>Confirmed</th>
+        <th>Associated case</th>
       </tr>
     </thead>
 
@@ -40,6 +41,7 @@
           <%= window.transition_info(:confirmed) ||
             render('maintenance_windows/unconfirmed_buttons', window: window) %>
         </td>
+        <td><%= window.case.ticket_link %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -31,7 +31,7 @@
     </thead>
 
     <tbody>
-    <% cluster.open_related_maintenance_windows.map(&:decorate).each do |window| %>
+    <% cluster.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
       <tr>
         <td><%= window.associated_model.links %></td>
         <td><%= window.scheduled_period %></td>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -57,8 +57,8 @@
           <td><%= log.engineer.name %></td>
           <td><%= log.details %></td>
           <td>
-            <% log.cases.each do |kase| %>
-              <%= link_to kase.rt_ticket_id, kase %>
+            <% log.cases.map(&:decorate).each do |kase| %>
+              <%= kase.ticket_link %>
             <% end %>
           </td>
         </tr>

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe ApplicationDecorator do
         )
       end
 
-      it 'includes correct icon when has confirmed maintenance window' do
-        window = create(:confirmed_maintenance_window, component: component)
+      it 'includes correct icon when has in progress maintenance window' do
+        window = create(:maintenance_window, state: :started, component: component)
         ticket_id = window.case.rt_ticket_id
 
         expect(subject).to include(
@@ -71,7 +71,7 @@ RSpec.describe ApplicationDecorator do
 
       it 'includes icon for every open maintenance window' do
         create(:requested_maintenance_window, component: component)
-        create(:confirmed_maintenance_window, component: component)
+        create(:maintenance_window, state: :started, component: component)
         create(:ended_maintenance_window, component: component)
 
         expect(subject).to match(/<i .*<i /)

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -78,12 +78,12 @@ RSpec.describe ApplicationDecorator do
         expect(subject).to be_empty
       end
 
-      it 'gives nothing when only has ended maintenance window' do
+      it 'gives nothing when only has finished maintenance window' do
         create(:ended_maintenance_window, component: component)
         expect(subject).to be_empty
       end
 
-      it 'includes icon for every open maintenance window' do
+      it 'includes icon for every unfinished maintenance window' do
         create(:requested_maintenance_window, component: component)
         create(:maintenance_window, state: :started, component: component)
         create(:ended_maintenance_window, component: component)

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe ApplicationDecorator do
         )
       end
 
+      it 'includes correct icon when has confirmed maintenance window' do
+        window = create(:confirmed_maintenance_window, component: component)
+        ticket_id = window.case.rt_ticket_id
+
+        expect(subject).to include(
+          h.icon(
+            'wrench',
+            inline: true,
+            class: 'faded-icon',
+            title: "Maintenance is scheduled for #{component.name} for ticket #{ticket_id}"
+          )
+        )
+      end
+
       it 'includes correct icon when has in progress maintenance window' do
         window = create(:maintenance_window, state: :started, component: component)
         ticket_id = window.case.rt_ticket_id

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -92,4 +92,15 @@ RSpec.describe CaseDecorator do
       expect(support_case.decorate.credit_charge_info).to eq 'Pending'
     end
   end
+
+  describe '#ticket_link' do
+    it 'returns link to Case page with ticket id as text' do
+      kase = create(:case)
+      kase.rt_ticket_id = 12345
+
+      link = kase.decorate.ticket_link
+
+      expect(link).to eq h.link_to('12345', h.case_path(kase))
+    end
+  end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -98,20 +98,15 @@ RSpec.feature "Maintenance windows", type: :feature do
         case: support_case
       )
 
-      expect(Case.request_tracker).to receive(
-        :add_ticket_correspondence
-      ).with(
-        id: window.case.rt_ticket_id,
-        text: /Maintenance.*#{component.name}.*confirmed by #{user_name}.*component.*now under maintenance/
-      )
-
       visit cluster_path(component.cluster, as: user)
       button_text = "Unconfirmed"
       click_button(button_text)
 
+      window.reload
+      expect(window).to be_confirmed
+      expect(window.confirmed_by).to eq(user)
       expect(page).not_to have_button(button_text)
       expect(page.all('table')[1]).to have_text(user_name)
-      expect(window.confirmed_by).to eq(user)
       expect(find('.alert')).to have_text(/maintenance confirmed/)
     end
 

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Cluster, type: :model do
   include_examples 'canonical_name'
   include_examples 'markdown_description'
-  include_examples 'maintenance_windows'
 
   describe '#valid?' do
     context 'when managed cluster' do

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -254,10 +254,10 @@ RSpec.describe Cluster, type: :model do
     it { is_expected.to eq 15 }
   end
 
-  describe '#open_related_maintenance_windows' do
+  describe '#unfinished_related_maintenance_windows' do
     subject { create(:cluster) }
 
-    it 'gives non-ended maintenance windows for Cluster and parts' do
+    it 'gives unfinished maintenance windows for Cluster and parts' do
       create(:requested_maintenance_window, cluster: subject, id: 1)
       create(:confirmed_maintenance_window, cluster: subject, id: 2)
       create(:ended_maintenance_window, cluster: subject, id: 3)
@@ -267,7 +267,7 @@ RSpec.describe Cluster, type: :model do
       create(:confirmed_maintenance_window, component: component, id: 5)
       create(:ended_maintenance_window, component: component, id: 6)
 
-      resulting_window_ids = subject.open_related_maintenance_windows.map(&:id)
+      resulting_window_ids = subject.unfinished_related_maintenance_windows.map(&:id)
 
       expect(resulting_window_ids).to match_array([1, 2, 4, 5])
     end
@@ -276,7 +276,7 @@ RSpec.describe Cluster, type: :model do
       create(:requested_maintenance_window, cluster: subject, id: 1, created_at: 2.days.ago)
       create(:confirmed_maintenance_window, cluster: subject, id: 2, created_at: 1.day.ago)
 
-      resulting_window_ids = subject.open_related_maintenance_windows.map(&:id)
+      resulting_window_ids = subject.unfinished_related_maintenance_windows.map(&:id)
 
       expect(resulting_window_ids).to eq([2, 1])
     end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Component, type: :model do
   include_examples 'inheritable_support_type'
-  include_examples 'maintenance_windows'
 
   describe '#case_form_json' do
     subject do

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -124,8 +124,12 @@ RSpec.describe MaintenanceWindow, type: :model do
 
       it 'has RT ticket comment added when requested' do
         subject.component = create(:component, name: 'some_component')
+        subject.requested_start = 1.days.since
+        subject.requested_end = 2.days.since
         requestor = create(:admin, name: 'some_user')
 
+        expected_start = subject.requested_start.to_formatted_s(:short)
+        expected_end = subject.requested_end.to_formatted_s(:short)
         expected_cluster_url = Rails.application.routes.url_helpers.cluster_url(
           subject.component.cluster
         )
@@ -133,7 +137,7 @@ RSpec.describe MaintenanceWindow, type: :model do
           :add_ticket_correspondence
         ).with(
           id: subject.case.rt_ticket_id,
-          text: /requested.*some_component.*by some_user.*must be confirmed.*#{expected_cluster_url}/
+          text: /requested.*some_component.*#{expected_start}.*#{expected_end}.*by some_user.*must be confirmed.*#{expected_cluster_url}/
         )
 
         subject.request!(requestor)
@@ -162,7 +166,7 @@ RSpec.describe MaintenanceWindow, type: :model do
           :add_ticket_correspondence
         ).with(
           id: subject.case.rt_ticket_id,
-          text: /Maintenance.*some_component.*confirmed by some_user.*component.*now under maintenance/
+          text: /maintenance.*some_component.*confirmed by some_user.*scheduled/
         )
 
         subject.confirm!(user)
@@ -183,7 +187,7 @@ RSpec.describe MaintenanceWindow, type: :model do
           :add_ticket_correspondence
         ).with(
           id: subject.case.rt_ticket_id,
-          text: /Maintenance.*some_component.*rejected by some_user/
+          text: /maintenance.*some_component.*rejected by some_user/
         )
 
         subject.reject!(user)
@@ -206,7 +210,7 @@ RSpec.describe MaintenanceWindow, type: :model do
 
         expect(Case.request_tracker).to receive(:add_ticket_correspondence).with(
           id: subject.case.rt_ticket_id,
-          text: "confirmed maintenance of some_component started."
+          text: /maintenance of some_component .* started/
         )
 
         subject.start!
@@ -229,7 +233,7 @@ RSpec.describe MaintenanceWindow, type: :model do
 
         expect(Case.request_tracker).to receive(:add_ticket_correspondence).with(
           id: subject.case.rt_ticket_id,
-          text: "some_component is no longer under maintenance."
+          text: /maintenance of some_component .* ended/
         )
 
         subject.end!

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -249,8 +249,8 @@ RSpec.describe MaintenanceWindow, type: :model do
   end
 
   describe '#in_progress?' do
-    it 'is currently an alias for `confirmed?`' do
-      window = create(:confirmed_maintenance_window)
+    it 'is currently an alias for `started?`' do
+      window = create(:maintenance_window, state: :started)
 
       expect(window).to be_in_progress
     end

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -248,14 +248,6 @@ RSpec.describe MaintenanceWindow, type: :model do
     end
   end
 
-  describe '#in_progress?' do
-    it 'is currently an alias for `started?`' do
-      window = create(:maintenance_window, state: :started)
-
-      expect(window).to be_in_progress
-    end
-  end
-
   describe '#associated_cluster' do
     it 'gives cluster when associated model is cluster' do
       cluster = create(:cluster)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Service, type: :model do
   include_examples 'inheritable_support_type'
-  include_examples 'maintenance_windows'
 
   describe '#case_form_json' do
     subject do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,7 +81,7 @@ RSpec.configure do |config|
 
   # Print slowest examples and example groups at the end of the spec run, to
   # help surface which specs are running particularly slow.
-  # config.profile_examples = 2
+  config.profile_examples = 2
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/support/shared_examples/maintenance_windows.rb
+++ b/spec/support/shared_examples/maintenance_windows.rb
@@ -3,24 +3,4 @@ RSpec.shared_examples 'maintenance_windows' do
   let :factory do
     SpecUtils.class_factory_identifier(described_class)
   end
-
-  describe '#unfinished_maintenance_windows' do
-    subject { create(factory) }
-
-    it 'returns non-finished associated maintenance windows' do
-      MaintenanceWindow.possible_states.map do |state|
-        create(:maintenance_window, factory => subject, state: state)
-      end
-
-      open_windows = subject.unfinished_maintenance_windows
-      open_window_states = open_windows.map(&:state).map(&:to_sym)
-
-      expect(open_window_states).to match_array([
-        :confirmed,
-        :new,
-        :requested,
-        :started,
-      ])
-    end
-  end
 end

--- a/spec/support/shared_examples/maintenance_windows.rb
+++ b/spec/support/shared_examples/maintenance_windows.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'maintenance_windows' do
     SpecUtils.class_factory_identifier(described_class)
   end
 
-  describe '#open_maintenance_windows' do
+  describe '#unfinished_maintenance_windows' do
     subject { create(factory) }
 
     it 'returns non-finished associated maintenance windows' do
@@ -12,7 +12,7 @@ RSpec.shared_examples 'maintenance_windows' do
         create(:maintenance_window, factory => subject, state: state)
       end
 
-      open_windows = subject.open_maintenance_windows
+      open_windows = subject.unfinished_maintenance_windows
       open_window_states = open_windows.map(&:state).map(&:to_sym)
 
       expect(open_window_states).to match_array([

--- a/spec/support/shared_examples/maintenance_windows.rb
+++ b/spec/support/shared_examples/maintenance_windows.rb
@@ -1,6 +1,0 @@
-
-RSpec.shared_examples 'maintenance_windows' do
-  let :factory do
-    SpecUtils.class_factory_identifier(described_class)
-  end
-end


### PR DESCRIPTION
This PR contains the final fixes and tweaks for the new maintenance system (hopefully, and barring issues brought up from the other outstanding PRs). See commits for full details, but in particular this includes:

- updates to the icons shown for things with upcoming/in progress maintenance to account for the new states and process;

- updates to the comments made on RT tickets for maintenance transitions to be more consistent and accurate;

- various updates to consistently refer to maintenance as finished vs unfinished, rather than sometimes also referring to open vs closed;

- some other refactoring and tweaks for minor related things I've spotted.

Based on #91. This should complete #42 / https://trello.com/c/L2GTfslB/173-maintenance-period-extensions.