### PR TITLE
Create automatic level 3 Tier for each new Issue

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -54,6 +54,8 @@ class Issue < ApplicationRecord
             },
             unless: :requires_service
 
+  after_create :create_standard_consultancy_tier
+
   def advice_only?
     support_type == 'advice-only'
   end
@@ -82,5 +84,21 @@ class Issue < ApplicationRecord
 
   def default_subject
     name
+  end
+
+  private
+
+  def create_standard_consultancy_tier
+    # By default we want to support the creation of a Tier 3/consultancy Case,
+    # with the ability to provide any arbitrary details, for every Issue.
+    self.tiers.create!(
+      level: 3,
+      fields: [
+        {
+          type: 'textarea',
+          name: 'Details',
+        }
+      ]
+    )
   end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -170,4 +170,21 @@ RSpec.describe Issue, type: :model do
       end
     end
   end
+
+  context 'on create' do
+    it 'has standard level 3 Tier automatically created' do
+      issue = create(:issue, tiers: [])
+
+      expect(issue.tiers.length).to eq 1
+      tier = issue.tiers.first
+      expect(tier.level).to eq 3
+      expected_fields = [
+        {
+          type: 'textarea',
+          name: 'Details',
+        }
+      ]
+      expect(tier.fields.map(&:symbolize_keys)).to match_array(expected_fields)
+    end
+  end
 end


### PR DESCRIPTION
By default we want to support the creation of a Tier 3/consultancy Case, with the ability to provide any arbitrary details, for every Issue.

Trello: https://trello.com/c/l7nOOOeV/219-automatically-create-level-3-tier-for-each-issue-when-it-is-created-1-4-day.