### PR TITLE
Allow specifying maintenance durations in form; remove requested_end

### DIFF
--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -53,6 +53,7 @@ class MaintenanceWindowsController < ApplicationController
     :case_id,
     :requested_start,
     :requested_end,
+    :duration,
   ].freeze
 
   CONFIRM_PARAM_NAMES = [
@@ -61,8 +62,7 @@ class MaintenanceWindowsController < ApplicationController
   ].freeze
 
   def request_maintenance_window_params
-    # XXX Get duration from request.
-    params.require(:maintenance_window).permit(REQUEST_PARAM_NAMES).merge(duration: 1)
+    params.require(:maintenance_window).permit(REQUEST_PARAM_NAMES)
   end
 
   def confirm_maintenance_window_params

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -5,7 +5,6 @@ class MaintenanceWindowsController < ApplicationController
       component_id: params[:component_id],
       service_id: params[:service_id],
       requested_start: suggested_requested_start,
-      requested_end: suggested_requested_end,
     )
   end
 
@@ -52,13 +51,11 @@ class MaintenanceWindowsController < ApplicationController
     :service_id,
     :case_id,
     :requested_start,
-    :requested_end,
     :duration,
   ].freeze
 
   CONFIRM_PARAM_NAMES = [
     :requested_start,
-    :requested_end,
   ].freeze
 
   def request_maintenance_window_params
@@ -71,10 +68,6 @@ class MaintenanceWindowsController < ApplicationController
 
   def suggested_requested_start
     1.day.from_now.at_midnight
-  end
-
-  def suggested_requested_end
-    suggested_requested_start.advance(days: 1)
   end
 
   # XXX if we changed `request` to be accessed at `/request` (rather than

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -3,10 +3,7 @@ class MaintenanceWindowsController < ApplicationController
 
   def new
     @maintenance_window = MaintenanceWindow.new(
-      cluster_id: params[:cluster_id],
-      component_id: params[:component_id],
-      service_id: params[:service_id],
-      requested_start: suggested_requested_start,
+      default_maintenance_window_params
     )
   end
 
@@ -60,6 +57,16 @@ class MaintenanceWindowsController < ApplicationController
     :requested_start,
   ].freeze
 
+  def default_maintenance_window_params
+    {
+      cluster_id: params[:cluster_id],
+      component_id: params[:component_id],
+      service_id: params[:service_id],
+      requested_start: default_requested_start,
+      duration: 1,
+    }
+  end
+
   def request_maintenance_window_params
     params.require(:maintenance_window).permit(REQUEST_PARAM_NAMES)
   end
@@ -68,8 +75,9 @@ class MaintenanceWindowsController < ApplicationController
     params.require(:maintenance_window).permit(CONFIRM_PARAM_NAMES)
   end
 
-  def suggested_requested_start
-    1.day.from_now.at_midnight
+  def default_requested_start
+    # Default is 9am on next business day.
+    1.business_day.from_now.at_beginning_of_day.advance(hours: 9)
   end
 
   # XXX if we changed `request` to be accessed at `/request` (rather than

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,4 +1,6 @@
 class MaintenanceWindowsController < ApplicationController
+  decorates_assigned :maintenance_window
+
   def new
     @maintenance_window = MaintenanceWindow.new(
       cluster_id: params[:cluster_id],

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -43,6 +43,20 @@ class ApplicationDecorator < Draper::Decorator
     []
   end
 
+  def bootstrap_valid_class(field_name)
+    errors[field_name].any? ? 'is-invalid' : 'is-valid'
+  end
+
+  def invalid_feedback_div(field_name)
+    h.raw(
+      [
+        '<div class="invalid-feedback">',
+        errors[field_name].join('; ').capitalize,
+        '</div>',
+      ].join
+    )
+  end
+
   private
 
   def internal_icon

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -27,6 +27,25 @@ class MaintenanceWindowDecorator < ApplicationDecorator
     h.send(path_method, self, associated_model_id_param => associated_model.id)
   end
 
+  def case_attributes(form_action)
+    {
+      class: ['form-control is-valid'],
+      'data-test': 'case-select',
+    }.merge(
+      conditional_attributes(action: form_action, field: 'Case')
+    )
+  end
+
+  def duration_attributes(form_action)
+    {
+      min: 1,
+      class: ['form-control'],
+      required: true,
+    }.merge(
+      conditional_attributes(action: form_action, field: 'duration')
+    )
+  end
+
   private
 
   def scheduled_period_state_indicator
@@ -51,5 +70,16 @@ class MaintenanceWindowDecorator < ApplicationDecorator
 
   def format(date_time)
     date_time.to_formatted_s(:short)
+  end
+
+  def conditional_attributes(action:, field:)
+    if action.confirm?
+      {
+        disabled: true,
+        title: "The #{field} this maintenance has been requested for cannot be changed"
+      }
+    else
+      {}
+    end
   end
 end

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -37,10 +37,9 @@ class MaintenanceWindowDecorator < ApplicationDecorator
   end
 
   def duration_attributes(form_action)
-    valid_class = model.errors[:duration].any? ? 'is-invalid' : 'is-valid'
     {
       min: 1,
-      class: ["form-control #{valid_class}"],
+      class: ["form-control #{bootstrap_valid_class(:duration)}"],
       required: true,
     }.merge(
       conditional_attributes(action: form_action, field: 'duration')

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -37,9 +37,10 @@ class MaintenanceWindowDecorator < ApplicationDecorator
   end
 
   def duration_attributes(form_action)
+    valid_class = model.errors[:duration].any? ? 'is-invalid' : 'is-valid'
     {
       min: 1,
-      class: ['form-control'],
+      class: ["form-control #{valid_class}"],
       required: true,
     }.merge(
       conditional_attributes(action: form_action, field: 'duration')

--- a/app/helpers/date_time_select_helper.rb
+++ b/app/helpers/date_time_select_helper.rb
@@ -63,7 +63,7 @@ module DateTimeSelectHelper
     end
 
     def valid_class
-      model.errors[datetime_field_name].any? ? 'is-invalid' : 'is-valid'
+      model.bootstrap_valid_class(datetime_field_name)
     end
 
     def field_name(select_name)

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -40,6 +40,16 @@
       ) %>
     </div>
 
+    <div class="form-group">
+      <%= f.label(:duration, 'Duration (in business days)') %>
+      <%= f.number_field(
+        :duration,
+        min: 1,
+        class: ['form-control'],
+        required: true
+      ) %>
+    </div>
+
     <%= render 'partials/date_time_select',
       model: maintenance_window,
       datetime_field_name: 'requested_start'

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -36,9 +36,7 @@
         :duration,
         maintenance_window.duration_attributes(action)
       ) %>
-      <div class="invalid-feedback">
-        <%= maintenance_window.errors[:duration].join('; ').capitalize %>
-      </div>
+      <%= maintenance_window.invalid_feedback_div(:duration) %>
     </div>
 
     <%= render 'partials/date_time_select',

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -3,7 +3,7 @@
   raise "Unknown action: #{action}" unless [:request, :confirm].include?(action)
   action = action.to_s.inquiry
 
-  case_label, conditional_case_attributes =
+  case_label, conditional_case_attributes, conditional_duration_attributes =
     if action.confirm?
       [
         'Associated Case',
@@ -11,9 +11,13 @@
           disabled: true,
           title: 'The Case this maintenance has been requested for cannot be changed'
         },
+        {
+          disabled: true,
+          title: 'The duration this maintenance has been requested for cannot be changed'
+        },
       ]
     else
-      ['Case to associate this maintenance with', {}]
+      ['Case to associate this maintenance with', {}, {}]
     end
 %>
 
@@ -40,13 +44,15 @@
       ) %>
     </div>
 
-    <div class="form-group">
+    <div class="form-group" data-test="duration-input-group">
       <%= f.label(:duration, 'Duration (in business days)') %>
       <%= f.number_field(
         :duration,
-        min: 1,
-        class: ['form-control'],
-        required: true
+        {
+          min: 1,
+          class: ['form-control'],
+          required: true,
+        }.merge(conditional_duration_attributes)
       ) %>
     </div>
 

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -13,7 +13,7 @@
 <%= render 'partials/tabs', activate: :maintenance do %>
   <%= form_for maintenance_window,
     url: request.original_fullpath,
-    html: { novalidate: true, class: 'card-body' } do |f| %>
+    html: { class: 'card-body' } do |f| %>
     <%= f.hidden_field :cluster_id %>
     <%= f.hidden_field :component_id %>
     <%= f.hidden_field :service_id %>

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -3,22 +3,11 @@
   raise "Unknown action: #{action}" unless [:request, :confirm].include?(action)
   action = action.to_s.inquiry
 
-  case_label, conditional_case_attributes, conditional_duration_attributes =
-    if action.confirm?
-      [
-        'Associated Case',
-        {
-          disabled: true,
-          title: 'The Case this maintenance has been requested for cannot be changed'
-        },
-        {
-          disabled: true,
-          title: 'The duration this maintenance has been requested for cannot be changed'
-        },
-      ]
-    else
-      ['Case to associate this maintenance with', {}, {}]
-    end
+  case_label = if action.confirm?
+                 'Associated Case'
+               else
+                 'Case to associate this maintenance with'
+               end
 %>
 
 <%= render 'partials/tabs', activate: :maintenance do %>
@@ -37,10 +26,7 @@
         :id,
         :case_select_details,
         {},
-        {
-          class: ['form-control is-valid'],
-          'data-test': 'case-select',
-        }.merge(conditional_case_attributes)
+        maintenance_window.case_attributes(action)
       ) %>
     </div>
 
@@ -48,11 +34,7 @@
       <%= f.label(:duration, 'Duration (in business days)') %>
       <%= f.number_field(
         :duration,
-        {
-          min: 1,
-          class: ['form-control'],
-          required: true,
-        }.merge(conditional_duration_attributes)
+        maintenance_window.duration_attributes(action)
       ) %>
     </div>
 

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -36,6 +36,9 @@
         :duration,
         maintenance_window.duration_attributes(action)
       ) %>
+      <div class="invalid-feedback">
+        <%= maintenance_window.errors[:duration].join('; ').capitalize %>
+      </div>
     </div>
 
     <%= render 'partials/date_time_select',

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -54,10 +54,6 @@
       model: maintenance_window,
       datetime_field_name: 'requested_start'
     %>
-    <%= render 'partials/date_time_select',
-      model: maintenance_window,
-      datetime_field_name: 'requested_end'
-    %>
 
     <%= f.submit "#{action.titlecase} Maintenance",
       class: 'btn btn-primary btn-block'

--- a/app/views/maintenance_windows/confirm.html.erb
+++ b/app/views/maintenance_windows/confirm.html.erb
@@ -1,5 +1,5 @@
 <% content_for :subtitle { 'Confirm Maintenance' } %>
 <%= render 'maintenance_windows/form',
-  maintenance_window: @maintenance_window,
+  maintenance_window: maintenance_window,
   action: :confirm
 %>

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :subtitle { 'Request Maintenance' } %>
 <%= render 'maintenance_windows/form',
-  maintenance_window: @maintenance_window,
+  maintenance_window: maintenance_window,
   action: :request
 %>

--- a/app/views/partials/_date_time_select.html.erb
+++ b/app/views/partials/_date_time_select.html.erb
@@ -28,8 +28,6 @@
       https://github.com/twbs/bootstrap/issues/23454).
     %>
     <input class="form-control is-invalid" type="hidden"/>
-    <div class="invalid-feedback">
-      <%= model.errors[datetime_field_name].join('; ').capitalize %>
-    </div>
+    <%= model.invalid_feedback_div(datetime_field_name) %>
   </div>
 </div>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,10 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+# Remove default `field_with_errors` wrapper Rails puts around form
+# helper-generated inputs for fields with errors (see
+# https://coderwall.com/p/s-zwrg/remove-rails-field_with_errors-wrapper).
+ActionView::Base.field_error_proc = Proc.new do |html_tag, _instance|
+  html_tag.html_safe
+end

--- a/db/migrate/20180323182505_remove_maintenance_window_requested_end.rb
+++ b/db/migrate/20180323182505_remove_maintenance_window_requested_end.rb
@@ -1,0 +1,7 @@
+class RemoveMaintenanceWindowRequestedEnd < ActiveRecord::Migration[5.1]
+  def change
+    [:maintenance_windows, :maintenance_window_state_transitions].each do |table|
+      remove_column table, :requested_end, :timestamp
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180323140700) do
+ActiveRecord::Schema.define(version: 20180323182505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -212,7 +212,6 @@ ActiveRecord::Schema.define(version: 20180323140700) do
     t.string "to", null: false
     t.bigint "user_id"
     t.datetime "requested_start"
-    t.datetime "requested_end"
     t.index ["maintenance_window_id"], name: "index_mwst_on_mw_id"
     t.index ["user_id"], name: "index_maintenance_window_state_transitions_on_user_id"
   end
@@ -229,7 +228,6 @@ ActiveRecord::Schema.define(version: 20180323140700) do
     t.bigint "service_id"
     t.text "state", default: "new", null: false
     t.datetime "requested_start"
-    t.datetime "requested_end"
     t.integer "duration"
     t.index ["case_id"], name: "index_maintenance_windows_on_case_id"
     t.index ["cluster_id"], name: "index_maintenance_windows_on_cluster_id"

--- a/spec/factories/maintenance_window.rb
+++ b/spec/factories/maintenance_window.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     add_attribute(:case) { create(:case) } # Avoid conflict with case keyword.
     created_at 7.days.ago
     requested_start 1.days.from_now.at_midnight
-    requested_end 2.days.from_now.at_midnight
     duration 1
 
     # This could also be a Cluster or Service; but one of these must be
@@ -47,7 +46,6 @@ FactoryBot.define do
 
       after(:create) do |window|
         window.requested_start = 2.days.ago.at_midnight
-        window.requested_end = 1.days.ago.at_midnight
         window.expire!
       end
     end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -150,6 +150,7 @@ RSpec.feature "Maintenance windows", type: :feature do
 
       it 'can request maintenance in association with any Case for Cluster' do
         select cluster_case.subject
+        fill_in 'Duration', with: 2
         fill_in_datetime_selects 'requested-start', with: valid_requested_start
         fill_in_datetime_selects 'requested-end', with: valid_requested_end
         click_button 'Request Maintenance'
@@ -157,6 +158,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         new_window = cluster_case.maintenance_windows.first
         expect(new_window).to be_requested
         expect(new_window.requested_by).to eq user
+        expect(new_window.duration).to eq 2
         expect(new_window.requested_start).to eq valid_requested_start
         expect(new_window.requested_end).to eq valid_requested_end
         expect(current_path).to eq(cluster_maintenance_windows_path(cluster))

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -47,13 +47,20 @@ RSpec.shared_examples 'confirmation form' do
     case_select = test_element('case-select')
 
     expect(case_select).to be_disabled
-    expect(case_select[:title]).to match(/cannot be changed/)
+    expect(case_select[:title]).to match(/Case.*cannot be changed/)
   end
 
   it 'includes correct Case select label' do
     case_select_label = test_element('case-select-label')
 
     expect(case_select_label).to have_text(/Associated Case/)
+  end
+
+  it 'cannot change duration for requested maintenance' do
+    duration_input = test_element('duration-input-group').find('input')
+
+    expect(duration_input).to be_disabled
+    expect(duration_input[:title]).to match(/duration.*cannot be changed/)
   end
 
   it 'can confirm requested maintenance' do

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -26,7 +26,7 @@ end
 
 RSpec.shared_examples 'maintenance form initially valid' do
   it 'does not initially have invalid elements' do
-    [requested_start_element, requested_end_element].each do |element|
+    [requested_start_element].each do |element|
       expect(element).not_to have_selector('select', class: 'is-invalid')
     end
   end
@@ -58,14 +58,12 @@ RSpec.shared_examples 'confirmation form' do
 
   it 'can confirm requested maintenance' do
     fill_in_datetime_selects 'requested-start', with: valid_requested_start
-    fill_in_datetime_selects 'requested-end', with: valid_requested_end
     click_button 'Confirm Maintenance'
 
     window.reload
     expect(window).to be_confirmed
     expect(window.confirmed_by).to eq user
     expect(window.requested_start).to eq valid_requested_start
-    expect(window.requested_end).to eq valid_requested_end
     confirmed_transition = window.transitions.find_by_to(:confirmed)
     expect(confirmed_transition.requested_start).to eq valid_requested_start
     expect(current_path).to eq(cluster_maintenance_windows_path(cluster))
@@ -79,7 +77,6 @@ RSpec.feature "Maintenance windows", type: :feature do
   let :cluster { support_case.cluster }
   let :site { support_case.site }
 
-  let :valid_requested_end { DateTime.new(2023, 9, 20, 13, 0) }
   let :valid_requested_start { DateTime.new(2022, 9, 10, 13, 0) }
 
   before :each do
@@ -102,10 +99,6 @@ RSpec.feature "Maintenance windows", type: :feature do
 
   def requested_start_element
     test_element(:requested_start)
-  end
-
-  def requested_end_element
-    test_element(:requested_end)
   end
 
   context 'when user is an admin' do
@@ -152,7 +145,6 @@ RSpec.feature "Maintenance windows", type: :feature do
         select cluster_case.subject
         fill_in 'Duration', with: 2
         fill_in_datetime_selects 'requested-start', with: valid_requested_start
-        fill_in_datetime_selects 'requested-end', with: valid_requested_end
         click_button 'Request Maintenance'
 
         new_window = cluster_case.maintenance_windows.first
@@ -160,7 +152,6 @@ RSpec.feature "Maintenance windows", type: :feature do
         expect(new_window.requested_by).to eq user
         expect(new_window.duration).to eq 2
         expect(new_window.requested_start).to eq valid_requested_start
-        expect(new_window.requested_end).to eq valid_requested_end
         expect(current_path).to eq(cluster_maintenance_windows_path(cluster))
         expect(find('.alert')).to have_text(/Maintenance requested/)
       end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.shared_examples 'maintenance form error handling' do |form_action|
-  it 're-renders form with error when invalid date entered' do
+  it 're-renders form with error when invalid requested_start entered' do
     original_path = current_path
     requested_start_in_past = DateTime.new(2016, 9, 20, 13)
 
@@ -18,9 +18,8 @@ RSpec.shared_examples 'maintenance form error handling' do |form_action|
     invalidated_selects =
       requested_start_element.all('select', class: 'is-invalid')
     expect(invalidated_selects.length).to eq(5)
-    expect(requested_start_element.find('.invalid-feedback')).to have_text(
-      'Cannot be in the past'
-    )
+    invalid_feedback = requested_start_element.find('.invalid-feedback')
+    expect(invalid_feedback).to have_text('Cannot be in the past')
   end
 end
 


### PR DESCRIPTION
This PR completes https://trello.com/c/74FbrsaD/200-change-maintenance-form-to-show-requested-start-and-duration, by removing the `requested_end` field entirely and allowing setting maintenance `duration`s from the maintenance form.

Based on #136.