### PR TITLE
MaintenanceWindow `requested_start` and `requested_end` validations

### DIFF
--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -122,8 +122,39 @@ class MaintenanceWindow < ApplicationRecord
 
   def validate_requested_period
     return unless requested_start && requested_end
+    validate_start_before_end
+    validate_start_or_end_in_future_if_needed
+  end
+
+  def validate_start_before_end
     if requested_start > requested_end
       errors.add(:requested_end, 'must be after start')
+    end
+  end
+
+  def validate_start_or_end_in_future_if_needed
+    return if maintenance_period_can_be_passed?
+    validate_field_in_future(:requested_start)
+    validate_field_in_future(:requested_end)
+  end
+
+  def maintenance_period_can_be_passed?
+    # In any of these states the maintenance period can be passed, otherwise
+    # existing saved MaintenanceWindows would become invalidated.
+    #
+    # Note in particular that the maintenance period can be passed when
+    # maintenance is only `started` to allow maintenance which has not been
+    # progressed on time to be caught up to the state it should be in (e.g. if
+    # we did not progress MWs for a while for some reason); without this the MW
+    # would be invalid when the `confirmed` -> `started` transition happened,
+    # as it should already be `ended`.
+    [cancelled?, ended?, expired?, rejected?, started?].any?
+  end
+
+  def validate_field_in_future(field_name)
+    field = send(field_name)
+    if field.past?
+      errors.add(field_name, 'cannot be in the past')
     end
   end
 

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -10,6 +10,7 @@ class MaintenanceWindow < ApplicationRecord
   validate :validate_precisely_one_associated_model
   validates_presence_of :requested_start
   validates_presence_of :requested_end
+  validate :validate_requested_period
 
   scope :unfinished, -> { where.not(state: finished_states) }
 
@@ -117,6 +118,13 @@ class MaintenanceWindow < ApplicationRecord
 
   def number_associated_models
     [cluster, component, service].select(&:present?).length
+  end
+
+  def validate_requested_period
+    return unless requested_start && requested_end
+    if requested_start > requested_end
+      errors.add(:requested_end, 'must be after start')
+    end
   end
 
   # Represents a query for the value of a particular property of a

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -72,7 +72,80 @@ RSpec.describe MaintenanceWindow, type: :model do
 
         it 'should be invalid' do
           expect(subject).to be_invalid
-          expect(subject.errors.messages).to include(requested_end: ['must be after start'])
+          expect(subject.errors.messages).to match(requested_end: ['must be after start'])
+        end
+      end
+
+      context 'when requested_start and requested_end in past' do
+        subject do
+          build(
+            :maintenance_window,
+            state: state,
+            requested_start: 2.days.ago,
+            requested_end: 1.days.ago,
+          )
+        end
+
+        valid_states = [:cancelled, :ended, :expired, :rejected, :started]
+
+        valid_states.each do |state|
+          context "when #{state}" do
+            let :state { state }
+
+            it { is_expected.to be_valid }
+          end
+        end
+
+        other_states = MaintenanceWindow.possible_states - valid_states
+
+        other_states.each do |state|
+          context "when #{state}" do
+            let :state { state }
+
+            it 'should be invalid' do
+              expect(subject).to be_invalid
+              expect(subject.errors.messages).to match(
+                requested_start: ['cannot be in the past'],
+                requested_end: ['cannot be in the past'],
+              )
+            end
+          end
+        end
+      end
+
+      context 'when just requested_start in past' do
+        subject do
+          build(
+            :maintenance_window,
+            state: state,
+            requested_start: 1.days.ago,
+            requested_end: 1.days.from_now,
+          )
+        end
+
+        valid_states = [:cancelled, :ended, :expired, :rejected, :started]
+
+        valid_states.each do |state|
+          context "when #{state}" do
+            let :state { state }
+
+            it { is_expected.to be_valid }
+          end
+        end
+
+        other_states = MaintenanceWindow.possible_states - valid_states
+
+        other_states.each do |state|
+          context "when #{state}" do
+            let :state { state }
+
+            it 'should be invalid' do
+              expect(subject).to be_invalid
+              expect(subject.errors.messages).to match(
+                requested_start: ['cannot be in the past'],
+              )
+            end
+          end
         end
       end
     end

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe MaintenanceWindow, type: :model do
     describe 'requested_start and requested_end validations' do
       it { is_expected.to validate_presence_of(:requested_start) }
       it { is_expected.to validate_presence_of(:requested_end) }
+
+      context 'when requested_start after requested_end' do
+        subject do
+          build(
+            :maintenance_window,
+            requested_start: 2.days.from_now,
+            requested_end: 1.days.from_now,
+          )
+        end
+
+        it 'should be invalid' do
+          expect(subject).to be_invalid
+          expect(subject.errors.messages).to include(requested_end: ['must be after start'])
+        end
+      end
     end
   end
 

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -1,60 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe MaintenanceWindow, type: :model do
-  it { is_expected.to validate_presence_of(:requested_start) }
-  it { is_expected.to validate_presence_of(:requested_end) }
-
   describe '#valid?' do
-    subject do
-      build(
-        :maintenance_window,
-        cluster: cluster,
-        component: component,
-        service: service
-      )
-    end
-    let :cluster { nil }
-    let :component { nil }
-    let :service { nil }
+    describe 'associated_model validations' do
+      subject do
+        build(
+          :maintenance_window,
+          cluster: cluster,
+          component: component,
+          service: service
+        )
+      end
+      let :cluster { nil }
+      let :component { nil }
+      let :service { nil }
 
-    context 'when single associated model given' do
-      let :cluster { create(:cluster) }
+      context 'when single associated model given' do
+        let :cluster { create(:cluster) }
 
-      it { is_expected.to be_valid }
-    end
+        it { is_expected.to be_valid }
+      end
 
-    context 'when no associated model given' do
-      it { is_expected.to be_invalid }
-    end
+      context 'when no associated model given' do
+        it { is_expected.to be_invalid }
+      end
 
-    context 'when both Cluster and Component associated' do
-      let :cluster { create(:cluster) }
-      let :component { create(:component) }
+      context 'when both Cluster and Component associated' do
+        let :cluster { create(:cluster) }
+        let :component { create(:component) }
 
-      it { is_expected.to be_invalid }
-    end
+        it { is_expected.to be_invalid }
+      end
 
-    context 'when both Cluster and Service associated' do
-      let :cluster { create(:cluster) }
-      let :service { create(:service) }
+      context 'when both Cluster and Service associated' do
+        let :cluster { create(:cluster) }
+        let :service { create(:service) }
 
-      it { is_expected.to be_invalid }
-    end
+        it { is_expected.to be_invalid }
+      end
 
-    context 'when both Component and Service associated' do
-      let :component { create(:component) }
-      let :service { create(:service) }
+      context 'when both Component and Service associated' do
+        let :component { create(:component) }
+        let :service { create(:service) }
 
-      it { is_expected.to be_invalid }
+        it { is_expected.to be_invalid }
+      end
     end
 
     context 'after invalid transition' do
+      subject { create(:maintenance_window) }
+
       before :each do
-        subject.cluster = create(:cluster)
         subject.request!
       end
 
       it { is_expected.to be_invalid }
+    end
+
+    describe 'requested_start and requested_end validations' do
+      it { is_expected.to validate_presence_of(:requested_start) }
+      it { is_expected.to validate_presence_of(:requested_end) }
     end
   end
 

--- a/spec/services/progress_maintenance_window_spec.rb
+++ b/spec/services/progress_maintenance_window_spec.rb
@@ -41,18 +41,23 @@ RSpec.describe ProgressMaintenanceWindow do
       include_examples 'progresses', from: :requested, to: :expired
     end
 
-    def create_window(state:)
-      create(
+    def build_window(state:)
+      # Use `build` rather than `create` as many of the windows will be invalid
+      # at the time they are created, as they are ready to be transitioned to a
+      # different state and would now be invalid if they were saved in their
+      # current state.
+      build(
         :maintenance_window,
         state: state,
         requested_start: requested_start,
         requested_end: requested_end,
         component: component,
+        id: 123
       )
     end
 
     def test_progression(initial_state:, expected_state:, expected_message:)
-      window = create_window(state: initial_state)
+      window = build_window(state: initial_state)
 
       result = described_class.new(window).progress
 


### PR DESCRIPTION
This PR adds various validations for the MaintenanceWindow `requested_start` and `requested_end` validations, to ensure certain invariants about these properties hold:

- `requested_start` should always be before `requested_end`;

- `requested_start` and `requested_end` cannot be in the past, apart from in certain 'finished' states for a MaintenanceWindow to avoid every saved MaintenanceWindow eventually becoming invalid which would likely cause us future problems.

Adding these validations now became particularly important as non-admin users will soon be able to change these fields, so we want to be more robust when given bad data to make the UX better and avoid saving data which we would consider invalid.

The diff here is a bit large, but there shouldn't be anything too complex here, and some of the changes are just due to existing validation tests changing position without any actual behaviour changes.

Another step towards https://trello.com/c/k81APmbi/191-expired-maintenance-should-still-show-in-table-users-can-always-change-requested-start-and-end-date-when-confirming; based on #100.