### PR TITLE
Fix invalid cases when model support type changed

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -36,6 +36,14 @@ class Case < ApplicationRecord
     presence: true,
     inclusion: {in: TICKET_STATUSES}
 
+  # Only validate Issue relationship on create, as the Issue must be allowed
+  # given the associated model for this Case at the point when the Case is
+  # created, but the associated model's `support_type` (or less commonly the
+  # Issue's) may later change and become incompatible with this Issue, but this
+  # should not invalidate a Case which was allowed at the point when it was
+  # created.
+  validates_with IssueValidator, on: :create
+
   validates_with Validator
 
   after_initialize :assign_cluster_if_necessary

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -44,7 +44,7 @@ class Case < ApplicationRecord
   # created.
   validates_with IssueValidator, on: :create
 
-  validates_with Validator
+  validates_with AssociatedModelValidator
 
   after_initialize :assign_cluster_if_necessary
   after_initialize :generate_token, on: :create

--- a/app/models/case/associated_model_validator.rb
+++ b/app/models/case/associated_model_validator.rb
@@ -1,8 +1,6 @@
 
 class Case
-  class AssociatedModelValidator < ActiveModel::Validator
-    attr_reader :record
-
+  class AssociatedModelValidator < Validator
     def validate(record)
       @record = record
 
@@ -41,14 +39,6 @@ class Case
           record.errors.add(:service, error)
         end
       end
-    end
-
-    def part_required?(part_name)
-      record.issue.send("requires_#{part_name}")
-    end
-
-    def part(part_name)
-      record.send(part_name)
     end
   end
 end

--- a/app/models/case/associated_model_validator.rb
+++ b/app/models/case/associated_model_validator.rb
@@ -1,52 +1,54 @@
 
-class Case::AssociatedModelValidator < ActiveModel::Validator
-  attr_reader :record
+class Case
+  class AssociatedModelValidator < ActiveModel::Validator
+    attr_reader :record
 
-  def validate(record)
-    @record = record
+    def validate(record)
+      @record = record
 
-    Cluster::PART_NAMES.each do |part_name|
-      validate_correct_cluster_part_relationship(part_name)
+      Cluster::PART_NAMES.each do |part_name|
+        validate_correct_cluster_part_relationship(part_name)
+      end
+      validate_service_correct_type
     end
-    validate_service_correct_type
-  end
 
-  private
+    private
 
-  def validate_correct_cluster_part_relationship(part_name)
-    part = part(part_name)
-    error = if part_required?(part_name)
-              if !part
-                "issue requires a #{part_name} but one was not given"
-              elsif part.cluster != record.cluster
-                "given #{part_name} is not part of given cluster"
+    def validate_correct_cluster_part_relationship(part_name)
+      part = part(part_name)
+      error = if part_required?(part_name)
+                if !part
+                  "issue requires a #{part_name} but one was not given"
+                elsif part.cluster != record.cluster
+                  "given #{part_name} is not part of given cluster"
+                end
+              elsif part
+                "issue does not require a #{part_name} but one was given"
               end
-            elsif part
-              "issue does not require a #{part_name} but one was given"
-            end
-    record.errors.add(part_name, error) if error
-  end
+      record.errors.add(part_name, error) if error
+    end
 
-  def validate_service_correct_type
-    if part_required?(:service) && part(:service)
-      required_service_type = record.issue.service_type
-      return unless required_service_type
+    def validate_service_correct_type
+      if part_required?(:service) && part(:service)
+        required_service_type = record.issue.service_type
+        return unless required_service_type
 
-      associated_service_type = part(:service).service_type
+        associated_service_type = part(:service).service_type
 
-      if associated_service_type != required_service_type
-        error = "must be associated with #{required_service_type.name} " \
-          "service but given a #{associated_service_type.name} service"
-        record.errors.add(:service, error)
+        if associated_service_type != required_service_type
+          error = "must be associated with #{required_service_type.name} " \
+            "service but given a #{associated_service_type.name} service"
+          record.errors.add(:service, error)
+        end
       end
     end
-  end
 
-  def part_required?(part_name)
-    record.issue.send("requires_#{part_name}")
-  end
+    def part_required?(part_name)
+      record.issue.send("requires_#{part_name}")
+    end
 
-  def part(part_name)
-    record.send(part_name)
+    def part(part_name)
+      record.send(part_name)
+    end
   end
 end

--- a/app/models/case/associated_model_validator.rb
+++ b/app/models/case/associated_model_validator.rb
@@ -1,5 +1,5 @@
 
-class Case::Validator < ActiveModel::Validator
+class Case::AssociatedModelValidator < ActiveModel::Validator
   attr_reader :record
 
   def validate(record)

--- a/app/models/case/associated_model_validator.rb
+++ b/app/models/case/associated_model_validator.rb
@@ -5,15 +5,13 @@ class Case::AssociatedModelValidator < ActiveModel::Validator
   def validate(record)
     @record = record
 
-    PART_NAMES.each do |part_name|
+    Cluster::PART_NAMES.each do |part_name|
       validate_correct_cluster_part_relationship(part_name)
     end
     validate_service_correct_type
   end
 
   private
-
-  PART_NAMES = [:component, :service].freeze
 
   def validate_correct_cluster_part_relationship(part_name)
     part = part(part_name)

--- a/app/models/case/issue_validator.rb
+++ b/app/models/case/issue_validator.rb
@@ -10,8 +10,6 @@ class Case::IssueValidator < ActiveModel::Validator
 
   private
 
-  PART_NAMES = [:component, :service].freeze
-
   def validate_issue_allowed_for_cluster_or_part
     issue_errors_with_conditions.map do |error, condition|
       record.errors.add(:issue, error) if condition
@@ -32,7 +30,7 @@ class Case::IssueValidator < ActiveModel::Validator
   end
 
   def all_conditional_cluster_part_issue_errors
-    PART_NAMES.map do |part_name|
+    Cluster::PART_NAMES.map do |part_name|
       conditional_cluster_part_issue_errors(part_name)
     end.reduce(:merge)
   end
@@ -81,7 +79,7 @@ class Case::IssueValidator < ActiveModel::Validator
   end
 
   def no_parts_required?
-    !PART_NAMES.map { |part_name| part_required?(part_name) }.any?
+    !Cluster::PART_NAMES.map { |part_name| part_required?(part_name) }.any?
   end
 
   def part_required?(part_name)

--- a/app/models/case/issue_validator.rb
+++ b/app/models/case/issue_validator.rb
@@ -1,8 +1,6 @@
 
 class Case
-  class IssueValidator < ActiveModel::Validator
-    attr_reader :record
-
+  class IssueValidator < Validator
     def validate(record)
       @record = record
 
@@ -81,14 +79,6 @@ class Case
 
     def no_parts_required?
       !Cluster::PART_NAMES.map { |part_name| part_required?(part_name) }.any?
-    end
-
-    def part_required?(part_name)
-      record.issue.send("requires_#{part_name}")
-    end
-
-    def part(part_name)
-      record.send(part_name)
     end
   end
 end

--- a/app/models/case/issue_validator.rb
+++ b/app/models/case/issue_validator.rb
@@ -1,92 +1,94 @@
 
-class Case::IssueValidator < ActiveModel::Validator
-  attr_reader :record
+class Case
+  class IssueValidator < ActiveModel::Validator
+    attr_reader :record
 
-  def validate(record)
-    @record = record
+    def validate(record)
+      @record = record
 
-    validate_issue_allowed_for_cluster_or_part
-  end
-
-  private
-
-  def validate_issue_allowed_for_cluster_or_part
-    issue_errors_with_conditions.map do |error, condition|
-      record.errors.add(:issue, error) if condition
+      validate_issue_allowed_for_cluster_or_part
     end
-  end
 
-  def issue_errors_with_conditions
-    conditional_cluster_issue_errors.merge(
-      all_conditional_cluster_part_issue_errors
-    )
-  end
+    private
 
-  def conditional_cluster_issue_errors
-    {
-      managed_issue_error_for('cluster') => managed_issue_for_advice_cluster?,
-      advice_only_issue_error_for('cluster') => advice_only_issue_for_managed_cluster?,
-    }
-  end
+    def validate_issue_allowed_for_cluster_or_part
+      issue_errors_with_conditions.map do |error, condition|
+        record.errors.add(:issue, error) if condition
+      end
+    end
 
-  def all_conditional_cluster_part_issue_errors
-    Cluster::PART_NAMES.map do |part_name|
-      conditional_cluster_part_issue_errors(part_name)
-    end.reduce(:merge)
-  end
+    def issue_errors_with_conditions
+      conditional_cluster_issue_errors.merge(
+        all_conditional_cluster_part_issue_errors
+      )
+    end
 
-  def conditional_cluster_part_issue_errors(part_name)
-    {
-      managed_issue_error_for(part_name) => managed_issue_for_advice_part?(part_name),
-      advice_only_issue_error_for(part_name) => advice_only_issue_for_managed_part?(part_name),
-    }
-  end
+    def conditional_cluster_issue_errors
+      {
+        managed_issue_error_for('cluster') => managed_issue_for_advice_cluster?,
+        advice_only_issue_error_for('cluster') => advice_only_issue_for_managed_cluster?,
+      }
+    end
 
-  def managed_issue_for_advice_cluster?
-    record.issue.managed? && no_parts_required? && record.cluster&.advice?
-  end
+    def all_conditional_cluster_part_issue_errors
+      Cluster::PART_NAMES.map do |part_name|
+        conditional_cluster_part_issue_errors(part_name)
+      end.reduce(:merge)
+    end
 
-  def managed_issue_for_advice_part?(part_name)
-    record.issue.managed? &&
-      part_required?(part_name) &&
-      part(part_name)&.advice?
-  end
+    def conditional_cluster_part_issue_errors(part_name)
+      {
+        managed_issue_error_for(part_name) => managed_issue_for_advice_part?(part_name),
+        advice_only_issue_error_for(part_name) => advice_only_issue_for_managed_part?(part_name),
+      }
+    end
 
-  def managed_issue_error_for(model_type)
-    <<-EOF.squish
+    def managed_issue_for_advice_cluster?
+      record.issue.managed? && no_parts_required? && record.cluster&.advice?
+    end
+
+    def managed_issue_for_advice_part?(part_name)
+      record.issue.managed? &&
+        part_required?(part_name) &&
+        part(part_name)&.advice?
+    end
+
+    def managed_issue_error_for(model_type)
+      <<-EOF.squish
       is only available for #{SupportType::MANAGED_TEXT}
       #{model_type.to_s.pluralize}, but given #{model_type} is
       #{SupportType::ADVICE_TEXT}
-    EOF
-  end
+      EOF
+    end
 
-  def advice_only_issue_for_managed_cluster?
-    record.issue.advice_only? && record.cluster.managed?
-  end
+    def advice_only_issue_for_managed_cluster?
+      record.issue.advice_only? && record.cluster.managed?
+    end
 
-  def advice_only_issue_for_managed_part?(part_name)
-    record.issue.advice_only? &&
-      part_required?(part_name) &&
-      part(part_name).managed?
-  end
+    def advice_only_issue_for_managed_part?(part_name)
+      record.issue.advice_only? &&
+        part_required?(part_name) &&
+        part(part_name).managed?
+    end
 
-  def advice_only_issue_error_for(model_type)
-    <<-EOF.squish
+    def advice_only_issue_error_for(model_type)
+      <<-EOF.squish
       is only available for #{SupportType::ADVICE_TEXT}
       #{model_type.to_s.pluralize}, but given #{model_type} is
       #{SupportType::MANAGED_TEXT}
-    EOF
-  end
+      EOF
+    end
 
-  def no_parts_required?
-    !Cluster::PART_NAMES.map { |part_name| part_required?(part_name) }.any?
-  end
+    def no_parts_required?
+      !Cluster::PART_NAMES.map { |part_name| part_required?(part_name) }.any?
+    end
 
-  def part_required?(part_name)
-    record.issue.send("requires_#{part_name}")
-  end
+    def part_required?(part_name)
+      record.issue.send("requires_#{part_name}")
+    end
 
-  def part(part_name)
-    record.send(part_name)
+    def part(part_name)
+      record.send(part_name)
+    end
   end
 end

--- a/app/models/case/issue_validator.rb
+++ b/app/models/case/issue_validator.rb
@@ -1,0 +1,94 @@
+
+class Case::IssueValidator < ActiveModel::Validator
+  attr_reader :record
+
+  def validate(record)
+    @record = record
+
+    validate_issue_allowed_for_cluster_or_part
+  end
+
+  private
+
+  PART_NAMES = [:component, :service].freeze
+
+  def validate_issue_allowed_for_cluster_or_part
+    issue_errors_with_conditions.map do |error, condition|
+      record.errors.add(:issue, error) if condition
+    end
+  end
+
+  def issue_errors_with_conditions
+    conditional_cluster_issue_errors.merge(
+      all_conditional_cluster_part_issue_errors
+    )
+  end
+
+  def conditional_cluster_issue_errors
+    {
+      managed_issue_error_for('cluster') => managed_issue_for_advice_cluster?,
+      advice_only_issue_error_for('cluster') => advice_only_issue_for_managed_cluster?,
+    }
+  end
+
+  def all_conditional_cluster_part_issue_errors
+    PART_NAMES.map do |part_name|
+      conditional_cluster_part_issue_errors(part_name)
+    end.reduce(:merge)
+  end
+
+  def conditional_cluster_part_issue_errors(part_name)
+    {
+      managed_issue_error_for(part_name) => managed_issue_for_advice_part?(part_name),
+      advice_only_issue_error_for(part_name) => advice_only_issue_for_managed_part?(part_name),
+    }
+  end
+
+  def managed_issue_for_advice_cluster?
+    record.issue.managed? && no_parts_required? && record.cluster&.advice?
+  end
+
+  def managed_issue_for_advice_part?(part_name)
+    record.issue.managed? &&
+      part_required?(part_name) &&
+      part(part_name)&.advice?
+  end
+
+  def managed_issue_error_for(model_type)
+    <<-EOF.squish
+      is only available for #{SupportType::MANAGED_TEXT}
+      #{model_type.to_s.pluralize}, but given #{model_type} is
+      #{SupportType::ADVICE_TEXT}
+    EOF
+  end
+
+  def advice_only_issue_for_managed_cluster?
+    record.issue.advice_only? && record.cluster.managed?
+  end
+
+  def advice_only_issue_for_managed_part?(part_name)
+    record.issue.advice_only? &&
+      part_required?(part_name) &&
+      part(part_name).managed?
+  end
+
+  def advice_only_issue_error_for(model_type)
+    <<-EOF.squish
+      is only available for #{SupportType::ADVICE_TEXT}
+      #{model_type.to_s.pluralize}, but given #{model_type} is
+      #{SupportType::MANAGED_TEXT}
+    EOF
+  end
+
+  def no_parts_required?
+    !PART_NAMES.map { |part_name| part_required?(part_name) }.any?
+  end
+
+  def part_required?(part_name)
+    record.issue.send("requires_#{part_name}")
+  end
+
+  def part(part_name)
+    record.send(part_name)
+  end
+end

--- a/app/models/case/validator.rb
+++ b/app/models/case/validator.rb
@@ -1,0 +1,16 @@
+
+class Case
+  class Validator < ActiveModel::Validator
+    attr_reader :record
+
+    private
+
+    def part_required?(part_name)
+      record.issue.send("requires_#{part_name}")
+    end
+
+    def part(part_name)
+      record.send(part_name)
+    end
+  end
+end

--- a/app/models/case/validator.rb
+++ b/app/models/case/validator.rb
@@ -8,7 +8,6 @@ class Case::Validator < ActiveModel::Validator
     PART_NAMES.each do |part_name|
       validate_correct_cluster_part_relationship(part_name)
     end
-    validate_issue_allowed_for_cluster_or_part
     validate_service_correct_type
   end
 
@@ -30,12 +29,6 @@ class Case::Validator < ActiveModel::Validator
     record.errors.add(part_name, error) if error
   end
 
-  def validate_issue_allowed_for_cluster_or_part
-    issue_errors_with_conditions.map do |error, condition|
-      record.errors.add(:issue, error) if condition
-    end
-  end
-
   def validate_service_correct_type
     if part_required?(:service) && part(:service)
       required_service_type = record.issue.service_type
@@ -49,72 +42,6 @@ class Case::Validator < ActiveModel::Validator
         record.errors.add(:service, error)
       end
     end
-  end
-
-  def issue_errors_with_conditions
-    conditional_cluster_issue_errors.merge(
-      all_conditional_cluster_part_issue_errors
-    )
-  end
-
-  def conditional_cluster_issue_errors
-    {
-      managed_issue_error_for('cluster') => managed_issue_for_advice_cluster?,
-      advice_only_issue_error_for('cluster') => advice_only_issue_for_managed_cluster?,
-    }
-  end
-
-  def all_conditional_cluster_part_issue_errors
-    PART_NAMES.map do |part_name|
-      conditional_cluster_part_issue_errors(part_name)
-    end.reduce(:merge)
-  end
-
-  def conditional_cluster_part_issue_errors(part_name)
-    {
-      managed_issue_error_for(part_name) => managed_issue_for_advice_part?(part_name),
-      advice_only_issue_error_for(part_name) => advice_only_issue_for_managed_part?(part_name),
-    }
-  end
-
-  def managed_issue_for_advice_cluster?
-    record.issue.managed? && no_parts_required? && record.cluster&.advice?
-  end
-
-  def managed_issue_for_advice_part?(part_name)
-    record.issue.managed? &&
-      part_required?(part_name) &&
-      part(part_name)&.advice?
-  end
-
-  def managed_issue_error_for(model_type)
-    <<-EOF.squish
-      is only available for #{SupportType::MANAGED_TEXT}
-      #{model_type.to_s.pluralize}, but given #{model_type} is
-      #{SupportType::ADVICE_TEXT}
-    EOF
-  end
-
-  def advice_only_issue_for_managed_cluster?
-    record.issue.advice_only? && record.cluster.managed?
-  end
-
-  def advice_only_issue_for_managed_part?(part_name)
-    record.issue.advice_only? &&
-      part_required?(part_name) &&
-      part(part_name).managed?
-  end
-
-  def advice_only_issue_error_for(model_type)
-    <<-EOF.squish
-      is only available for #{SupportType::ADVICE_TEXT}
-      #{model_type.to_s.pluralize}, but given #{model_type} is
-      #{SupportType::MANAGED_TEXT}
-    EOF
-  end
-
-  def no_parts_required?
-    !PART_NAMES.map { |part_name| part_required?(part_name) }.any?
   end
 
   def part_required?(part_name)

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -4,6 +4,7 @@ class Cluster < ApplicationRecord
   include MarkdownDescription
 
   SUPPORT_TYPES = SupportType::VALUES
+  PART_NAMES = [:component, :service].freeze
 
   belongs_to :site
   has_many :component_groups, dependent: :destroy

--- a/spec/models/case/validation_spec.rb
+++ b/spec/models/case/validation_spec.rb
@@ -59,6 +59,21 @@ RSpec.shared_examples 'associated Cluster part validation' do |part_name|
           )
         end
       end
+
+      context "with `managed` #{part_name} which is later switched to `advice`" do
+        let :part { create(managed_part_name, cluster: cluster) }
+
+        before :each do
+          # Create Case which is initially valid.
+          subject.save!
+
+          # Update the part to one which would no longer be compatible with
+          # given issue.
+          part.update!(support_type: :advice)
+        end
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context 'when `advice` issue' do
@@ -94,6 +109,21 @@ RSpec.shared_examples 'associated Cluster part validation' do |part_name|
 
       context "with `advice` #{part_name}" do
         let :part { create(advice_part_name, cluster: cluster) }
+        it { is_expected.to be_valid }
+      end
+
+      context "with `advice` #{part_name} which is later switched to `managed`" do
+        let :part { create(advice_part_name, cluster: cluster) }
+
+        before :each do
+          # Create Case which is initially valid.
+          subject.save!
+
+          # Update the part to one which would no longer be compatible with
+          # given issue.
+          part.update!(support_type: :managed)
+        end
+
         it { is_expected.to be_valid }
       end
     end
@@ -189,6 +219,21 @@ RSpec.describe Case, type: :model do
             )
           end
         end
+
+        context "with `managed` cluster which is later switched to `advice`" do
+          let :cluster { create(:managed_cluster) }
+
+          before :each do
+            # Create Case which is initially valid.
+            subject.save!
+
+            # Update the cluster to one which would no longer be compatible
+            # with given issue.
+            cluster.update!(support_type: :advice)
+          end
+
+          it { is_expected.to be_valid }
+        end
       end
 
       context 'when `advice` issue' do
@@ -224,6 +269,21 @@ RSpec.describe Case, type: :model do
 
         context 'with `advice` cluster' do
           let :cluster { create(:advice_cluster) }
+          it { is_expected.to be_valid }
+        end
+
+        context "with `advice` cluster which is later switched to `managed`" do
+          let :cluster { create(:advice_cluster) }
+
+          before :each do
+            # Create Case which is initially valid.
+            subject.save!
+
+            # Update the cluster to one which would no longer be compatible with
+            # given issue.
+            cluster.update!(support_type: :managed)
+          end
+
           it { is_expected.to be_valid }
         end
       end


### PR DESCRIPTION
This PR fixes an issue where Cases could become invalid if their associated model's `support_type` is later changed; this could then cause an error in the UI in some circumstances. See https://github.com/alces-software/alces-flight-center/commit/ec819c7f74a4610e849e71c4278c40d4b7a060b3 for an explanation of the issue and fix; the other commits here are just refactoring following this change. The diff here is quite large but most of this is just churn due to renaming/splitting some files and changing indentation.

Trello: https://trello.com/c/EFipx2DP/186-fix-error-when-admin-views-all-cases-page-and-some-cases-have-since-become-invalid-due-to-their-associated-models-support-type-c.