### PR TITLE
Fix time handling

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,15 @@ module AlcesFlightCenter
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    # Use our local time zone whenever we work with/display times in app; no
+    # matter where users are we want to use and for them to see the schedule
+    # that we operate on.
+    config.time_zone = 'London'
+
+    # Still save everything in UTC; should make things more straightforward if
+    # we ever want to handle times in other time zones in future.
+    config.active_record.default_timezone = :utc
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.shared_examples 'maintenance form error handling' do |form_action|
   it 're-renders form with error when invalid requested_start entered' do
     original_path = current_path
-    requested_start_in_past = DateTime.new(2016, 9, 20, 13)
+    requested_start_in_past = Time.new(2016, 9, 20, 13)
 
     expect do
       fill_in_datetime_selects 'requested-start', with: requested_start_in_past
@@ -89,7 +89,7 @@ RSpec.feature "Maintenance windows", type: :feature do
   let :cluster { support_case.cluster }
   let :site { support_case.site }
 
-  let :valid_requested_start { DateTime.new(2022, 9, 10, 13, 0) }
+  let :valid_requested_start { Time.new(2022, 9, 10, 13, 0) }
 
   let :reject_button_text { 'Reject' }
   let :end_button_text { 'End' }
@@ -159,7 +159,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       include_examples 'maintenance form initially valid'
 
       it 'uses correct default values' do
-        a_distant_friday = DateTime.new(2025, 3, 7, 0, 0)
+        a_distant_friday = Time.new(2025, 3, 7, 0, 0)
         following_monday_at_9 = a_distant_friday.advance(days: 3, hours: 9)
 
         travel_to a_distant_friday do

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.shared_examples 'maintenance form error handling' do |form_action|
   it 're-renders form with error when invalid requested_start entered' do
     original_path = current_path
-    requested_start_in_past = Time.new(2016, 9, 20, 13)
+    requested_start_in_past = Time.zone.local(2016, 9, 20, 13)
 
     expect do
       fill_in_datetime_selects 'requested-start', with: requested_start_in_past
@@ -89,7 +89,7 @@ RSpec.feature "Maintenance windows", type: :feature do
   let :cluster { support_case.cluster }
   let :site { support_case.site }
 
-  let :valid_requested_start { Time.new(2022, 9, 10, 13, 0) }
+  let :valid_requested_start { Time.zone.local(2022, 9, 10, 13, 0) }
 
   let :reject_button_text { 'Reject' }
   let :end_button_text { 'End' }
@@ -159,7 +159,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       include_examples 'maintenance form initially valid'
 
       it 'uses correct default values' do
-        a_distant_friday = Time.new(2025, 3, 7, 0, 0)
+        a_distant_friday = Time.zone.local(2025, 3, 7, 0, 0)
         following_monday_at_9 = a_distant_friday.advance(days: 3, hours: 9)
 
         travel_to a_distant_friday do

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe MaintenanceWindow, type: :model do
   end
 
   describe '#expected_end' do
-    let :monday { Time.new(2025, 3, 24, 9, 0) }
+    let :monday { Time.zone.local(2025, 3, 24, 9, 0) }
     let :wednesday { monday.advance(days: 2) }
     let :following_monday { monday.advance(weeks: 1) }
 

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe MaintenanceWindow, type: :model do
   end
 
   describe '#expected_end' do
-    let :monday { DateTime.new(2025, 3, 24, 9, 0) }
+    let :monday { Time.new(2025, 3, 24, 9, 0) }
     let :wednesday { monday.advance(days: 2) }
     let :following_monday { monday.advance(weeks: 1) }
 

--- a/spec/services/progress_maintenance_window_spec.rb
+++ b/spec/services/progress_maintenance_window_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ProgressMaintenanceWindow do
     end
 
     context 'when requested_start and expected_end in future' do
-      let :requested_start { DateTime.current.advance(days: 1) }
+      let :requested_start { 1.day.from_now }
 
       include_examples 'does not progress', MaintenanceWindow.possible_states
     end


### PR DESCRIPTION
Use our local time zone whenever we work with/display times in app; no matter where users are we want to use and for them to see the schedule that we operate on.

This change is necessary as previously we used UTC everywhere, which worked fine for us until daylight saving time started the other day, after which the times things would occur were an hour off from what we'd expect.

Still save everything in UTC; should make things more straightforward if we ever want to handle times in other time zones in future.

Also needed to update some failing tests following this change; these were fixed by using the `Time` rather than `DateTime` class, which I presume is dues to `DateTime` not handling daylight saving time (see https://stackoverflow.com/a/21075654/2620402).

Trello: https://trello.com/c/1VGTrKdd/216-use-uk-alces-time-everywhere.