### PR TITLE
Track `requested_start` and `requested_end` in MaintenanceWindow transitions

### DIFF
--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -16,7 +16,7 @@ class MaintenanceWindow < ApplicationRecord
   attr_accessor :skip_comments
 
   state_machine initial: :new do
-    audit_trail context: :user
+    audit_trail context: [:user, :requested_start, :requested_end]
 
     state :new
     state :requested

--- a/db/migrate/20180308175322_track_requested_start_and_end_in_transitions.rb
+++ b/db/migrate/20180308175322_track_requested_start_and_end_in_transitions.rb
@@ -1,0 +1,6 @@
+class TrackRequestedStartAndEndInTransitions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :maintenance_window_state_transitions, :requested_start, :datetime
+    add_column :maintenance_window_state_transitions, :requested_end, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180220124843) do
+ActiveRecord::Schema.define(version: 20180308175322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,6 +211,8 @@ ActiveRecord::Schema.define(version: 20180220124843) do
     t.string "from"
     t.string "to", null: false
     t.bigint "user_id"
+    t.datetime "requested_start"
+    t.datetime "requested_end"
     t.index ["maintenance_window_id"], name: "index_mwst_on_mw_id"
     t.index ["user_id"], name: "index_maintenance_window_state_transitions_on_user_id"
   end

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -268,6 +268,30 @@ RSpec.describe MaintenanceWindow, type: :model do
     end
   end
 
+  describe 'values tracked in transitions' do
+    it 'tracks requested_start in transitions' do
+      window = create(:maintenance_window, requested_start: 1.days.from_now)
+
+      new_requested_start = 2.days.from_now.at_midnight
+      window.requested_start = new_requested_start
+      window.request!(create(:admin))
+
+      request_transition = window.transitions.where(event: :request).first
+      expect(request_transition.requested_start).to eq(new_requested_start)
+    end
+
+    it 'tracks requested_end in transitions' do
+      window = create(:maintenance_window, requested_end: 1.days.from_now)
+
+      new_requested_end = 2.days.from_now.at_midnight
+      window.requested_end = new_requested_end
+      window.request!(create(:admin))
+
+      request_transition = window.transitions.where(event: :request).first
+      expect(request_transition.requested_end).to eq(new_requested_end)
+    end
+  end
+
   describe '#method_missing' do
     describe '#*_at' do
       it 'returns time transition occurred for valid state' do


### PR DESCRIPTION
The values for `requested_start` and `requested_end` may soon potentially change for a MaintenanceWindow at different points; in particular a site contact will soon be able to  change these values when they confirm some maintenance. Therefore we now want to track these values as they change in the MaintenanceWindow transition model so that we do not lose this potentially useful information.

One small step towards https://trello.com/c/k81APmbi/191-expired-maintenance-should-still-show-in-table-users-can-always-change-requested-start-and-end-date-when-confirming; based on #99.