### PR TITLE
Add comments to cases

### DIFF
--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -2,12 +2,16 @@ class CaseCommentsController < ApplicationController
   before_action :require_login
 
   def create
-    case_id = params[:id]
+    case_id = params[:case_id]
     my_case = Case.find(case_id)
 
     if my_case.site == current_user.site || current_user.admin?
-      my_case.case_comments.create(user: current_user, text: params[:text])
-      flash[:notice] = 'New comment added.'
+      new_comment = my_case.case_comments.create(user: current_user, text: params[:case_comment][:text])
+      if new_comment.persisted?
+        flash[:notice] = 'New comment added.'
+      else
+        flash[:error] = 'Your comment was not added.'
+      end
     else
       flash[:error] = 'You do not have permission to comment on this case.'
     end

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -5,15 +5,11 @@ class CaseCommentsController < ApplicationController
     case_id = params[:case_id]
     my_case = Case.find(case_id)
 
-    if my_case.site == current_user.site || current_user.admin?
-      new_comment = my_case.case_comments.create(user: current_user, text: params[:case_comment][:text])
-      if new_comment.persisted?
-        flash[:notice] = 'New comment added.'
-      else
-        flash[:error] = 'Your comment was not added.'
-      end
+    new_comment = my_case.case_comments.create(user: current_user, text: params[:case_comment][:text])
+    if new_comment.persisted?
+      flash[:notice] = 'New comment added.'
     else
-      flash[:error] = 'You do not have permission to comment on this case.'
+      flash[:error] = "Your comment was not added. #{new_comment.errors.full_messages.join('; ').strip}"
     end
 
     redirect_to case_path(case_id)

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -1,0 +1,17 @@
+class CaseCommentsController < ApplicationController
+  before_action :require_login
+
+  def create
+    case_id = params[:id]
+    my_case = Case.find(case_id)
+
+    if my_case.site == current_user.site || current_user.admin?
+      my_case.case_comments.create(user: current_user, text: params[:text])
+      flash[:notice] = 'New comment added.'
+    else
+      flash[:error] = 'You do not have permission to comment on this case.'
+    end
+
+    redirect_to case_path(case_id)
+  end
+end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -16,6 +16,7 @@ class CasesController < ApplicationController
 
   def show
     @case = Case.find(params[:id]).decorate
+    @comment = @case.case_comments.new
   end
 
   def new

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -23,6 +23,7 @@ class Case < ApplicationRecord
   has_one :credit_charge, required: false
   has_many :maintenance_windows
   has_and_belongs_to_many :log
+  has_many :case_comments
 
   delegate :category, :chargeable, to: :issue
   delegate :site, to: :cluster, allow_nil: true

--- a/app/models/case_comment.rb
+++ b/app/models/case_comment.rb
@@ -8,4 +8,12 @@ class CaseComment < ApplicationRecord
   validates :case, presence: true
 
   validates :text, length: { minimum: 2}
+
+  validate :valid_user, on: :create
+
+  private
+
+  def valid_user
+    errors.add(:user, 'does not have permission to post a comment on this case') unless user.admin? || user.site == site
+  end
 end

--- a/app/models/case_comment.rb
+++ b/app/models/case_comment.rb
@@ -1,0 +1,11 @@
+class CaseComment < ApplicationRecord
+  belongs_to :user
+  belongs_to :case
+
+  delegate :site, to: :case, allow_nil: true
+
+  validates :user, presence: true
+  validates :case, presence: true
+
+  validates :text, length: { minimum: 2}
+end

--- a/app/views/case_comments/_case_comment.html.erb
+++ b/app/views/case_comments/_case_comment.html.erb
@@ -1,0 +1,8 @@
+<div class="card">
+  <div class="card-header">
+    <%= comment.updated_at.to_formatted_s(:long) %> - <b><%= comment.user.name %></b>
+  </div>
+  <div class="card-body">
+    <%= comment.text %>
+  </div>
+</div>

--- a/app/views/case_comments/_form.html.erb
+++ b/app/views/case_comments/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_for [@case, @comment] do |f| %>
+  <div class="form-group">
+    <%= f.text_area :text,
+          class: 'form-control',
+          rows: 3
+    %>
+  </div>
+  <div class="form-group">
+    <%= f.submit "Add new comment",
+          class: 'btn btn-primary btn-block'
+    %>
+  </div>
+<% end %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -57,6 +57,7 @@
               comment: comment
             %>
           <% end %>
+          <%= render 'case_comments/form' %>
         </td>
       </tr>
     </table>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -49,6 +49,16 @@
         <th>Details</th>
         <td><%= simple_format(@case.details) %></td>
       </tr>
+      <tr>
+        <th>Comments</th>
+        <td>
+          <% @case.case_comments.order(:created_at).each do |comment| %>
+            <%= render 'case_comments/case_comment',
+              comment: comment
+            %>
+          <% end %>
+        </td>
+      </tr>
     </table>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
         post :archive
         post :restore
       end
+      resources :case_comments, only: :create
     end
 
     resources :clusters, only: :show do

--- a/db/migrate/20180406110011_create_case_comments.rb
+++ b/db/migrate/20180406110011_create_case_comments.rb
@@ -6,8 +6,6 @@ class CreateCaseComments < ActiveRecord::Migration[5.1]
       t.string :text, null: false
 
       t.timestamps null: false
-
-      t.index ['case_id'], name: 'index_comments_on_case_id'
     end
   end
 end

--- a/db/migrate/20180406110011_create_case_comments.rb
+++ b/db/migrate/20180406110011_create_case_comments.rb
@@ -1,0 +1,13 @@
+class CreateCaseComments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :case_comments do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :case, foreign_key: true, null: false
+      t.string :text, null: false
+
+      t.timestamps null: false
+
+      t.index ['case_id'], name: 'index_comments_on_case_id'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,7 +57,6 @@ ActiveRecord::Schema.define(version: 20180412163928) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["case_id"], name: "index_case_comments_on_case_id"
-    t.index ["case_id"], name: "index_comments_on_case_id"
     t.index ["user_id"], name: "index_case_comments_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,17 @@ ActiveRecord::Schema.define(version: 20180412163928) do
     t.index ["component_id"], name: "index_asset_record_fields_on_component_id"
   end
 
+  create_table "case_comments", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "case_id", null: false
+    t.string "text", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["case_id"], name: "index_case_comments_on_case_id"
+    t.index ["case_id"], name: "index_comments_on_case_id"
+    t.index ["user_id"], name: "index_case_comments_on_user_id"
+  end
+
   create_table "cases", force: :cascade do |t|
     t.string "details", null: false
     t.datetime "created_at", null: false
@@ -295,6 +306,8 @@ ActiveRecord::Schema.define(version: 20180412163928) do
   add_foreign_key "asset_record_fields", "asset_record_field_definitions"
   add_foreign_key "asset_record_fields", "component_groups"
   add_foreign_key "asset_record_fields", "components"
+  add_foreign_key "case_comments", "cases"
+  add_foreign_key "case_comments", "users"
   add_foreign_key "cases", "clusters"
   add_foreign_key "cases", "components"
   add_foreign_key "cases", "issues"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,12 @@
 
 FactoryBot.define do
+
+  factory :case_comment do
+    user create(:user)
+    add_attribute(:case) { create(:case) } # Avoid conflict with case keyword.
+    text 'This is a comment'
+  end
+
   sequence :email do |n|
     "a.scientist.#{n}@liverpool.ac.uk"
   end

--- a/spec/models/case_comment_spec.rb
+++ b/spec/models/case_comment_spec.rb
@@ -1,5 +1,58 @@
 require 'rails_helper'
 
 RSpec.describe CaseComment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  before :each do
+    @site = create(:site)
+    cluster = create(:cluster, site: @site)
+    @case = create(:case, cluster: cluster)
+  end
+
+  describe '#create' do
+    it 'prevents empty comments' do
+      admin = create(:admin)
+      expect do
+        CaseComment.create!(
+           case: @case,
+           user: admin,
+           text: ''
+        )
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'prevents users from other sites commenting' do
+      other_site = create(:site)
+      other_user = create(:user, site: other_site)
+
+      expect do
+        CaseComment.create!(
+           case: @case,
+           user: other_user,
+           text: 'This comment is not allowed'
+        )
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'allows users from the correct site to comment' do
+      my_user = create(:user, site: @site)
+
+      my_comment = CaseComment.create!(
+         case: @case,
+         user: my_user,
+         text: 'This comment is allowed'
+      )
+
+      expect(@case.case_comments.first).to eq(my_comment)
+    end
+
+    it 'allows admins to comment' do
+      my_comment = CaseComment.create!(
+         case: @case,
+         user: create(:admin),
+         text: 'This comment is allowed'
+      )
+
+      expect(@case.case_comments.first).to eq(my_comment)
+    end
+  end
 end

--- a/spec/models/case_comment_spec.rb
+++ b/spec/models/case_comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CaseComment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR adds the ability for users to add comments to cases.

A user may comment on any `Case` within their `Site`. Admins may comment on any `Case`. Comments are displayed from oldest to newest on a `Case`'s page, with the name of the user who posted the comment and the date and time at which they did so.

Empty comments are prohibited, and comments must be at least two characters long ("OK" probably being the tersest possible comment still containing useful information).

Trello: https://trello.com/c/JHENp9CD/217-add-comments-to-cases-2-days-moreish