### PR TITLE
MaintenanceWindow-related test tweaks

### DIFF
--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -52,12 +52,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       end
     end
 
-    context 'when new' do
-      subject { create(:maintenance_window, state: :new) }
-
-      it_behaves_like 'it can be cancelled'
-      it_behaves_like 'it can be expired'
-
+    RSpec.shared_examples 'it can be requested' do
       it 'can be requested' do
         user = create(:user)
         subject.request!(user)
@@ -87,12 +82,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       end
     end
 
-    context 'when requested' do
-      subject { create(:maintenance_window, state: :requested) }
-
-      it_behaves_like 'it can be cancelled'
-      it_behaves_like 'it can be expired'
-
+    RSpec.shared_examples 'it can be confirmed' do
       it 'can be confirmed by user' do
         user = create(:user)
         subject.confirm!(user)
@@ -114,7 +104,9 @@ RSpec.describe MaintenanceWindow, type: :model do
 
         subject.confirm!(user)
       end
+    end
 
+    RSpec.shared_examples 'it can be rejected' do
       it 'can be rejected' do
         user = create(:user)
         subject.reject!(user)
@@ -137,11 +129,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       end
     end
 
-    context 'when confirmed' do
-      subject do
-        create(:maintenance_window, state: :confirmed)
-      end
-
+    RSpec.shared_examples 'it can be started' do
       it 'can be started' do
         subject.start!
 
@@ -160,11 +148,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       end
     end
 
-    context 'when started' do
-      subject do
-        create(:maintenance_window, state: :started)
-      end
-
+    RSpec.shared_examples 'it can be ended' do
       it 'can be ended' do
         subject.end!
 
@@ -181,6 +165,39 @@ RSpec.describe MaintenanceWindow, type: :model do
 
         subject.end!
       end
+    end
+
+    context 'when new' do
+      subject { create(:maintenance_window, state: :new) }
+
+      it_behaves_like 'it can be cancelled'
+      it_behaves_like 'it can be expired'
+      it_behaves_like 'it can be requested'
+    end
+
+    context 'when requested' do
+      subject { create(:maintenance_window, state: :requested) }
+
+      it_behaves_like 'it can be cancelled'
+      it_behaves_like 'it can be expired'
+      it_behaves_like 'it can be confirmed'
+      it_behaves_like 'it can be rejected'
+    end
+
+    context 'when confirmed' do
+      subject do
+        create(:maintenance_window, state: :confirmed)
+      end
+
+      it_behaves_like 'it can be started'
+    end
+
+    context 'when started' do
+      subject do
+        create(:maintenance_window, state: :started)
+      end
+
+      it_behaves_like 'it can be ended'
     end
 
     it 'does not have transition comment added when `legacy_migration_mode` flag set on model' do

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       expect(window.state).to eq 'new'
     end
 
-    RSpec.shared_examples 'can be cancelled' do
+    RSpec.shared_examples 'it can be cancelled' do
       it 'can be cancelled' do
         user = create(:user)
         subject.cancel!(user)
@@ -31,7 +31,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       end
     end
 
-    RSpec.shared_examples 'can be expired' do
+    RSpec.shared_examples 'it can be expired' do
       it 'can be expired' do
         subject.expire!
 
@@ -55,8 +55,8 @@ RSpec.describe MaintenanceWindow, type: :model do
     context 'when new' do
       subject { create(:maintenance_window, state: :new) }
 
-      include_examples 'can be cancelled'
-      include_examples 'can be expired'
+      it_behaves_like 'it can be cancelled'
+      it_behaves_like 'it can be expired'
 
       it 'can be requested' do
         user = create(:user)
@@ -90,8 +90,8 @@ RSpec.describe MaintenanceWindow, type: :model do
     context 'when requested' do
       subject { create(:maintenance_window, state: :requested) }
 
-      include_examples 'can be cancelled'
-      include_examples 'can be expired'
+      it_behaves_like 'it can be cancelled'
+      it_behaves_like 'it can be expired'
 
       it 'can be confirmed by user' do
         user = create(:user)


### PR DESCRIPTION
Nothing major here, just:

- making things clearer/DRYer in `maintenance_window_spec`;

- improving test coverage in `maintenance_window_decorator_spec`.