### PR TITLE
Implement case archiving UI as an index page

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -12,6 +12,7 @@ class CasesController < ApplicationController
              end
 
     current_site.cases.map(&:update_ticket_status!) if current_user.admin?
+    @archive = true
   end
 
   def show

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -5,14 +5,9 @@ class CasesController < ApplicationController
 
   def index
     @site = current_site
-    @title = if current_user.admin?
-               'Manage support cases'
-             else
-               'Support case archive'
-             end
-
+    @title = 'Manage support cases'
+    @archive = archive?
     current_site.cases.map(&:update_ticket_status!) if current_user.admin?
-    @archive = true
   end
 
   def show
@@ -83,6 +78,10 @@ class CasesController < ApplicationController
   end
 
   private
+
+  def archive?
+    params.permit(:archive)[:archive] == 'true'
+  end
 
   def case_params
     params.require(:case).permit(

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -1,8 +1,30 @@
 class ComponentsController < ApplicationController
   decorates_assigned :component
 
+  def index
+    @title = 'Components'
+    @table_tile = 'All Components' # Consider removing
+    @component_groups = component_groups_from_type
+  end
+
   def show
     @title = "#{@component.name} Management Dashboard"
     @subtitle = @component.component_type.name
+  end
+
+  private
+
+  def component_groups_from_type
+    if type_param.blank?
+      @scope.component_groups
+    else
+      @scope.component_groups_by_type.find do |group_type|
+        group_type.name == type_param[:type]
+      end.component_groups
+    end
+  end
+
+  def type_param
+    params.permit(:type)
   end
 end

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,4 +1,8 @@
 class MaintenanceWindowsController < ApplicationController
+  def index
+    @title = 'Maintenance'
+  end
+
   def new
     assign_new_maintenance_title
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,10 @@
 class ServicesController < ApplicationController
   decorates_assigned :service
 
+  def index
+    @title = 'Services'
+  end
+
   def show
     @service = Service.find(params[:id])
     @title = "#{@service.name} Dashboard"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,10 @@ module ApplicationHelper
     @nav_link_procs ||= []
   end
 
+  def icon_span(text, icon = '')
+    raw("<span class='fa #{icon}'></span> ") + text
+  end
+
   def render_tab_bar(**render_args, &b)
     template = if @scope.is_a? Cluster
                  'clusters/tabs'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,15 @@ module ApplicationHelper
     @nav_link_procs ||= []
   end
 
+  def render_tab_bar(**render_args, &b)
+    template = if @scope.is_a? Cluster
+                 'clusters/tabs'
+               else
+                 'partials/card'
+               end
+    render(template, **render_args, &b)
+  end
+
   def dark_button_classes
     ['btn', 'btn-primary', 'btn-block']
   end

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -2,11 +2,16 @@
   <%= render 'partials/card_header_nav',
     list_items: ([].tap do |list|
       unless archive
-        list.push( link_to 'View all',
-          current_user.admin? ? site_cases_path(model) : cases_path,
-          class: ['nav-link', 'btn', 'btn-primary'],
-          role: 'button'
-        )
+        archive_param = { archive: true }
+        path = if current_user.admin?
+                 site_cases_path(model, **archive_param)
+               else
+                 cases_path(**archive_param)
+               end
+        list.push(link_to 'View all',
+                          path,
+                          class: ['nav-link', 'btn', 'btn-primary'],
+                          role: 'button')
       end
       list.push model.decorate.case_form_buttons
     end),

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -1,6 +1,3 @@
-
-<% manage_cases_page = current_user.admin? && archive %>
-
 <div class='card'>
   <%= render 'partials/card_header_nav',
     list_items: ([].tap do |list|
@@ -15,76 +12,8 @@
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>
-  <div class='table-responsive'>
-    <table class="table">
-      <thead>
-        <tr>
-          <th>Date</th>
-          <th>Creator</th>
-          <th>Subject</th>
-          <th>Association</th>
-          <th>Ticket ID</th>
-          <% if manage_cases_page %>
-            <th>Ticket status</th>
-            <th>Chargeable</th>
-          <% else %>
-            <th>Contact support</th>
-            <th>Archive<%= archive ? '/Restore' : '' %></th>
-          <% end %>
-          <th>Credit charge</th>
-        </tr>
-      </thead>
-
-      <tbody>
-      <% model.cases.order(created_at: :desc).decorate.each do |c| %>
-        <% if archive || c.open %>
-          <% if c.archived && !manage_cases_page %>
-            <tr
-              class="archived-case-row"
-              title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
-            >
-          <% elsif manage_cases_page && c.requires_credit_charge? %>
-            <tr
-              class="credit-charge-required-case-row"
-              title="This support case is chargeable and has been completed, and needs some credits associated with it."
-            >
-          <% else %>
-            <tr>
-          <% end %>
-            <td
-              title="Support case created on <%= c.created_at.to_formatted_s(:long) %>"
-            >
-              <%= c.created_at.to_formatted_s(:short) %>
-            </td>
-            <td><%= c.user.name %></td>
-            <td><%= link_to c.subject, case_path(c) %></td>
-            <td><%= c.association_info %></td>
-            <td><%= c.rt_ticket_id %></td>
-            <% if manage_cases_page %>
-              <td>
-                <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>
-              </td>
-              <td><%= c.chargeable_symbol %></td>
-            <% else %>
-              <td><%= render 'cases/email_support_icon', support_case: c %></td>
-              <td><%= render 'cases/archive_icon', support_case: c %></td>
-            <% end %>
-            <td>
-              <% if c.credit_charge_allowed? && manage_cases_page %>
-                <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
-                <%= form_for credit_charge, class: 'form-inline' do |f| %>
-                  <%= f.hidden_field :case_id %>
-                  <%= f.number_field :amount, class: 'form-control', required: true %>
-                  <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
-                <% end %>
-              <% else %>
-                <%= c.credit_charge_info %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      <% end %>
-      </tbody>
-    </table>
-  </div>
+  <% @cases = model.cases %>
+  <% @archive = archive %>
+  <%= render template: 'cases/index' %>
 </div>
+

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -11,79 +11,80 @@
           role: 'button'
         )
       end
-      list.push model.case_form_buttons
+      list.push model.decorate.case_form_buttons
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>
-
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Date</th>
-        <th>Creator</th>
-        <th>Subject</th>
-        <th>Association</th>
-        <th>Ticket ID</th>
-        <% if manage_cases_page %>
-          <th>Ticket status</th>
-          <th>Chargeable</th>
-        <% else %>
-          <th>Contact support</th>
-          <th>Archive<%= archive ? '/Restore' : '' %></th>
-        <% end %>
-        <th>Credit charge</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% model.cases.order(created_at: :desc).decorate.each do |c| %>
-      <% if archive || c.open %>
-        <% if c.archived && !manage_cases_page %>
-          <tr
-            class="archived-case-row"
-            title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
-          >
-        <% elsif manage_cases_page && c.requires_credit_charge? %>
-          <tr
-            class="credit-charge-required-case-row"
-            title="This support case is chargeable and has been completed, and needs some credits associated with it."
-          >
-        <% else %>
-          <tr>
-        <% end %>
-          <td
-            title="Support case created on <%= c.created_at.to_formatted_s(:long) %>"
-          >
-            <%= c.created_at.to_formatted_s(:short) %>
-          </td>
-          <td><%= c.user.name %></td>
-          <td><%= link_to c.subject, case_path(c) %></td>
-          <td><%= c.association_info %></td>
-          <td><%= c.rt_ticket_id %></td>
+  <div class='table-responsive'>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Creator</th>
+          <th>Subject</th>
+          <th>Association</th>
+          <th>Ticket ID</th>
           <% if manage_cases_page %>
-            <td>
-              <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>
-            </td>
-            <td><%= c.chargeable_symbol %></td>
+            <th>Ticket status</th>
+            <th>Chargeable</th>
           <% else %>
-            <td><%= render 'cases/email_support_icon', support_case: c %></td>
-            <td><%= render 'cases/archive_icon', support_case: c %></td>
+            <th>Contact support</th>
+            <th>Archive<%= archive ? '/Restore' : '' %></th>
           <% end %>
-          <td>
-            <% if c.credit_charge_allowed? && manage_cases_page %>
-              <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
-              <%= form_for credit_charge, class: 'form-inline' do |f| %>
-                <%= f.hidden_field :case_id %>
-                <%= f.number_field :amount, class: 'form-control', required: true %>
-                <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
-              <% end %>
-            <% else %>
-              <%= c.credit_charge_info %>
-            <% end %>
-          </td>
+          <th>Credit charge</th>
         </tr>
+      </thead>
+
+      <tbody>
+      <% model.cases.order(created_at: :desc).decorate.each do |c| %>
+        <% if archive || c.open %>
+          <% if c.archived && !manage_cases_page %>
+            <tr
+              class="archived-case-row"
+              title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
+            >
+          <% elsif manage_cases_page && c.requires_credit_charge? %>
+            <tr
+              class="credit-charge-required-case-row"
+              title="This support case is chargeable and has been completed, and needs some credits associated with it."
+            >
+          <% else %>
+            <tr>
+          <% end %>
+            <td
+              title="Support case created on <%= c.created_at.to_formatted_s(:long) %>"
+            >
+              <%= c.created_at.to_formatted_s(:short) %>
+            </td>
+            <td><%= c.user.name %></td>
+            <td><%= link_to c.subject, case_path(c) %></td>
+            <td><%= c.association_info %></td>
+            <td><%= c.rt_ticket_id %></td>
+            <% if manage_cases_page %>
+              <td>
+                <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>
+              </td>
+              <td><%= c.chargeable_symbol %></td>
+            <% else %>
+              <td><%= render 'cases/email_support_icon', support_case: c %></td>
+              <td><%= render 'cases/archive_icon', support_case: c %></td>
+            <% end %>
+            <td>
+              <% if c.credit_charge_allowed? && manage_cases_page %>
+                <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
+                <%= form_for credit_charge, class: 'form-inline' do |f| %>
+                  <%= f.hidden_field :case_id %>
+                  <%= f.number_field :amount, class: 'form-control', required: true %>
+                  <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
+                <% end %>
+              <% else %>
+                <%= c.credit_charge_info %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
       <% end %>
-    <% end %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -13,7 +13,6 @@
                           class: ['nav-link', 'btn', 'btn-primary'],
                           role: 'button')
       end
-      list.push model.decorate.case_form_buttons
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -21,4 +21,3 @@
   <% @archive = archive %>
   <%= render template: 'cases/index' %>
 </div>
-

--- a/app/views/cases/_cases_table.html.erb
+++ b/app/views/cases/_cases_table.html.erb
@@ -13,6 +13,7 @@
                           class: ['nav-link', 'btn', 'btn-primary'],
                           role: 'button')
       end
+      list.push model.decorate.case_form_buttons
     end),
     title: raw("#{archive ? 'All' : 'Open'} support cases &mdash; #{model.name}")
   %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,4 +1,77 @@
+<% manage_cases_page = current_user.admin? && @archive %>
 
-<%= render_tab_bar activate: :cases %>
-<%= render 'cases_table', model: @scope, archive: true %>
+<%= render_tab_bar activate: :cases do %>
+  <div class='table-responsive'>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Creator</th>
+          <th>Subject</th>
+          <th>Association</th>
+          <th>Ticket ID</th>
+          <% if manage_cases_page %>
+            <th>Ticket status</th>
+            <th>Chargeable</th>
+          <% else %>
+            <th>Contact support</th>
+            <th>Archive<%= @archive ? '/Restore' : '' %></th>
+          <% end %>
+          <th>Credit charge</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @scope.cases.order(created_at: :desc).decorate.each do |c| %>
+          <% if @archive || c.open %>
+            <% if c.archived && !manage_cases_page %>
+              <tr
+                class="archived-case-row"
+                title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
+              >
+            <% elsif manage_cases_page && c.requires_credit_charge? %>
+              <tr
+                class="credit-charge-required-case-row"
+                title="This support case is chargeable and has been completed, and needs some credits associated with it."
+              >
+            <% else %>
+              <tr>
+            <% end %>
+              <td
+                title="Support case created on <%= c.created_at.to_formatted_s(:long) %>"
+              >
+                <%= c.created_at.to_formatted_s(:short) %>
+              </td>
+              <td><%= c.user.name %></td>
+              <td><%= link_to c.subject, case_path(c) %></td>
+              <td><%= c.association_info %></td>
+              <td><%= c.rt_ticket_id %></td>
+              <% if manage_cases_page %>
+                <td>
+                  <%= link_to c.last_known_ticket_status, c.rt_ticket_url %>
+                </td>
+                <td><%= c.chargeable_symbol %></td>
+              <% else %>
+                <td><%= render 'cases/email_support_icon', support_case: c %></td>
+                <td><%= render 'cases/archive_icon', support_case: c %></td>
+              <% end %>
+              <td>
+                <% if c.credit_charge_allowed? && manage_cases_page %>
+                  <% credit_charge = c.credit_charge || CreditCharge.new(case: c) %>
+                  <%= form_for credit_charge, class: 'form-inline' do |f| %>
+                    <%= f.hidden_field :case_id %>
+                    <%= f.number_field :amount, class: 'form-control', required: true %>
+                    <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
+                  <% end %>
+                <% else %>
+                  <%= c.credit_charge_info %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
 

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,2 +1,4 @@
 
-<%= render 'cases_table', model: site, archive: true %>
+<%= render_tab_bar activate: :cases %>
+<%= render 'cases_table', model: @scope, archive: true %>
+

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,9 +1,6 @@
 <% manage_cases_page = current_user.admin? && @archive %>
 
 <%= render_tab_bar activate: :cases do %>
-  <ul class='nav nav-tabs nav-justified' >
-    <%= @scope.decorate.case_form_buttons %>
-  </ul>
   <div class='table-responsive'>
     <table class="table">
       <thead>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,6 +1,9 @@
 <% manage_cases_page = current_user.admin? && @archive %>
 
 <%= render_tab_bar activate: :cases do %>
+  <ul class='nav nav-tabs nav-justified' >
+    <%= @scope.decorate.case_form_buttons %>
+  </ul>
   <div class='table-responsive'>
     <table class="table">
       <thead>

--- a/app/views/cases/new.html.erb
+++ b/app/views/cases/new.html.erb
@@ -1,2 +1,6 @@
 
-<%= new_case_form(clusters: @clusters, single_part: @single_part) %>
+<%= render_tab_bar activate: :cases do %>
+  <div class='card-body'>
+    <%= new_case_form(clusters: @clusters, single_part: @single_part) %>
+  </div>
+<% end %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -3,50 +3,52 @@
   <%= render 'partials/card_header_nav',
     title: 'Overview'
   %>
-  <table class="table table-responsive">
-    <tr style="width: 100%;">
-      <th>Date</th>
-      <td><%= @case.created_at.to_formatted_s(:long) %></td>
-    </tr>
-    <tr>
-      <th>Creator</th>
-      <td><%= @case.user.name %></td>
-    </tr>
-    <tr>
-      <th>Association</th>
-      <td><%= @case.association_info %></td>
-    </tr>
-    <tr>
-      <th>Ticket ID</th>
-      <td><%= @case.rt_ticket_id %></td>
-    </tr>
-    <tr>
-      <th>Category</th>
-      <td><%= @case.category&.name || 'None' %></td>
-    </tr>
-    <tr>
-      <th>Issue</th>
-      <td><%= @case.issue.name %></td>
-    </tr>
-    <tr>
-      <th>Chargeable</th>
-      <td><%= @case.chargeable_symbol %></td>
-    </tr>
-    <tr>
-      <th>Credit charge</th>
-      <td><%= @case.credit_charge_info %></td>
-    </tr>
-    <tr>
-      <th>Archived</th>
-      <td><%= boolean_symbol(@case.archived) %></td>
-    </tr>
-    <tr>
-      <th>Subject</th>
-      <td><%= @case.subject %></td>
-    </tr>
-    <tr>
-      <th>Details</th>
-      <td><%= simple_format(@case.details) %></td>
-    </tr>
-  </table>
+  <div class='table-responsive'>
+    <table class="table">
+      <tr style="width: 100%;">
+        <th>Date</th>
+        <td><%= @case.created_at.to_formatted_s(:long) %></td>
+      </tr>
+      <tr>
+        <th>Creator</th>
+        <td><%= @case.user.name %></td>
+      </tr>
+      <tr>
+        <th>Association</th>
+        <td><%= @case.association_info %></td>
+      </tr>
+      <tr>
+        <th>Ticket ID</th>
+        <td><%= @case.rt_ticket_id %></td>
+      </tr>
+      <tr>
+        <th>Category</th>
+        <td><%= @case.category&.name || 'None' %></td>
+      </tr>
+      <tr>
+        <th>Issue</th>
+        <td><%= @case.issue.name %></td>
+      </tr>
+      <tr>
+        <th>Chargeable</th>
+        <td><%= @case.chargeable_symbol %></td>
+      </tr>
+      <tr>
+        <th>Credit charge</th>
+        <td><%= @case.credit_charge_info %></td>
+      </tr>
+      <tr>
+        <th>Archived</th>
+        <td><%= boolean_symbol(@case.archived) %></td>
+      </tr>
+      <tr>
+        <th>Subject</th>
+        <td><%= @case.subject %></td>
+      </tr>
+      <tr>
+        <th>Details</th>
+        <td><%= simple_format(@case.details) %></td>
+      </tr>
+    </table>
+  </div>
 </div>

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -1,0 +1,42 @@
+<%
+  tabs = [
+    { id: :overview, path: cluster_path(@cluster) },
+    { id: :logs, path: cluster_logs_path(@cluster) },
+    { id: :cases, path: cluster_cases_path(@cluster) },
+    {
+      id: :maintenance,
+      path: cluster_maintenance_windows_path(@cluster),
+      admin_dropdown: [
+        {
+          text: 'Existing',
+          path: cluster_maintenance_windows_path(@cluster)
+        },{
+          text: 'Request',
+          path: new_cluster_maintenance_window_path(@cluster)
+        }
+      ]
+    },
+    {
+      id: :services, path: cluster_services_path(@cluster)
+    },
+    {
+      id: :components, path: '', # Path is ignored b/c dropdown
+      dropdown: @cluster.component_groups_by_type.map(&:name).map do |t|
+        { text: t, path: cluster_components_path(@cluster, type: t) }
+      end.push(text: 'All', path: cluster_components_path(@cluster))
+    }
+  ]
+%>
+<div class='card'>
+  <div class='card-header'>
+    <ul class="nav nav-tabs nav-justified">
+      <% tabs.each do |tab| %>
+        <% active = (tab[:id] == activate) %>
+        <% tab[:text] = tab[:id].to_s.capitalize unless tab[:text] %>
+        <%= render 'partials/nav_link', **tab, active: active, classes: 'px-3' %>
+      <% end %>
+    </ul>
+  </div>
+  <%= yield if block_given? %>
+</div>
+

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -6,12 +6,6 @@
       id: :cases, path: cluster_cases_path(@cluster),
       dropdown: [
         {
-          text: 'New Case',
-          path: new_cluster_case_path(@cluster)
-        }, {
-          text: 'Consultancy',
-          path: new_cluster_consultancy_path(@cluster)
-        }, {
           text: 'Current',
           path: cluster_cases_path(@cluster)
         }, {

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -2,23 +2,31 @@
   tabs = [
     { id: :overview, path: cluster_path(@cluster) },
     { id: :logs, path: cluster_logs_path(@cluster) },
-    { id: :cases, path: cluster_cases_path(@cluster) },
     {
+      id: :cases, path: cluster_cases_path(@cluster),
+      dropdown: [
+        {
+          text: 'Current',
+          path: cluster_cases_path(@cluster)
+        }, {
+          text: 'Archive',
+          path: cluster_cases_path(@cluster, archive: true)
+        }
+      ]
+    }, {
       id: :maintenance,
       path: cluster_maintenance_windows_path(@cluster),
       admin_dropdown: [
         {
           text: 'Existing',
           path: cluster_maintenance_windows_path(@cluster)
-        },{
+        }, {
           text: 'Request',
           path: new_cluster_maintenance_window_path(@cluster)
         }
       ]
     },
-    {
-      id: :services, path: cluster_services_path(@cluster)
-    },
+    { id: :services, path: cluster_services_path(@cluster) },
     {
       id: :components, path: '', # Path is ignored b/c dropdown
       dropdown: @cluster.component_groups_by_type.map(&:name).map do |t|

--- a/app/views/clusters/_tabs.html.erb
+++ b/app/views/clusters/_tabs.html.erb
@@ -6,6 +6,12 @@
       id: :cases, path: cluster_cases_path(@cluster),
       dropdown: [
         {
+          text: 'New Case',
+          path: new_cluster_case_path(@cluster)
+        }, {
+          text: 'Consultancy',
+          path: new_cluster_consultancy_path(@cluster)
+        }, {
           text: 'Current',
           path: cluster_cases_path(@cluster)
         }, {

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,52 +1,7 @@
 
-<%= render 'cases/cases_table', model: cluster, archive: true %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav',
-             title: 'Overview',
-             list_items: [
-               cluster.start_maintenance_request_link,
-               link_to(
-                 'Logs',
-                 cluster_logs_path(cluster),
-                 role: 'button',
-                 class: dark_button_classes
-               )
-             ] %>
-
+<%= render 'clusters/tabs', activate: :overview do %>
   <%= render 'clusters/details', cluster: cluster %>
-</div>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Maintenance' %>
-
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>For</th>
-        <th>Maintenance period</th>
-        <th>Requested</th>
-        <th>Confirmed</th>
-        <th>Associated case</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% cluster.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
-      <tr>
-        <td><%= window.associated_model.links %></td>
-        <td><%= window.scheduled_period %></td>
-        <td><%= window.transition_info(:requested) %></td>
-        <td>
-          <%= window.transition_info(:confirmed) ||
-            render('maintenance_windows/unconfirmed_buttons', window: window) %>
-        </td>
-        <td><%= window.case.ticket_link %></td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>
+<% end %>
 
 <div class='card'>
   <%= render 'partials/card_header_nav', title: 'Documents' %>
@@ -60,51 +15,3 @@
   </ul>
 </div>
 
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Services' %>
-
-  <table class="table table-responsive">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Support type</th>
-      </tr>
-    </thead>
-
-    <tbody>
-    <% cluster.services.each do |service| %>
-      <tr>
-        <td width='40%'>
-          <%= link_to service.name, service_path(service) %>
-          <%= service.cluster_part_icons %>
-        </td>
-        <td width='30%'><%= service.readable_support_type.capitalize %></td>
-        <td width='10%'>
-          <%= service.start_maintenance_request_link %>
-        </td>
-        <td width='20%'>
-          <%= service.change_support_type_button %>
-        </td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
-</div>
-
-<% cluster.component_groups_by_type.each do |type| %>
-  <div class='card'>
-    <%= render 'partials/card_header_nav', title: type.name.pluralize %>
-
-    <div class='card-body'>
-      <% type.component_groups.each do |group| %>
-        <h6 class="card-title">
-          <%= group.decorate.link %>
-        </h6>
-
-        <%= render 'partials/components_table', group: group %>
-
-      <% end %>
-    </div>
-
-  </div>
-<% end %>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,0 +1,9 @@
+
+<%= render_tab_bar activate: :components do %>
+  <div class='card-body'>
+    <% @component_groups.each do |group| %>
+      <h6><%= group.decorate.link %></h6>
+      <%= render 'partials/components_table', group: group %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/consultancy/new.html.erb
+++ b/app/views/consultancy/new.html.erb
@@ -7,36 +7,38 @@
   </div>
 <% end %>
 
-<%= form_for @case do |f| %>
-  <%= f.hidden_field(:cluster_id) %>
-  <%= f.hidden_field(:component_id) %>
-  <%= f.hidden_field(:service_id) %>
-  <%= f.hidden_field(:issue_id) %>
+<%= render_tab_bar activate: :cases do %>
+  <%= form_for @case, html: { class: 'card-body' } do |f| %>
+    <%= f.hidden_field(:cluster_id) %>
+    <%= f.hidden_field(:component_id) %>
+    <%= f.hidden_field(:service_id) %>
+    <%= f.hidden_field(:issue_id) %>
 
-  <div class="form-group">
-    <%= f.label :details,
-      raw(
-        <<~EOF
-          Please enter as much information as possible about the consultancy
-          you would like to request from Alces Software.<br><strong>Note that
-          all custom consultancy will be billed at your usual site
-          rates.</strong>
+    <div class="form-group">
+      <%= f.label :details,
+        raw(
+          <<~EOF
+            Please enter as much information as possible about the consultancy
+            you would like to request from Alces Software.<br><strong>Note that
+            all custom consultancy will be billed at your usual site
+            rates.</strong>
+          EOF
+        )
+      %>
+      <%= f.text_area :details,
+        class: ['form-control', 'consultancy-details'],
+        rows: 10
+      %>
+    </div>
+
+    <%= f.submit(
+      class: ['btn', 'btn-primary', 'btn-block', 'consultancy-submit'],
+      data: {
+        confirm: <<~EOF
+          Are you sure you would like to request consultancy from Alces Software?
+          By proceeding you acknowledge that this may incur charges.
         EOF
-      )
-    %>
-    <%= f.text_area :details,
-      class: ['form-control', 'consultancy-details'],
-      rows: 10
-    %>
-  </div>
-
-  <%= f.submit(
-    class: ['btn', 'btn-primary', 'btn-block', 'consultancy-submit'],
-    data: {
-      confirm: <<~EOF
-        Are you sure you would like to request consultancy from Alces Software?
-        By proceeding you acknowledge that this may incur charges.
-      EOF
-    }
-  ) %>
+      }
+    ) %>
+  <% end %>
 <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,3 +1,29 @@
+
+<%= render_tab_bar activate: :logs do %>
+  <div class='table-responsive'>
+    <table class='table'>
+      <thead>
+        <th>Date Created</th>
+        <th>Engineer</th>
+        <th>Details</th>
+        <th>Related Ticket(s)</th>
+      </thead>
+      <% @logs.each do |log| %>
+        <tr>
+          <td><%= log.created_at.to_formatted_s(:long) %></td>
+          <td><%= log.engineer.name %></td>
+          <td><%= log.details %></td>
+          <td>
+            <% log.cases.map(&:decorate).each do |kase| %>
+              <%= kase.ticket_link %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+<% end %>
+
 <% if current_user.admin? %>
   <div class='card'>
     <%= render 'partials/card_header_nav', title: 'Add Log' %>
@@ -40,30 +66,4 @@
     </div>
   </div>
 <% end %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Entries' %>
-  <div class='table-responsive'>
-    <table class='table'>
-      <thead>
-        <th>Date Created</th>
-        <th>Engineer</th>
-        <th>Details</th>
-        <th>Related Ticket(s)</th>
-      </thead>
-      <% @logs.each do |log| %>
-        <tr>
-          <td><%= log.created_at.to_formatted_s(:long) %></td>
-          <td><%= log.engineer.name %></td>
-          <td><%= log.details %></td>
-          <td>
-            <% log.cases.map(&:decorate).each do |kase| %>
-              <%= kase.ticket_link %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-  </div>
-</div>
 

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,0 +1,32 @@
+
+<%= render_tab_bar activate: :maintenance do %>
+  <div class='table-responsive'>
+    <table class="maintenance table">
+      <thead>
+        <tr>
+          <th>For</th>
+          <th>Maintenance period</th>
+          <th>Requested</th>
+          <th>Confirmed</th>
+          <th>Associated case</th>
+        </tr>
+      </thead>
+
+      <tbody>
+      <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
+        <tr>
+          <td><%= window.associated_model.links %></td>
+          <td><%= window.scheduled_period %></td>
+          <td><%= window.transition_info(:requested) %></td>
+          <td>
+            <%= window.transition_info(:confirmed) ||
+              render('maintenance_windows/unconfirmed_buttons', window: window) %>
+          </td>
+          <td><%= window.case.ticket_link %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>
+

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -1,31 +1,33 @@
 
-<%= form_for @maintenance_window,
-  url: request.original_fullpath,
-  html: { novalidate: true, } do |f| %>
-  <%= f.hidden_field :cluster_id %>
-  <%= f.hidden_field :component_id %>
-  <%= f.hidden_field :service_id %>
+<%= render_tab_bar activate: :maintenance do %>
+  <%= form_for @maintenance_window,
+    url: request.original_fullpath,
+    html: { novalidate: true, class: 'card-body' } do |f| %>
+    <%= f.hidden_field :cluster_id %>
+    <%= f.hidden_field :component_id %>
+    <%= f.hidden_field :service_id %>
 
-  <div class="form-group">
-    <%= f.label :case_id, 'Case to associate this maintenance with' %>
-    <%= f.collection_select(
-      :case_id,
-      @maintenance_window.associated_cluster.cases.order(created_at: :desc).decorate,
-      :id,
-      :case_select_details,
-      {},
-      {class: ['form-control is-valid']}
-    ) %>
-  </div>
+    <div class="form-group">
+      <%= f.label :case_id, 'Case to associate this maintenance with' %>
+      <%= f.collection_select(
+        :case_id,
+        @maintenance_window.associated_cluster.cases.order(created_at: :desc).decorate,
+        :id,
+        :case_select_details,
+        {},
+        {class: ['form-control is-valid']}
+      ) %>
+    </div>
 
-  <%= render 'partials/date_time_select',
-    model: @maintenance_window,
-    datetime_field_name: 'requested_start'
-  %>
-  <%= render 'partials/date_time_select',
-    model: @maintenance_window,
-    datetime_field_name: 'requested_end'
-  %>
+    <%= render 'partials/date_time_select',
+      model: @maintenance_window,
+      datetime_field_name: 'requested_start'
+    %>
+    <%= render 'partials/date_time_select',
+      model: @maintenance_window,
+      datetime_field_name: 'requested_end'
+    %>
 
-  <%= f.submit "Request Maintenance", class: 'btn btn-primary btn-block' %>
+    <%= f.submit "Request Maintenance", class: 'btn btn-primary btn-block' %>
+  <% end %>
 <% end %>

--- a/app/views/partials/_asset_record_table.html.erb
+++ b/app/views/partials/_asset_record_table.html.erb
@@ -4,46 +4,48 @@
   <%= render('partials/card_header_nav', title: 'Asset Record') %>
 
   <%= form_tag decorated_model.asset_record_path, method: 'PATCH' do %>
-    <table class="table table-responsive m-0">
-      <thead>
-        <tr>
-          <th>Field</th>
-          <th>Value</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>Component Make</td>
-          <td><% if (model.is_a? ComponentGroup) && (action == 'edit') %>
-            <% makes = ComponentMake.where(component_type: model.component_type) %>
-            <%= collection_select :component_make,
-                                  :id,
-                                  makes,
-                                  :id,
-                                  :name,
-                                  { selected: model.component_make.id } %>
-          <% else %>
-            <%= model.component_make.name %>
-          <% end %></td>
-        </tr>
-        <% model.asset_record.each do |field| %>
-          <tr class="form-group">
-            <td width="50%">
-              <%= label_tag(field.definition.id, field.name) %>
-            </td>
-
-            <td width="50%">
-              <% if action == 'edit' %>
-                <%= field.decorate.form_input(model) %>
-              <% else %>
-                <%= field.value %>
-              <% end %>
-            </td>
+    <div class='table-responsive'>
+      <table class="table m-0">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Value</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>Component Make</td>
+            <td><% if (model.is_a? ComponentGroup) && (action == 'edit') %>
+              <% makes = ComponentMake.where(component_type: model.component_type) %>
+              <%= collection_select :component_make,
+                                    :id,
+                                    makes,
+                                    :id,
+                                    :name,
+                                    { selected: model.component_make.id } %>
+            <% else %>
+              <%= model.component_make.name %>
+            <% end %></td>
+          </tr>
+          <% model.asset_record.each do |field| %>
+            <tr class="form-group">
+              <td width="50%">
+                <%= label_tag(field.definition.id, field.name) %>
+              </td>
+
+              <td width="50%">
+                <% if action == 'edit' %>
+                  <%= field.decorate.form_input(model) %>
+                <% else %>
+                  <%= field.value %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
     <%= render 'partials/edit_submit_button',
                action: action,
                edit_path: decorated_model.edit_asset_record_path %>

--- a/app/views/partials/_card.html.erb
+++ b/app/views/partials/_card.html.erb
@@ -1,0 +1,5 @@
+<% if block_given? %>
+  <div class='card'>
+     <%= yield %>
+  </div>
+<% end %>

--- a/app/views/partials/_components_table.html.erb
+++ b/app/views/partials/_components_table.html.erb
@@ -1,10 +1,12 @@
 
-  <table class="table table-responsive">
+<div class='table-responsive'>
+  <table class="table">
 
     <thead>
       <tr>
         <th>Name</th>
         <th>Support type</th>
+        <th></th>
         <th></th>
       </tr>
     </thead>
@@ -28,5 +30,5 @@
         </tr>
       <% end %>
     </tbody>
-
   </table>
+</div>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -57,6 +57,7 @@
       <% if current_user.admin? %>
         <ul class="navbar-nav justify-content-end">
           <%= render 'partials/nav_link',
+                     active: false,
                      text: 'Admin Interface',
                      path: rails_admin_path,
                      nav_icon: 'fa-database' %>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,9 +1,27 @@
 <% path ||= model %>
 <% text ||= model.name %>
-<% active ||= false %>
-<li class='nav-item'>
+<% nav_icon ||= '' %>
+<% if current_user.admin? && (admin_dropdown ||= false) %>
+  <% dropdown = admin_dropdown %>
+<% end %>
+<% dropdown ||= false # Defines the variable %>
+<% classes ||= false %>
+<%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
+  <% class_string = "nav-link".tap do |str|
+    str << ' nav-link--active' if active
+    str << ' dropdown-toggle' if dropdown
+    str << ' ' + classes if classes
+  end %>
+  <% options = { class: class_string }.tap do |opt|
+    opt[:'data-toggle'] = 'dropdown' if dropdown
+  end %>
   <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
-              path,
-              class: "nav-link #{ 'nav-link--active' if active }"
-  %>
+              path, options %>
+  <% if dropdown %>
+    <div class='dropdown-menu'>
+      <% dropdown.each do |dropitem| %>
+        <%= link_to dropitem[:text], dropitem[:path], class: 'dropdown-item' %>
+      <% end %>
+    </div>
+  <% end %>
 </li>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -20,12 +20,12 @@
   end
 %>
 
-<%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
+<li class='nav-item<%= ' dropdown' if dropdown %>'>
   <%= link_to icon_span(text, nav_icon), path, link_options %>
   <% if dropdown %>
     <div class='dropdown-menu'>
       <% dropdown.each do |dropitem| %>
-        <%= link_to icon_span(dropitem[:text]),
+        <%= link_to dropitem[:text],
                     dropitem[:path],
                     class: 'dropdown-item' %>
       <% end %>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -3,6 +3,7 @@
   path ||= model
   text ||= model.name
   nav_icon ||= ''
+  # TODO: Remove this and replace dropdown with buttons
   if current_user.admin? && (admin_dropdown ||= false)
     dropdown = admin_dropdown
   end
@@ -19,13 +20,15 @@
   <% options = { class: class_string }.tap do |opt|
     opt[:'data-toggle'] = 'dropdown' if dropdown
   end %>
-  <%= link_to (raw("<span class='fa #{nav_icon}'></span> ") + text),
-              path, options %>
+  <%= link_to icon_span(text, nav_icon), path, options %>
   <% if dropdown %>
     <div class='dropdown-menu'>
       <% dropdown.each do |dropitem| %>
-        <%= link_to dropitem[:text], dropitem[:path], class: 'dropdown-item' %>
+        <%= link_to icon_span(dropitem[:text]),
+                    dropitem[:path],
+                    class: 'dropdown-item' %>
       <% end %>
     </div>
   <% end %>
 </li>
+

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -3,24 +3,25 @@
   path ||= model
   text ||= model.name
   nav_icon ||= ''
+  dropdown ||= false
+  classes ||= false
   # TODO: Remove this and replace dropdown with buttons
   if current_user.admin? && (admin_dropdown ||= false)
     dropdown = admin_dropdown
   end
-  dropdown ||= false
-  classes ||= false
+
+  link_options = {}.tap do |opt|
+    opt[:'data-toggle'] = 'dropdown' if dropdown
+    opt[:class] = ['nav-link'].tap do |class_arr|
+      class_arr << 'nav-link--active' if active
+      class_arr << 'dropdown-toggle' if dropdown
+      class_arr << classes if classes
+    end.flatten.join(' ')
+  end
 %>
 
 <%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
-  <% class_string = "nav-link".tap do |str|
-    str << ' nav-link--active' if active
-    str << ' dropdown-toggle' if dropdown
-    str << ' ' + classes if classes
-  end %>
-  <% options = { class: class_string }.tap do |opt|
-    opt[:'data-toggle'] = 'dropdown' if dropdown
-  end %>
-  <%= link_to icon_span(text, nav_icon), path, options %>
+  <%= link_to icon_span(text, nav_icon), path, link_options %>
   <% if dropdown %>
     <div class='dropdown-menu'>
       <% dropdown.each do |dropitem| %>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -1,11 +1,15 @@
-<% path ||= model %>
-<% text ||= model.name %>
-<% nav_icon ||= '' %>
-<% if current_user.admin? && (admin_dropdown ||= false) %>
-  <% dropdown = admin_dropdown %>
-<% end %>
-<% dropdown ||= false # Defines the variable %>
-<% classes ||= false %>
+<%
+  # Variable definitions for the template
+  path ||= model
+  text ||= model.name
+  nav_icon ||= ''
+  if current_user.admin? && (admin_dropdown ||= false)
+    dropdown = admin_dropdown
+  end
+  dropdown ||= false
+  classes ||= false
+%>
+
 <%= raw "<li class='nav-item #{'dropdown' if dropdown}'>" %>
   <% class_string = "nav-link".tap do |str|
     str << ' nav-link--active' if active

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,0 +1,31 @@
+
+<%= render_tab_bar activate: :services do %>
+  <div class='table-responsive'>
+    <table class='table'>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Support type</th>
+        </tr>
+      </thead>
+
+      <tbody>
+      <% @scope.services.map(&:decorate).each do |service| %>
+        <tr>
+          <td width='40%'>
+            <%= link_to service.name, service_path(service) %>
+            <%= service.cluster_part_icons %>
+          </td>
+          <td width='30%'><%= service.readable_support_type.capitalize %></td>
+          <td width='10%'>
+            <%= service.start_maintenance_request_link %>
+          </td>
+          <td width='20%'>
+            <%= service.change_support_type_button %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,12 @@ Rails.application.routes.draw do
   maintenance_form = Proc.new do
     resources :maintenance_windows, only: :new do
       collection do
-        post 'new', action: :create
+        # Do not define route helper (by passing `as: nil`) as otherwise this
+        # will overwrite the `${model}_maintenance_windows_path` helper, as by
+        # default `resources` expects `new` and `index` to use the same route.
+        # However we do not want this, and this route can be accessed using the
+        # `new_${model}_maintenance_windows_path` helper.
+        post 'new', action: :create, as: nil
       end
     end
   end
@@ -87,8 +92,11 @@ Rails.application.routes.draw do
     end
 
     resources :clusters, only: :show do
-      resources :cases, only: :new
+      resources :cases, only: [:index, :new]
+      resources :services, only: :index
       resources :consultancy, only: :new
+      resources :maintenance_windows, only: :index
+      resources :components, only: :index
       logs.call
     end
 

--- a/spec/features/cases_table_spec.rb
+++ b/spec/features/cases_table_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe 'Cases table', type: :feature do
       include_examples 'open cases table rendered'
     end
 
-    context 'when visit cases page' do
+    context 'when visit archive cases page' do
       it 'renders table of all Cases' do
-        visit cases_path(as: user)
+        visit cases_path(archive: true, as: user)
 
         cases = all('tr').map(&:text)
         expect(cases).to have_text('Open case')
@@ -79,9 +79,9 @@ RSpec.describe 'Cases table', type: :feature do
       include_examples 'open cases table rendered'
     end
 
-    context 'when visit cases page' do
+    context 'when visit archive cases page' do
       it 'renders table of all Cases, without Contact-specific buttons/info' do
-        visit site_cases_path(site, as: user)
+        visit site_cases_path(site, archive: true, as: user)
 
         headings = all('th').map(&:text)
         expect(headings).not_to include('Contact support')
@@ -121,7 +121,7 @@ RSpec.describe 'Cases table', type: :feature do
 
           # Neither Case's ticket has reached completion status yet so both
           # should have reloaded RT ticket status.
-          visit site_cases_path(site, as: user)
+          visit site_cases_path(site, archive: true, as: user)
           expect(open_case.reload.last_known_ticket_status).to eq 'open'
           expect(archived_case.reload.last_known_ticket_status).to eq completion_status
 
@@ -131,7 +131,7 @@ RSpec.describe 'Cases table', type: :feature do
 
           # Archived Case has reached completion status so ticket status is not
           # reloaded.
-          visit site_cases_path(site, as: user)
+          visit site_cases_path(site, archive: true, as: user)
           expect(open_case.reload.last_known_ticket_status).to eq 'open'
           expect(archived_case.reload.last_known_ticket_status).to eq completion_status
 

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -1,0 +1,56 @@
+
+require 'rails_helper'
+
+RSpec.describe 'cluster tabs', type: :feature do
+  let :cluster { create(:cluster) }
+
+  let :tabs { page.find('ul.nav-tabs') }
+  let :maintenance_tab { tabs.find('li', text: /Maintenance/) }
+
+  before :each do
+    # Prevent attempting to retrieve documents from S3 when Cluster page
+    # visited.
+    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
+  end
+
+  context 'when visiting the cluster page' do
+    before :each { visit cluster_path(cluster, as: user) }
+
+    context 'with an admin user' do
+      let :user { create(:admin) }
+
+      it 'has a dropdown menu for maintenance tab' do
+        expect(maintenance_tab).to match_css('.dropdown')
+        expect(maintenance_tab.first('div')).to match_css('.dropdown-menu')
+      end
+
+      it 'has a link to the existing maintenance' do
+        path = cluster_maintenance_windows_path(cluster)
+        expect(maintenance_tab).to have_link(href: path)
+      end
+
+      it 'has a link to request maintenance' do
+        path = new_cluster_maintenance_window_path(cluster)
+        expect(maintenance_tab).to have_link(href: path)
+      end
+    end
+
+    context 'with a contact user' do
+      let :user { create(:contact, site: cluster.site) }
+
+      it 'does not have dropdown menu for maintenance tab' do
+        expect(maintenance_tab).not_to match_css('.dropdown')
+      end
+
+      it 'has a link to the existing maintenance' do
+        path = cluster_maintenance_windows_path(cluster)
+        expect(maintenance_tab).to have_link(href: path)
+      end
+
+      it 'does not have a link to request maintenance' do
+        path = new_cluster_maintenance_window_path(cluster)
+        expect(maintenance_tab).not_to have_link(href: path)
+      end
+    end
+  end
+end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature "Maintenance windows", type: :feature do
       new_component_maintenance_window_path(component)
     end
 
-    it 'can navigate to maintenance request form from Cluster dashboard' do
-      visit cluster_path(cluster, as: user)
+    it 'can navigate to maintenance request form from Cluster dashboard Components tab' do
+      visit cluster_components_path(cluster, as: user)
 
       component_maintenance_link = page.find_link(
         href: component_maintenance_path
@@ -114,7 +114,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'can cancel requested maintenance' do
       window = create(:requested_maintenance_window, cluster: cluster)
 
-      visit cluster_path(cluster, as: user)
+      visit cluster_maintenance_windows_path(cluster, as: user)
       button_text = 'Cancel'
       click_button(button_text)
 
@@ -147,16 +147,18 @@ RSpec.feature "Maintenance windows", type: :feature do
         case: support_case
       )
 
-      visit cluster_path(component.cluster, as: user)
+      visit cluster_maintenance_windows_path(component.cluster, as: user)
       button_text = "Unconfirmed"
       click_button(button_text)
+      expect(find('.alert')).to have_text(/maintenance confirmed/)
 
       window.reload
       expect(window).to be_confirmed
       expect(window.confirmed_by).to eq(user)
+
+      visit cluster_maintenance_windows_path(component.cluster, as: user)
       expect(page).not_to have_button(button_text)
-      expect(page.all('table')[1]).to have_text(user_name)
-      expect(find('.alert')).to have_text(/maintenance confirmed/)
+      expect(page.first('table.maintenance')).to have_text(user_name)
     end
 
     it 'can reject requested maintenance' do
@@ -166,7 +168,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         case: support_case
       )
 
-      visit cluster_path(cluster, as: user)
+      visit cluster_maintenance_windows_path(cluster, as: user)
       button_text = 'Reject'
 
       click_button(button_text)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -38,4 +38,35 @@ RSpec.describe ApplicationHelper do
       expect(boolean_symbol(false)).to eq(raw('&cross;'))
     end
   end
+
+  describe '#render_tab_bar' do
+    subject { render_tab_bar }
+
+    # It has to return a string. Returning nil breaks the render
+    def expect_render_tabs(template)
+      expect(helper).to \
+        receive(:render).with(template, instance_of(Hash))
+                        .once.and_return('')
+    end
+
+    context 'without a scope set' do
+      before :each { @scope = nil }
+
+      it 'nothing is rendered' do
+        expect_render_tabs('partials/card')
+        subject
+      end
+    end
+
+    context 'within a cluster scope' do
+      let :cluster { create(:cluster) }
+      before :each { @scope = cluster }
+
+      it 'renders the cluster nav bar' do
+        expect_render_tabs('clusters/tabs')
+        subject
+      end
+    end
+  end
 end
+

--- a/spec/views/partials/_nav_link.html.erb_spec.rb
+++ b/spec/views/partials/_nav_link.html.erb_spec.rb
@@ -1,0 +1,43 @@
+
+require 'rails_helper'
+
+RSpec.describe 'renders the nav link', type: :view do
+  def render_link(**inputs)
+    render 'partials/nav_link', **inputs, current_user: user
+  end
+
+  context 'with a contact user' do
+    let :user { create(:contact) }
+
+    context 'with a model and a nil active link' do
+      let :model { create(:component) }
+      let :model_path { component_path(model) }
+
+      def render_model_link(**options)
+        render_link(model: model, active: nil, **options)
+      end
+
+      it 'renders a link to the models page' do
+        render_model_link
+        expect(rendered).to have_link(href: component_path(model))
+      end
+
+      it 'has the model name as the value' do
+        render_model_link
+        expect(rendered).to have_text(model.name)
+      end
+
+      it 'can override the model path with the path input' do
+        path = '/random-other-path'
+        render_model_link(path: path)
+        expect(rendered).to have_link(href: path)
+      end
+
+      it 'can override the model name with the text input' do
+        text = 'random-text'
+        render_model_link(text: text)
+        expect(rendered).to have_text(text)
+      end
+    end
+  end
+end

--- a/spec/views/partials/_nav_link.html.erb_spec.rb
+++ b/spec/views/partials/_nav_link.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'renders the nav link', type: :view do
       let :model_path { component_path(model) }
 
       def render_model_link(**options)
+        options.merge!(active: nil) unless options.key?(:active)
         render_link(model: model, active: nil, **options)
       end
 
@@ -37,6 +38,23 @@ RSpec.describe 'renders the nav link', type: :view do
         text = 'random-text'
         render_model_link(text: text)
         expect(rendered).to have_text(text)
+      end
+
+      it 'it activates the link with the active flag' do
+        render_model_link(active: true)
+        expect(rendered).to have_css('a.nav-link--active')
+      end
+
+      it 'has creates a icon with the nav_icon input' do
+        nav_icon = 'fa-cube'
+        render_model_link(nav_icon: nav_icon)
+        expect(rendered).to have_css("span.#{nav_icon}")
+      end
+
+      it 'can add arbitrary classes to the link with the classes input' do
+        additional_class = 'random-class'
+        render_model_link(classes: additional_class)
+        expect(rendered).to have_css("a.#{additional_class}")
       end
     end
   end

--- a/spec/views/partials/_nav_link.html.erb_spec.rb
+++ b/spec/views/partials/_nav_link.html.erb_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe 'renders the nav link', type: :view do
         it 'sets the first link to be the dropdown toggle' do
           first = rendered.first('a')
           expect(first[:class]).to include('dropdown-toggle')
+          expect(first[:'data-toggle']).to eq('dropdown')
         end
 
         it 'has the dropdown menu' do


### PR DESCRIPTION
Based on #93, please merge it first.

This PR implements the `UI` aspect for archiving cases. To facilitate this, the `cases table` has been split into a `index` page that can be integrated into the `cluster` tab bar. When viewing the index, the archive is off by default. However sending a `archive=true` parameter with the request will switch it on.

The buttons for adding a new case/ consultancy have been merged into the tab bar. However watch this space as that maybe reverted back in the future.

A spec has also been added for the creation of the `nav_links`. This allowed for the code to be cleaned up whilst ensuring the functionality is the same.

This PR may cause a few issues with the `UI` on non-tab pages, however this will be fixed when tabs are used across the board.