### PR TITLE
Automatically archive completed cases after two weeks

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -76,7 +76,7 @@ class Case < ApplicationRecord
   end
 
   def update_ticket_status!
-    return if ticket_completed? && !self.completed_at.nil?
+    return if ticket_completed? && self.completed_at
     self.last_known_ticket_status = associated_rt_ticket.status
     if ticket_completed?
       self.completed_at = associated_rt_ticket.resolved || DateTime.now.utc

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -79,7 +79,7 @@ class Case < ApplicationRecord
     return if ticket_completed? && !self.completed_at.nil?
     self.last_known_ticket_status = associated_rt_ticket.status
     if ticket_completed?
-      self.completed_at = associated_rt_ticket.resolved
+      self.completed_at = associated_rt_ticket.resolved || DateTime.now.utc
     end
     save!
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -105,6 +105,10 @@ class Case < ApplicationRecord
     associated_model.readable_model_name
   end
 
+  def ticket_completed?
+    COMPLETED_TICKET_STATUSES.include?(last_known_ticket_status)
+  end
+
   private
 
   def create_rt_ticket
@@ -128,10 +132,6 @@ class Case < ApplicationRecord
 
   def assign_default_subject_if_unset
     self.subject ||= issue.default_subject
-  end
-
-  def ticket_completed?
-    COMPLETED_TICKET_STATUSES.include?(last_known_ticket_status)
   end
 
   def associated_rt_ticket

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -135,7 +135,7 @@ class Case < ApplicationRecord
   end
 
   def associated_rt_ticket
-    rt.show_ticket(rt_ticket_id)
+    @associated_ticket ||= rt.show_ticket(rt_ticket_id)
   end
 
   def rt

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -79,7 +79,7 @@ class Case < ApplicationRecord
     return if ticket_completed? && self.completed_at
     self.last_known_ticket_status = associated_rt_ticket.status
     if ticket_completed?
-      self.completed_at = associated_rt_ticket.resolved || DateTime.now.utc
+      self.completed_at = DateTime.now.utc
     end
     save!
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -76,9 +76,11 @@ class Case < ApplicationRecord
   end
 
   def update_ticket_status!
-    return if ticket_completed?
-
+    return if ticket_completed? && !self.completed_at.nil?
     self.last_known_ticket_status = associated_rt_ticket.status
+    if ticket_completed?
+      self.completed_at = associated_rt_ticket.resolved
+    end
     save!
   end
 

--- a/app/models/fake_request_tracker_interface.rb
+++ b/app/models/fake_request_tracker_interface.rb
@@ -15,7 +15,8 @@ class FakeRequestTrackerInterface
     status = id % 2 == 0 ? 'open' : 'resolved'
     {
       id: id,
-      status: status
+      status: status,
+      resolved: id % 2 == 0 ? nil : Time.now
     }.to_struct
   end
 end

--- a/db/migrate/20180405103917_add_completion_time_to_case.rb
+++ b/db/migrate/20180405103917_add_completion_time_to_case.rb
@@ -1,0 +1,5 @@
+class AddCompletionTimeToCase < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cases, :completed_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180404161446) do
+ActiveRecord::Schema.define(version: 20180405103917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20180404161446) do
     t.string "last_known_ticket_status", default: "new", null: false
     t.text "token", null: false
     t.text "subject", null: false
+    t.datetime "completed_at"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"
     t.index ["issue_id"], name: "index_cases_on_issue_id"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,6 +19,7 @@
    ```crontab
    # Flight Center tasks.
    * * * * * dokku --rm run flight-center rake alces:cron:every_minute
+   @hourly   dokku --rm run flight-center rake alces:cron:hourly
    0 */3 * * * /home/ubuntu/flight-center-backup-database
    ```
 

--- a/lib/tasks/cases.rake
+++ b/lib/tasks/cases.rake
@@ -10,7 +10,7 @@ namespace :alces do
       Case.where(archived: false).each do |c|
         c.update_ticket_status!
 
-        if c.ticket_completed? && !c.completed_at.nil? && c.completed_at <= 2.weeks.ago
+        if c.ticket_completed? && c.completed_at && c.completed_at <= 2.weeks.ago
           c.archived = true
           logger.info("Archiving case #{c.id} completed at #{c.completed_at}")
         end

--- a/lib/tasks/cases.rake
+++ b/lib/tasks/cases.rake
@@ -1,0 +1,29 @@
+
+namespace :alces do
+  namespace :cases do
+    desc 'Archive cases that were resolved at least two weeks ago'
+    task auto_archive: :environment do |task|
+      logger = create_logger('log/tasks/cases/auto_archive.log')
+      logger.info("#{task.name} running at #{DateTime.current.iso8601}")
+      logger.info("Automatically archiving cases completed on or before #{2.weeks.ago}")
+
+      Case.where(archived: false).each do |c|
+        c.update_ticket_status!
+
+        if c.ticket_completed? && !c.completed_at.nil? && c.completed_at <= 2.weeks.ago
+          c.archived = true
+          logger.info("Archiving case #{c.id} completed at #{c.completed_at}")
+        end
+        c.save!
+      end
+    end
+
+    private
+
+    def create_logger(log_path)
+      FileUtils.mkdir_p(File.dirname(log_path))
+      shift_age = 'weekly'
+      ActiveSupport::Logger.new(log_path, shift_age)
+    end
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -5,5 +5,8 @@ namespace :alces do
   namespace :cron do
     desc 'Tasks to run every minute'
     task every_minute: 'alces:maintenance_windows:progress'
+
+    desc 'Tasks to run every hour'
+    task hourly: 'alces:cases:auto_archive'
   end
 end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Cases table', type: :feature do
   end
 
   let! :archived_case do
-    create(:archived_case, cluster: cluster, subject: 'Archived case')
+    create(:archived_case, cluster: cluster, subject: 'Archived case', completed_at: 2.days.ago)
   end
 
   RSpec.shared_examples 'open cases table rendered' do

--- a/spec/lib/tasks/cases_spec.rb
+++ b/spec/lib/tasks/cases_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'alces:cases:auto_archive' do
+  include_context 'rake'
+
+  before :each do
+    create(:case, id: 0, last_known_ticket_status: 'resolved', completed_at: 3.weeks.ago, archived: false)
+    create(:case, id: 1, last_known_ticket_status: 'deleted', completed_at: 2.weeks.ago, archived: false)
+    create(:case, id: 2, last_known_ticket_status: 'open', completed_at: 3.weeks.ago, archived: false)
+    create(:case, id: 3, last_known_ticket_status: 'rejected', completed_at: 1.weeks.ago, archived: false)
+  end
+
+  it_behaves_like 'it has prerequisite', :environment
+
+  it 'archives cases with tickets completed more than two weeks ago' do
+
+    subject.invoke
+
+    expect(Case.find(0).archived).to be(true)  # Easy case
+    expect(Case.find(1).archived).to be(true)  # On the edge of 2 weeks; 'deleted' is a completed state
+    expect(Case.find(2).archived).to be(false)  # Old but still open
+    expect(Case.find(3).archived).to be(false)  # Too recent to archive
+
+  end
+
+  describe 'logging' do
+    let(:logger) { Rails.logger }
+
+    before :each do
+      expect(ActiveSupport::Logger).to receive(:new).with(
+        'log/tasks/cases/auto_archive.log',
+        'weekly',
+      ).and_return(logger)
+      allow(logger).to receive(:info)
+    end
+
+    it 'logs when task started' do
+      expect(logger).to receive(:info).with(
+        "#{task_name} running at #{DateTime.current.iso8601}"
+      )
+
+      subject.invoke
+    end
+
+    it 'logs each case archival' do
+      expect(logger).to receive(:info).with(/Archiving case 0.*/)
+      expect(logger).to receive(:info).with(/Archiving case 1.*/)
+
+      subject.invoke
+    end
+  end
+end

--- a/spec/lib/tasks/cron_spec.rb
+++ b/spec/lib/tasks/cron_spec.rb
@@ -5,3 +5,8 @@ RSpec.describe 'alces:cron:every_minute' do
 
   it_behaves_like 'it has prerequisite', 'alces:maintenance_windows:progress'
 end
+
+RSpec.describe 'alces:cron:hourly' do
+  include_context 'rake'
+  it_behaves_like 'it has prerequisite', 'alces:cases:auto_archive'
+end


### PR DESCRIPTION
This PR adds the ability to automatically archive cases whose corresponding RT tickets have been completed at least two weeks ago.

An hourly rake cron task updates ticket statuses for all non-archived `Case`s.

If a ticket has transitioned from a non-completed state to a completed one (or fsr a resolution time wasn't previously recorded), the RT resolution time is recorded (if present - else current time is used) as the `Case`'s "completion time".

If the completion time is two weeks ago or greater, then the `archived` flag is also set on that `Case` and this change is logged to a file.

Trello: https://trello.com/c/OetM2i5j/169-auto-archive-cases-when-resolved-for-2-weeks