### PR TITLE
Filter Cases so only active selectable

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -55,6 +55,8 @@ class Case < ApplicationRecord
   # if this is possible but it was not explicitly passed.
   before_validation :create_rt_ticket, on: :create
 
+  scope :active, -> { where(archived: false) }
+
   def self.request_tracker
     # Note: `rt_interface_class` is a string which we `constantize`, rather
     # than a constant directly, otherwise Rails autoloading in development

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -48,7 +48,7 @@
         <div class='form-group'>
           <%= f.label :case_ids, 'Related Ticket(s)' %>
           <%= f.collection_select :case_ids,
-                                  @cases.decorate,
+                                  @cases.active.decorate,
                                   :id,
                                   :case_select_details,
                                   {},

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -22,7 +22,7 @@
       <%= f.label :case_id, case_label, 'data-test': 'case-select-label' %>
       <%= f.collection_select(
         :case_id,
-        maintenance_window.associated_cluster.cases.order(created_at: :desc).decorate,
+        maintenance_window.associated_cluster.cases.active.order(created_at: :desc).decorate,
         :id,
         :case_select_details,
         {},

--- a/spec/features/log_spec.rb
+++ b/spec/features/log_spec.rb
@@ -64,6 +64,29 @@ RSpec.feature Log, type: :feature do
 
       expect(submit_log.cases).to contain_exactly(*log_cases)
     end
+
+    it 'cannot select archived Case for subject to associate' do
+      case_attributes = {
+        cluster: cluster,
+        subject: 'archived_case',
+        archived: true
+      }
+      if subject.is_a?(Component)
+        case_attributes.merge!(
+          component: subject,
+          issue: create(:issue, requires_component: true)
+        )
+      end
+      archived_case = create(:case, case_attributes)
+
+      # Revisit the page so given Case would be shown, if we do not
+      # successfully filter it out, to avoid false positive.
+      visit current_path
+
+      expect do
+        select archived_case.subject
+      end.to raise_error(Capybara::ElementNotFound)
+    end
   end
 
   context 'when visiting the cluster log' do

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -230,6 +230,23 @@ RSpec.feature "Maintenance windows", type: :feature do
         invalid_feedback = duration_input_group.find('.invalid-feedback')
         expect(invalid_feedback).to have_text('Must be greater than 0')
       end
+
+      it 'cannot select archived Case for Cluster to associate' do
+        archived_case = create(
+          :case,
+          cluster: cluster,
+          subject: 'archived_case',
+          archived: true
+        )
+
+        # Revisit the page so given Case would be shown, if we do not
+        # successfully filter it out, to avoid false positive.
+        visit current_path
+
+        expect do
+          select archived_case.subject
+        end.to raise_error(Capybara::ElementNotFound)
+      end
     end
 
     it 'can cancel requested maintenance' do

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -201,6 +201,18 @@ RSpec.describe Case, type: :model do
     end
   end
 
+  describe '#active' do
+    it 'returns all non-archived Cases' do
+      create(:case, details: 'one', archived: false)
+      create(:case, details: 'two', archived: true)
+      create(:case, details: 'three', archived: false)
+
+      active_cases = Case.active
+
+      expect(active_cases.map(&:details)).to match_array(['one', 'three'])
+    end
+  end
+
   describe '#mailto_url' do
     it 'creates correct mailto URL' do
       cluster = create(:cluster, name: 'somecluster')


### PR DESCRIPTION
This PR filters the selectable Cases in the log and maintenance forms so only the active/non-archived Cases can be selected. To do this it adds an `active` scope to `Case` so we can also do this in other places in future.

Trello: https://trello.com/c/3E1HFmrM/170-hide-archived-cases-from-any-drop-down-when-asked-to-choose-tickets.
Related previous PR: https://github.com/alces-software/alces-flight-center/pull/146.