### PR TITLE
Standardize the (sub)titles across the pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,8 @@ class ApplicationController < ActionController::Base
 
   before_action :set_sentry_raven_context
   before_action :assign_current_user
-  before_action :define_navigation_variables
+  before_action :assign_scope
+  before_action :assign_title
 
   rescue_from ReadPermissionsError, with: :not_found
 
@@ -42,7 +43,7 @@ class ApplicationController < ActionController::Base
     params[id_method] || params[:id]
   end
 
-  def define_navigation_variables
+  def assign_scope
     return unless current_user
 
     @scope = case request.path
@@ -66,6 +67,10 @@ class ApplicationController < ActionController::Base
                          current_user.site
                        end
              end
+  end
+
+  def assign_title
+    @title = "Management Dashboard - #{@scope.name}" if @scope
   end
 
   def format_errors(model)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,7 +70,12 @@ class ApplicationController < ActionController::Base
   end
 
   def assign_title
-    @title = "Management Dashboard - #{@scope.name}" if @scope
+    if @scope
+      @title = <<~EOF.squish
+        #{@scope.readable_model_name.split.map(&:capitalize).join(' ')}
+        Dashboard - #{@scope.name}
+      EOF
+    end
   end
 
   def format_errors(model)

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -1,7 +1,6 @@
 class AssetRecordsController < ApplicationController
   def edit
     @asset = asset
-    @title = "Edit Asset Record"
   end
 
   def update

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -5,19 +5,15 @@ class CasesController < ApplicationController
 
   def index
     @site = current_site
-    @title = 'Manage support cases'
     @archive = archive?
     current_site.cases.map(&:update_ticket_status!) if current_user.admin?
   end
 
   def show
     @case = Case.find(params[:id]).decorate
-    @title = "Support case: #{@case.subject}"
   end
 
   def new
-    @title = "Create new support case"
-
     cluster_id = params[:cluster_id]
     component_id = params[:component_id]
     service_id = params[:service_id]

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -3,7 +3,6 @@ class ClustersController < ApplicationController
 
   def show
     @cluster = Cluster.find(params[:id])
-    @title = "#{@cluster.name} Management Dashboard"
 
     support_type = case @cluster.support_type.to_sym
                    when :managed

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -1,15 +1,5 @@
 class ClustersController < ApplicationController
   decorates_assigned :cluster
 
-  def show
-    @cluster = Cluster.find(params[:id])
-
-    support_type = case @cluster.support_type.to_sym
-                   when :managed
-                     'Managed'
-                   when :advice
-                     'Self-managed'
-                   end
-    @subtitle = "#{support_type} cluster"
-  end
+  def show; end
 end

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -1,5 +1,3 @@
 class ClustersController < ApplicationController
   decorates_assigned :cluster
-
-  def show; end
 end

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -12,8 +12,6 @@ class ComponentExpansionsController < ApplicationController
     redirect_back fallback_location: @cluster_part
   end
 
-  def edit; end
-
   def update
     @cluster_part.component_expansions.each do |expansion|
       new_params = update_expansion_param expansion

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -12,9 +12,7 @@ class ComponentExpansionsController < ApplicationController
     redirect_back fallback_location: @cluster_part
   end
 
-  def edit
-    @title = "Edit Expansions"
-  end
+  def edit; end
 
   def update
     @cluster_part.component_expansions.each do |expansion|

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -2,13 +2,11 @@ class ComponentsController < ApplicationController
   decorates_assigned :component
 
   def index
-    @title = 'Components'
     @table_tile = 'All Components' # Consider removing
     @component_groups = component_groups_from_type
   end
 
   def show
-    @title = "#{@component.name} Management Dashboard"
     @subtitle = @component.component_type.name
   end
 

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -6,9 +6,7 @@ class ComponentsController < ApplicationController
     @component_groups = component_groups_from_type
   end
 
-  def show
-    @subtitle = @component.component_type.name
-  end
+  def show; end
 
   private
 

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -6,8 +6,6 @@ class ComponentsController < ApplicationController
     @component_groups = component_groups_from_type
   end
 
-  def show; end
-
   private
 
   def component_groups_from_type

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -3,10 +3,20 @@ class ComponentsController < ApplicationController
 
   def index
     @table_tile = 'All Components' # Consider removing
-    @component_groups = component_groups_from_type
+    define_variables_from_type
   end
 
   private
+
+  def define_variables_from_type
+    @component_groups = component_groups_from_type
+    @type = parse_type
+  end
+
+  def parse_type
+    raw = type_param[:type]
+    raw.present? ? raw : 'All'
+  end
 
   def component_groups_from_type
     if @scope.is_a? ComponentGroup

--- a/app/controllers/consultancy_controller.rb
+++ b/app/controllers/consultancy_controller.rb
@@ -1,7 +1,5 @@
 class ConsultancyController < ApplicationController
   def new
-    @title = 'Request custom consultancy'
-
     @case = Case.new(
       cluster_id: params[:cluster_id],
       component_id: params[:component_id],

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,6 +1,5 @@
 class LogsController < ApplicationController
   def index
-    @title = 'Logs'
     @new_log = Log.new
     @scope = @component || @cluster
     @logs = @scope.logs

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,11 +1,7 @@
 class MaintenanceWindowsController < ApplicationController
-  def index
-    @title = 'Maintenance'
-  end
+  def index; end
 
   def new
-    assign_new_maintenance_title
-
     @maintenance_window = MaintenanceWindow.new(
       cluster_id: params[:cluster_id],
       component_id: params[:component_id],
@@ -16,8 +12,6 @@ class MaintenanceWindowsController < ApplicationController
   end
 
   def create
-    assign_new_maintenance_title
-
     handle_form_submission(action: :request, template: :new) do
       @maintenance_window = MaintenanceWindow.new(request_maintenance_window_params)
       ActiveRecord::Base.transaction do
@@ -74,10 +68,6 @@ class MaintenanceWindowsController < ApplicationController
 
   def confirm_maintenance_window_params
     params.require(:maintenance_window).permit(CONFIRM_PARAM_NAMES)
-  end
-
-  def assign_new_maintenance_title
-    @title = 'Request Maintenance'
   end
 
   def suggested_requested_start

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,6 +1,4 @@
 class MaintenanceWindowsController < ApplicationController
-  def index; end
-
   def new
     @maintenance_window = MaintenanceWindow.new(
       cluster_id: params[:cluster_id],

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,7 +1,4 @@
 class ServicesController < ApplicationController
   decorates_assigned :service
-
-  def index; end
-  def show; end
 end
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -2,14 +2,6 @@ class ServicesController < ApplicationController
   decorates_assigned :service
 
   def index; end
-
-  def show
-    @service = Service.find(params[:id])
-
-    # Show ServiceType name as subtitle, unless this is the same name as the
-    # Service and therefore uninteresting.
-    service_type = @service.service_type.name
-    same_name_as_service = service_type == @service.name
-    @subtitle = service_type unless same_name_as_service
-  end
+  def show; end
 end
+

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,13 +1,10 @@
 class ServicesController < ApplicationController
   decorates_assigned :service
 
-  def index
-    @title = 'Services'
-  end
+  def index; end
 
   def show
     @service = Service.find(params[:id])
-    @title = "#{@service.name} Dashboard"
 
     # Show ServiceType name as subtitle, unless this is the same name as the
     # Service and therefore uninteresting.

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,6 +3,4 @@ class SitesController < ApplicationController
     @title = 'Alces Admin Sites Dashboard'
     @sites = Site.all
   end
-
-  def show; end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -5,7 +5,6 @@ class SitesController < ApplicationController
   end
 
   def show
-    @title = "#{@site.name} Management Dashboard"
     @subtitle = "Welcome #{current_user.name}"
   end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -4,7 +4,5 @@ class SitesController < ApplicationController
     @sites = Site.all
   end
 
-  def show
-    @subtitle = "Welcome #{current_user.name}"
-  end
+  def show; end
 end

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -14,7 +14,7 @@ module TabsHelper
         id: :cases, path: scope_path('cases'),
         dropdown: [
           { text: 'Current', path: scope_path('cases') },
-          { text: 'Archive', path: scope_path('cases') }
+          { text: 'Archive', path: scope_path('cases', archive: true) }
         ]
       }
     end
@@ -27,11 +27,11 @@ module TabsHelper
 
     attr_reader :scope, :h
 
-    def scope_path(method = nil)
+    def scope_path(method = nil, **hash_params)
       method_string = [
         scope.class.name.underscore, method, 'path'
       ].reject(&:nil?).join('_')
-      h.send(method_string, scope)
+      h.send(method_string, scope, **hash_params)
     end
   end
 end

--- a/app/views/asset_records/edit.html.erb
+++ b/app/views/asset_records/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for :subtitle { 'Edit Asset Record' } %>
 <%= render 'partials/tabs', activate: :asset_record do %>
   <%= form_tag @scope.decorate.asset_record_path, method: 'PATCH' do %>
     <%= render 'partials/asset_record_table',

--- a/app/views/asset_records/show.html.erb
+++ b/app/views/asset_records/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :subtitle { 'View Asset Record' } %>
 <%= render 'partials/tabs', activate: :asset_record do %>
   <% if current_user.admin? %>
     <div class='nav nav-tabs nav-justified'>

--- a/app/views/asset_records/show.html.erb
+++ b/app/views/asset_records/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :subtitle { 'View Asset Record' } %>
+<% content_for :subtitle { 'Asset Record' } %>
 <%= render 'partials/tabs', activate: :asset_record do %>
   <% if current_user.admin? %>
     <div class='nav nav-tabs nav-justified'>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,5 +1,7 @@
 <% manage_cases_page = current_user.admin? && @archive %>
-
+<%= content_for :subtitle do
+  "#{@archive ? 'Archived' : 'Current'} Cases"
+end %>
 <%= render 'partials/tabs', activate: :cases do %>
   <ul class='nav nav-tabs nav-justified' >
     <%= @scope.decorate.case_form_buttons %>

--- a/app/views/cases/new.html.erb
+++ b/app/views/cases/new.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Open New Support Case' } %>
 <%= render 'partials/tabs', activate: :cases do %>
   <div class='card-body'>
     <%= new_case_form(clusters: @clusters, single_part: @single_part) %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Support Case' } %>
 <div class='card'>
   <%= render 'partials/card_header_nav',
     title: 'Overview'

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Cluster Overview' } %>
 <%= render 'partials/tabs', activate: :overview do %>
   <%= render 'clusters/details', cluster: cluster %>
 <% end %>

--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :subtitle { 'Cluster Overview' } %>
+<% content_for :subtitle { 'Overview' } %>
 <%= render 'partials/tabs', activate: :overview do %>
   <%= render 'clusters/details', cluster: cluster %>
 <% end %>

--- a/app/views/component_expansions/edit.html.erb
+++ b/app/views/component_expansions/edit.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Edit/Update/Delete Expansions' } %>
 <%= render 'partials/tabs', activate: :expansions do %>
   <%= render('partials/card_header_nav', title: 'New Expansion') %>
   <div class='card-block'>

--- a/app/views/component_expansions/index.html.erb
+++ b/app/views/component_expansions/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :subtitle { 'View Expansions' } %>
 <%= render 'partials/tabs', activate: :expansions do %>
   <% if current_user.admin? %>
     <div class='nav nav-tabs nav-justified'>

--- a/app/views/component_expansions/index.html.erb
+++ b/app/views/component_expansions/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :subtitle { 'View Expansions' } %>
+<% content_for :subtitle { 'Expansions' } %>
 <%= render 'partials/tabs', activate: :expansions do %>
   <% if current_user.admin? %>
     <div class='nav nav-tabs nav-justified'>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :subtitle { 'View Components' } %>
+<% content_for :subtitle { 'Components' } %>
 <%= render 'partials/tabs', activate: :components do %>
   <div class='card-body'>
     <% @component_groups.each do |group| %>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,4 +1,6 @@
-<% content_for :subtitle { 'Components' } %>
+<% content_for :subtitle do
+     'Components'.tap { |s| s << " - #{@type}" if @type.present? }
+   end %>
 <%= render 'partials/tabs', activate: :components do %>
   <div class='card-body'>
     <% @component_groups.each do |group| %>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'View Components' } %>
 <%= render 'partials/tabs', activate: :components do %>
   <div class='card-body'>
     <% @component_groups.each do |group| %>

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :subtitle { 'Component Overview' } %>
 <%= render 'partials/tabs', activate: :overview do %>
   <ul class="list-group list-group-flush">
     <li class="list-group-item">

--- a/app/views/components/show.html.erb
+++ b/app/views/components/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :subtitle { 'Component Overview' } %>
+<% content_for :subtitle { 'Overview' } %>
 <%= render 'partials/tabs', activate: :overview do %>
   <ul class="list-group list-group-flush">
     <li class="list-group-item">

--- a/app/views/consultancy/new.html.erb
+++ b/app/views/consultancy/new.html.erb
@@ -1,5 +1,5 @@
-
 <% cluster = @case.cluster %>
+<% content_for :subtitle { 'Request Consultancy' } %>
 <% if cluster.charging_info %>
   <div class="alert alert-warning">
     <p><strong><%= cluster.name %> charging info</strong></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,10 +34,7 @@
               <div class="col"></div>
               <div class="col-8">
                 <h1 class="display-4"><%= @title %></h1>
-                <% subtitle = yield :subtitle %>
-                <% if subtitle.present? %>
-                  <p class="lead"><%= subtitle %></p>
-                <% end %>
+                <p class="lead"><%= yield :subtitle %></p>
               </div>
               <div class="col"></div>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,8 +34,9 @@
               <div class="col"></div>
               <div class="col-8">
                 <h1 class="display-4"><%= @title %></h1>
-                <% if @subtitle %>
-                  <p class="lead"><%= @subtitle %></p>
+                <% subtitle = yield :subtitle %>
+                <% if subtitle.present? %>
+                  <p class="lead"><%= subtitle %></p>
                 <% end %>
               </div>
               <div class="col"></div>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :subtitle { 'View Logs' } %>
+<% content_for :subtitle { 'Logs' } %>
 <%= render 'partials/tabs', activate: :logs do %>
   <div class='table-responsive'>
     <table class='table'>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'View Logs' } %>
 <%= render 'partials/tabs', activate: :logs do %>
   <div class='table-responsive'>
     <table class='table'>

--- a/app/views/maintenance_windows/confirm.html.erb
+++ b/app/views/maintenance_windows/confirm.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Confirm Maintenance' } %>
 <%= render 'maintenance_windows/form',
   maintenance_window: @maintenance_window,
   action: :confirm

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Existing Maintenance' } %>
 <%= render 'partials/tabs', activate: :maintenance do %>
   <div class='table-responsive'>
     <table class="maintenance table">

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Request Maintenance' } %>
 <%= render 'maintenance_windows/form',
   maintenance_window: @maintenance_window,
   action: :request

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'Services' } %>
 <%= render 'partials/tabs', activate: :services do %>
   <div class='table-responsive'>
     <table class='table'>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :subtitle { 'Overview' } %>
 <%= render 'partials/tabs', activate: :overview do %>
   <ul class="list-group list-group-flush">
     <li class="list-group-item">

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,4 +1,4 @@
-
+<% content_for :subtitle { 'All Sites' } %>
 <div class='card'>
   <div class='card-header'>
     <ul class="nav">

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,4 +1,3 @@
-
 <% content_for :subtitle { 'Overview' } %>
 <%= render 'cases/cases_table', model: site, archive: false %>
 

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,4 +1,5 @@
 
+<% content_for :subtitle { 'Overview' } %>
 <%= render 'cases/cases_table', model: site, archive: false %>
 
 <div class='card'>


### PR DESCRIPTION
This PR address the following cards:
https://trello.com/c/BTiEUnDM/212-make-title-and-subtitle-properties-of-views-rather-than-controllers and
https://trello.com/c/Gg2o45CJ/208-fix-case-archive-link-to-work

The titles where inconsistent because they where being individually set within all the controllers. Instead the `title` is now being set within the `ApplicationController`. The title for all pages is `Management Dashboard - #{scope.name}`. The only exception to this is the root page for `admins` as they do not have a scope. In this case, the title is still being manually set.

The `subtitle` no longer uses an instance variable set within a controller. Instead, each view uses `content_for` to set the subtitle. This allows the same view to be rendered in multiple places, whilst guaranteeing that the subtitle is set correctly.

The bug where the cases archive link went to the regular cases page has also been fixed https://github.com/alces-software/alces-flight-center/commit/1b77314b78e4c8069b010f8f6f90cf61b3c76ae2.