### PR TITLE
Fix migrating existing MaintenanceWindows

### DIFF
--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -13,7 +13,7 @@ class MaintenanceWindow < ApplicationRecord
 
   scope :unfinished, -> { where.not(state: finished_states) }
 
-  attr_accessor :skip_comments
+  attr_accessor :legacy_migration_mode
 
   state_machine initial: :new do
     audit_trail context: [:user, :requested_start, :requested_end]
@@ -91,7 +91,7 @@ class MaintenanceWindow < ApplicationRecord
   delegate :site, to: :case
 
   def add_transition_comment
-    unless invalid? || skip_comments
+    unless invalid? || legacy_migration_mode
       maintenance_notifier.add_transition_comment(state)
     end
   end

--- a/app/models/maintenance_window/validator.rb
+++ b/app/models/maintenance_window/validator.rb
@@ -30,7 +30,7 @@ class MaintenanceWindow
     def validate_requested_period
       return unless requested_start && requested_end
       validate_start_before_end
-      validate_start_or_end_in_future_if_needed
+      validate_start_or_end_in_future_if_needed unless record.legacy_migration_mode
     end
 
     def validate_start_before_end

--- a/db/data_migrations/20180223150748_update_existing_maintenance_windows.rb
+++ b/db/data_migrations/20180223150748_update_existing_maintenance_windows.rb
@@ -1,8 +1,7 @@
 class UpdateExistingMaintenanceWindows < ActiveRecord::DataMigration
   def up
     MaintenanceWindow.all.each do |window|
-      # Don't want any comments left on RT tickets as we make changes.
-      window.skip_comments = true
+      window.legacy_migration_mode = true
 
       # Change the state to `new` (from `requested`, what the default was set
       # to when this column was created) so we can simulate the new maintenance

--- a/spec/models/maintenance_window/validation_spec.rb
+++ b/spec/models/maintenance_window/validation_spec.rb
@@ -6,6 +6,8 @@ RSpec.shared_examples 'it validates dates cannot be in the past' do |date_fields
   # invalidated.
   valid_states = [:cancelled, :ended, :expired, :rejected, :started]
 
+  let :legacy_migration_mode { false }
+
   valid_states.each do |state|
     context "when #{state}" do
       let :state { state }
@@ -29,6 +31,19 @@ RSpec.shared_examples 'it validates dates cannot be in the past' do |date_fields
       it 'should be invalid' do
         expect(subject).to be_invalid
         expect(subject.errors.messages).to match(expected_errors)
+      end
+    end
+  end
+
+  context 'when `legacy_migration_mode` flag set on model' do
+    let :legacy_migration_mode { true }
+
+    # Should skip this validation and be valid in every state.
+    MaintenanceWindow.possible_states.each do |state|
+      context "when #{state}" do
+        let :state { state }
+
+        it { is_expected.to be_valid }
       end
     end
   end
@@ -117,6 +132,7 @@ RSpec.describe MaintenanceWindow, type: :model do
             state: state,
             requested_start: 2.days.ago,
             requested_end: 1.days.ago,
+            legacy_migration_mode: legacy_migration_mode,
           )
         end
 
@@ -130,6 +146,7 @@ RSpec.describe MaintenanceWindow, type: :model do
             state: state,
             requested_start: 1.days.ago,
             requested_end: 1.days.from_now,
+            legacy_migration_mode: legacy_migration_mode,
           )
         end
 

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -183,11 +183,11 @@ RSpec.describe MaintenanceWindow, type: :model do
       end
     end
 
-    it 'does not have transition comment added when `skip_comments` flag set on model' do
+    it 'does not have transition comment added when `legacy_migration_mode` flag set on model' do
       # This test tests this behaviour for the started -> ended transition, but
       # any valid transition could be used.
       window = create(:maintenance_window, state: :started)
-      window.skip_comments = true
+      window.legacy_migration_mode = true
 
       expect(Case.request_tracker).not_to receive(:add_ticket_correspondence)
 


### PR DESCRIPTION
This PR fixes how we will migrate our existing production MaintenanceWindows to work, following recent changes to the MaintenanceWindow validations.

Based on #102. 