### PR TITLE
Add maintenance durations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'bootsnap', require: false
 gem "sentry-raven"
 gem 'state_machines-activerecord'
 gem 'state_machines-audit_trail'
+gem 'business_time'
 
 gem 'bootstrap', '~> 4.0.0'
 gem 'jquery-rails' # Required for Bootstrap.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
     builder (3.2.3)
+    business_time (0.9.3)
+      activesupport (>= 3.2.0)
+      tzinfo
     byebug (10.0.0)
     capybara (2.18.0)
       addressable
@@ -387,6 +390,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   bootstrap (~> 4.0.0)
+  business_time
   byebug
   capybara (~> 2.13)
   clearance

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -69,7 +69,8 @@ class MaintenanceWindowsController < ApplicationController
   ].freeze
 
   def request_maintenance_window_params
-    params.require(:maintenance_window).permit(REQUEST_PARAM_NAMES)
+    # XXX Get duration from request.
+    params.require(:maintenance_window).permit(REQUEST_PARAM_NAMES).merge(duration: 1)
   end
 
   def confirm_maintenance_window_params

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -8,7 +8,7 @@ class MaintenanceWindowDecorator < ApplicationDecorator
       [
         format(requested_start),
         '&mdash;',
-        format(requested_end),
+        format(expected_end),
         scheduled_period_state_indicator,
       ].join(' ').strip
     )

--- a/app/models/maintenance_notifier.rb
+++ b/app/models/maintenance_notifier.rb
@@ -15,7 +15,7 @@ MaintenanceNotifier = Struct.new(:window) do
   def requested_comment
     <<-EOF
       Maintenance requested for #{associated_model.name} from
-      #{requested_start} until #{requested_end} by #{window.requested_by.name};
+      #{requested_start} until #{expected_end} by #{window.requested_by.name};
       to proceed this maintenance must be confirmed on the cluster dashboard:
       #{cluster_dashboard_url}.
     EOF
@@ -25,7 +25,7 @@ MaintenanceNotifier = Struct.new(:window) do
     <<~EOF
       Request for maintenance of #{associated_model.name} confirmed by
       #{window.confirmed_by.name}; this maintenance has been scheduled from
-      #{requested_start} until #{requested_end}.
+      #{requested_start} until #{expected_end}.
     EOF
   end
 
@@ -56,7 +56,7 @@ MaintenanceNotifier = Struct.new(:window) do
     <<~EOF
       Scheduled maintenance of #{associated_model.name} has automatically
       started; this #{associated_model.readable_model_name} is now under
-      maintenance until #{requested_end}.
+      maintenance until #{expected_end}.
     EOF
   end
 
@@ -79,7 +79,7 @@ MaintenanceNotifier = Struct.new(:window) do
     window.requested_start.to_formatted_s(:short)
   end
 
-  def requested_end
-    window.requested_end.to_formatted_s(:short)
+  def expected_end
+    window.expected_end.to_formatted_s(:short)
   end
 end

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -8,7 +8,6 @@ class MaintenanceWindow < ApplicationRecord
   alias_attribute :transitions, :maintenance_window_state_transitions
 
   validates_presence_of :requested_start
-  validates_presence_of :requested_end
   validates :duration, presence: true, numericality: { greater_than: 0 }
   validates_with Validator
 

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -17,7 +17,7 @@ class MaintenanceWindow < ApplicationRecord
   attr_accessor :legacy_migration_mode
 
   state_machine initial: :new do
-    audit_trail context: [:user, :requested_start, :requested_end]
+    audit_trail context: [:user, :requested_start]
 
     state :new
     state :requested

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -9,6 +9,7 @@ class MaintenanceWindow < ApplicationRecord
 
   validates_presence_of :requested_start
   validates_presence_of :requested_end
+  validates :duration, presence: true, numericality: { greater_than: 0 }
   validates_with Validator
 
   scope :unfinished, -> { where.not(state: finished_states) }

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -79,6 +79,10 @@ class MaintenanceWindow < ApplicationRecord
     cluster || associated_model.cluster
   end
 
+  def expected_end
+    duration.business_days.after(requested_start)
+  end
+
   def method_missing(symbol, *args)
     query = TransitionQuery.parse(symbol)
     query ? query.value_for(self) : super

--- a/app/models/maintenance_window/validator.rb
+++ b/app/models/maintenance_window/validator.rb
@@ -11,7 +11,7 @@ class MaintenanceWindow
     private
 
     attr_reader :record
-    delegate :requested_start, :requested_end, to: :record
+    delegate :requested_start, to: :record
 
     def validate_precisely_one_associated_model
       record.errors.add(
@@ -28,21 +28,13 @@ class MaintenanceWindow
     end
 
     def validate_requested_period
-      return unless requested_start && requested_end
-      validate_start_before_end
-      validate_start_or_end_in_future_if_needed unless record.legacy_migration_mode
+      return unless requested_start
+      validate_start_in_future_if_needed unless record.legacy_migration_mode
     end
 
-    def validate_start_before_end
-      if requested_start > requested_end
-        record.errors.add(:requested_end, 'must be after start')
-      end
-    end
-
-    def validate_start_or_end_in_future_if_needed
+    def validate_start_in_future_if_needed
       return if maintenance_period_can_be_passed?
       validate_field_in_future(:requested_start)
-      validate_field_in_future(:requested_end)
     end
 
     def maintenance_period_can_be_passed?

--- a/app/services/progress_maintenance_window.rb
+++ b/app/services/progress_maintenance_window.rb
@@ -24,7 +24,7 @@ ProgressMaintenanceWindow = Struct.new(:window) do
   end
 
   def end_time_passed?
-    window.requested_end.past?
+    window.expected_end.past?
   end
 
   def start_time_passed?
@@ -59,7 +59,7 @@ ProgressMaintenanceWindow = Struct.new(:window) do
   end
 
   def end_date
-    format_datetime(window.requested_end)
+    format_datetime(window.expected_end)
   end
 
   def format_datetime(datetime)

--- a/db/migrate/20180323140700_add_duration_to_maintenance_windows.rb
+++ b/db/migrate/20180323140700_add_duration_to_maintenance_windows.rb
@@ -1,0 +1,5 @@
+class AddDurationToMaintenanceWindows < ActiveRecord::Migration[5.1]
+  def change
+    add_column :maintenance_windows, :duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180308175322) do
+ActiveRecord::Schema.define(version: 20180323140700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -230,6 +230,7 @@ ActiveRecord::Schema.define(version: 20180308175322) do
     t.text "state", default: "new", null: false
     t.datetime "requested_start"
     t.datetime "requested_end"
+    t.integer "duration"
     t.index ["case_id"], name: "index_maintenance_windows_on_case_id"
     t.index ["cluster_id"], name: "index_maintenance_windows_on_cluster_id"
     t.index ["component_id"], name: "index_maintenance_windows_on_component_id"

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -31,19 +31,16 @@ RSpec.describe MaintenanceWindowDecorator do
     subject do
       create(
         :maintenance_window,
-        requested_start: requested_start,
-        requested_end: requested_end,
+        requested_start: 1.days.from_now,
+        duration: 3,
         state: state,
       ).decorate
     end
 
-    let :requested_start { 1.days.from_now }
-    let :requested_end { 2.days.from_now }
-
     let :expected_time_range do
-      from = requested_start.to_formatted_s(:short)
-      to = requested_end.to_formatted_s(:short)
-      h.raw("#{from} &mdash; #{to}")
+      start_date = subject.requested_start.to_formatted_s(:short)
+      end_date = subject.expected_end.to_formatted_s(:short)
+      h.raw("#{start_date} &mdash; #{end_date}")
     end
 
     RSpec.shared_examples 'includes time range' do

--- a/spec/factories/maintenance_window.rb
+++ b/spec/factories/maintenance_window.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     created_at 7.days.ago
     requested_start 1.days.from_now.at_midnight
     requested_end 2.days.from_now.at_midnight
+    duration 1
 
     # This could also be a Cluster or Service; but one of these must be
     # associated and is the item under maintenance.

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.shared_examples 'maintenance form error handling' do |form_action|
   it 're-renders form with error when invalid date entered' do
     original_path = current_path
-    requested_end_in_past = DateTime.new(2016, 9, 20, 13)
+    requested_start_in_past = DateTime.new(2016, 9, 20, 13)
 
     expect do
-      fill_in_datetime_selects 'requested-end', with: requested_end_in_past
+      fill_in_datetime_selects 'requested-start', with: requested_start_in_past
       submit_button_text = "#{form_action.titlecase} Maintenance"
       click_button submit_button_text
     end.not_to change(MaintenanceWindow, :all)
@@ -16,10 +16,10 @@ RSpec.shared_examples 'maintenance form error handling' do |form_action|
       find('.alert')
     ).to have_text(/Unable to #{form_action} this maintenance/)
     invalidated_selects =
-      requested_end_element.all('select', class: 'is-invalid')
+      requested_start_element.all('select', class: 'is-invalid')
     expect(invalidated_selects.length).to eq(5)
-    expect(requested_end_element.find('.invalid-feedback')).to have_text(
-      'Must be after start; cannot be in the past'
+    expect(requested_start_element.find('.invalid-feedback')).to have_text(
+      'Cannot be in the past'
     )
   end
 end
@@ -238,12 +238,12 @@ RSpec.feature "Maintenance windows", type: :feature do
 
         include_examples 'confirmation form'
 
-        it 'displays errors if confirmed with existing dates on form load' do
-          [requested_start_element, requested_end_element].each do |element|
-            expect(element.find('.invalid-feedback')).to have_text(
-              'Cannot be in the past'
-            )
-          end
+        it 'displays error if date in past on form load' do
+          expect(
+            requested_start_element.find('.invalid-feedback')
+          ).to have_text(
+            'Cannot be in the past'
+          )
         end
       end
     end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -68,7 +68,6 @@ RSpec.shared_examples 'confirmation form' do
     expect(window.requested_end).to eq valid_requested_end
     confirmed_transition = window.transitions.find_by_to(:confirmed)
     expect(confirmed_transition.requested_start).to eq valid_requested_start
-    expect(confirmed_transition.requested_end).to eq valid_requested_end
     expect(current_path).to eq(cluster_maintenance_windows_path(cluster))
     expect(find('.alert')).to have_text(/Maintenance confirmed/)
   end

--- a/spec/models/component_group_spec.rb
+++ b/spec/models/component_group_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ComponentGroup, type: :model do
       group.save!
 
       group.reload
-      expect(group.component_names).to eq(['node01', 'node02', 'node03'])
+      expect(group.component_names).to match_array(['node01', 'node02', 'node03'])
     end
 
     it 'does not cause any nodes to be created when unset' do

--- a/spec/models/maintenance_window/validation_spec.rb
+++ b/spec/models/maintenance_window/validation_spec.rb
@@ -108,7 +108,6 @@ RSpec.describe MaintenanceWindow, type: :model do
 
     describe 'maintenance period validations' do
       it { is_expected.to validate_presence_of(:requested_start) }
-      it { is_expected.to validate_presence_of(:requested_end) }
 
       it { is_expected.to validate_presence_of(:duration) }
       it { is_expected.to validate_numericality_of(:duration).is_greater_than(0) }
@@ -119,7 +118,6 @@ RSpec.describe MaintenanceWindow, type: :model do
             :maintenance_window,
             state: state,
             requested_start: 1.days.ago,
-            requested_end: 1.days.from_now,
             legacy_migration_mode: legacy_migration_mode,
           )
         end

--- a/spec/models/maintenance_window/validation_spec.rb
+++ b/spec/models/maintenance_window/validation_spec.rb
@@ -106,9 +106,12 @@ RSpec.describe MaintenanceWindow, type: :model do
       it { is_expected.to be_invalid }
     end
 
-    describe 'requested_start and requested_end validations' do
+    describe 'maintenance period validations' do
       it { is_expected.to validate_presence_of(:requested_start) }
       it { is_expected.to validate_presence_of(:requested_end) }
+
+      it { is_expected.to validate_presence_of(:duration) }
+      it { is_expected.to validate_numericality_of(:duration).is_greater_than(0) }
 
       context 'when requested_start after requested_end' do
         subject do

--- a/spec/models/maintenance_window/validation_spec.rb
+++ b/spec/models/maintenance_window/validation_spec.rb
@@ -113,36 +113,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       it { is_expected.to validate_presence_of(:duration) }
       it { is_expected.to validate_numericality_of(:duration).is_greater_than(0) }
 
-      context 'when requested_start after requested_end' do
-        subject do
-          build(
-            :maintenance_window,
-            requested_start: 2.days.from_now,
-            requested_end: 1.days.from_now,
-          )
-        end
-
-        it 'should be invalid' do
-          expect(subject).to be_invalid
-          expect(subject.errors.messages).to match(requested_end: ['must be after start'])
-        end
-      end
-
-      context 'when requested_start and requested_end in past' do
-        subject do
-          build(
-            :maintenance_window,
-            state: state,
-            requested_start: 2.days.ago,
-            requested_end: 1.days.ago,
-            legacy_migration_mode: legacy_migration_mode,
-          )
-        end
-
-        it_behaves_like 'it validates dates cannot be in the past' , [:requested_start, :requested_end]
-      end
-
-      context 'when just requested_start in past' do
+      context 'when requested_start in past' do
         subject do
           build(
             :maintenance_window,

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -69,11 +69,10 @@ RSpec.describe MaintenanceWindow, type: :model do
       it 'has RT ticket comment added when requested' do
         subject.component = create(:component, name: 'some_component')
         subject.requested_start = 1.days.since
-        subject.requested_end = 2.days.since
         requestor = create(:admin, name: 'some_user')
 
         expected_start = subject.requested_start.to_formatted_s(:short)
-        expected_end = subject.requested_end.to_formatted_s(:short)
+        expected_end = subject.expected_end.to_formatted_s(:short)
         expected_cluster_dashboard_url =
           Rails.application.routes.url_helpers.cluster_maintenance_windows_url(
             subject.component.cluster
@@ -104,7 +103,7 @@ RSpec.describe MaintenanceWindow, type: :model do
         user = create(:user, name: 'some_user')
 
         expected_start = subject.requested_start.to_formatted_s(:short)
-        expected_end = subject.requested_end.to_formatted_s(:short)
+        expected_end = subject.expected_end.to_formatted_s(:short)
         text_regex = Regexp.new <<~REGEX.squish
           maintenance.*some_component.*confirmed by
           some_user.*scheduled.*#{expected_start}.*#{expected_end}
@@ -150,7 +149,7 @@ RSpec.describe MaintenanceWindow, type: :model do
       it 'has RT ticket comment added when started' do
         subject.component = create(:component, name: 'some_component')
 
-        expected_end = subject.requested_end.to_formatted_s(:short)
+        expected_end = subject.expected_end.to_formatted_s(:short)
         text_regex = Regexp.new <<~REGEX.squish
           maintenance of some_component .* started.*this component.*under
           maintenance until #{expected_end}

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -263,17 +263,6 @@ RSpec.describe MaintenanceWindow, type: :model do
       request_transition = window.transitions.where(event: :request).first
       expect(request_transition.requested_start).to eq(new_requested_start)
     end
-
-    it 'tracks requested_end in transitions' do
-      window = create(:maintenance_window, requested_end: 1.days.from_now)
-
-      new_requested_end = 2.days.from_now.at_midnight
-      window.requested_end = new_requested_end
-      window.request!(create(:admin))
-
-      request_transition = window.transitions.where(event: :request).first
-      expect(request_transition.requested_end).to eq(new_requested_end)
-    end
   end
 
   describe '#expected_end' do

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -277,6 +277,32 @@ RSpec.describe MaintenanceWindow, type: :model do
     end
   end
 
+  describe '#expected_end' do
+    let :monday { DateTime.new(2025, 3, 24, 9, 0) }
+    let :wednesday { monday.advance(days: 2) }
+    let :following_monday { monday.advance(weeks: 1) }
+
+    it 'gives expected end date calculated from requested_start and duration' do
+      window = create(
+        :maintenance_window,
+        requested_start: monday,
+        duration: 2
+      )
+
+      expect(window.expected_end).to eq(wednesday)
+    end
+
+    it 'only includes business days in calculation' do
+      window = create(
+        :maintenance_window,
+        requested_start: monday,
+        duration: 5
+      )
+
+      expect(window.expected_end).to eq(following_monday)
+    end
+  end
+
   describe '#method_missing' do
     describe '#*_at' do
       it 'returns time transition occurred for valid state' do

--- a/spec/services/progress_maintenance_window_spec.rb
+++ b/spec/services/progress_maintenance_window_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ProgressMaintenanceWindow do
         :maintenance_window,
         state: state,
         requested_start: requested_start,
-        requested_end: requested_end,
+        duration: 1,
         component: component,
         id: 123
       )
@@ -74,7 +74,7 @@ RSpec.describe ProgressMaintenanceWindow do
 
     def test_progression_message(message:, window:, expected:)
       start_date = window.requested_start.to_formatted_s(:short)
-      end_date = window.requested_end.to_formatted_s(:short)
+      end_date = window.expected_end.to_formatted_s(:short)
       full_expected_message = <<~EOF.squish
         Maintenance window #{window.id} (#{component.name} | #{start_date} -
         #{end_date}): #{expected}
@@ -86,16 +86,14 @@ RSpec.describe ProgressMaintenanceWindow do
       create(:component, name: 'somenode')
     end
 
-    context 'when requested_start and requested_end in future' do
+    context 'when requested_start and expected_end in future' do
       let :requested_start { DateTime.current.advance(days: 1) }
-      let :requested_end { DateTime.current.advance(days: 2) }
 
       include_examples 'does not progress', MaintenanceWindow.possible_states
     end
 
     context 'when just requested_start passed' do
       let :requested_start { 1.hours.ago }
-      let :requested_end { DateTime.current.advance(days: 1) }
 
       include_examples 'progresses unstarted windows'
 
@@ -103,11 +101,10 @@ RSpec.describe ProgressMaintenanceWindow do
       include_examples 'does not progress', other_states
     end
 
-    context 'when requested_start and requested_end passed' do
-      let :requested_start { 2.hours.ago }
-      let :requested_end { 1.hours.ago }
+    context 'when requested_start and expected_end passed' do
+      let :requested_start { 2.days.ago }
 
-      # If both `requested_start` and `requested_end` have passed and a window
+      # If both `requested_start` and `expected_end` have passed and a window
       # has still not transitioned from an unstarted state (e.g. if the
       # maintenance period is very short or we have not progressed
       # MaintenanceWindows for a while for some reason), then we still want to

--- a/spec/services/progress_maintenance_window_spec.rb
+++ b/spec/services/progress_maintenance_window_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe ProgressMaintenanceWindow do
     end
 
     context 'when requested_start and expected_end passed' do
-      let :requested_start { 2.days.ago }
+      let :requested_start { 7.days.ago }
 
       # If both `requested_start` and `expected_end` have passed and a window
       # has still not transitioned from an unstarted state (e.g. if the


### PR DESCRIPTION
This PR is the first step towards changing the time slot for a MaintenanceWindow from being specified as a `requested_start` and `requested_end` to being specified by a `requested_start` and a `duration` (in days). The maintenance should then last from `requested_start` until `duration` business days later, with only the former value being changeable by Site contacts when they confirm maintenance (so we always have the number of days we request to carry out maintenance).

This PR consists of most steps to remove/update our usage of `requested_end` and replace it with `duration` instead; updating the actual maintenance form to reflect this change is still to come.

Trello: https://trello.com/c/74FbrsaD/200-change-maintenance-form-to-show-requested-start-and-duration.