### PR TITLE
Migrate existing data for tiers

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -40,6 +40,7 @@ class Issue < ApplicationRecord
 
   belongs_to :category, required: false
   belongs_to :service_type, required: false
+  has_many :cases
   has_many :tiers
 
   validates :name, presence: true

--- a/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
+++ b/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
@@ -1,0 +1,103 @@
+class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
+  def up
+    create_tiers
+    update_cases
+  end
+
+  private
+
+  def create_tiers
+    create_level_1_tiers_for_support_type_change_issues
+    create_initial_level_2_tiers_for_non_special_issues
+    create_level_3_tiers_for_non_special_issues
+  end
+
+  def update_cases
+    add_level_1_tier_fields_to_support_type_change_cases
+    add_level_2_tier_fields_to_non_special_cases
+    add_level_3_tier_fields_to_consultancy_cases
+  end
+
+  def create_level_3_tiers_for_non_special_issues
+    non_special_issues.each do |issue|
+      # We already have a (private) method to create the level 3/consultancy
+      # Tier for new Issues, so just delegate to this.
+      issue.send(:create_standard_consultancy_tier)
+    end
+  end
+
+  def create_level_1_tiers_for_support_type_change_issues
+    support_type_change_issues.each do |issue|
+      issue.tiers.create!(
+        level: 1,
+        fields: [{
+          type: 'input',
+          name: 'Info'
+        }],
+      )
+    end
+  end
+
+  def create_initial_level_2_tiers_for_non_special_issues
+    non_special_issues.each do |issue|
+      # Turn existing `details_template`s for Issues into initial fields for
+      # level 2 Tiers by creating `input` field for each line in template.
+      fields = issue
+        .details_template
+        .lines
+        .map { |f| {type: 'input', name: f.strip.chomp(':')} }
+
+      issue.tiers.create!(level: 2, fields: fields)
+    end
+  end
+
+  def add_level_1_tier_fields_to_support_type_change_cases
+    each_case(support_type_change_issues) do |kase|
+      fields = [{type: 'input', name: 'Info', value: kase.details}]
+      kase.update!(tier_level: 1, fields: fields)
+    end
+  end
+
+  def add_level_2_tier_fields_to_non_special_cases
+    each_case(non_special_issues) do |kase|
+      fields = [{type: 'textarea', name: 'Details', value: kase.details}]
+      kase.update!(tier_level: 2, fields: fields)
+    end
+  end
+
+  def add_level_3_tier_fields_to_consultancy_cases
+    each_case(consultancy_issues) do |kase|
+      fields = [{type: 'textarea', name: 'Details', value: kase.details}]
+      kase.update!(tier_level: 3, fields: fields)
+    end
+  end
+
+  def non_special_issues
+    Issue.all.reject(&:special?)
+  end
+
+  def support_type_change_issues
+    [
+      Issue.request_component_becomes_advice_issue,
+      Issue.request_component_becomes_managed_issue,
+      Issue.request_service_becomes_advice_issue,
+      Issue.request_service_becomes_managed_issue,
+    ]
+  end
+
+  def consultancy_issues
+    [
+      Issue.cluster_consultancy_issue,
+      Issue.component_consultancy_issue,
+      Issue.service_consultancy_issue,
+    ]
+  end
+
+  def each_case(issues)
+    issues.each do |issue|
+      issue.cases.each do |kase|
+        yield kase
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sketch out the initial data migration to update all current Issues and Cases for the new relations to Tiers or Tier-related fields, respectively, that they will now need.

The exact details of the specific Tiers or the format of the Tier-related fields that we need may later change as we determine our requirements in more detail, or if we alter the data format needed for Tier fields; if this happens this migration can then be updated or an additional migration made as needed (depending on whether we have already deployed it).

Trello: https://trello.com/c/dxor1dSa/220-migrate-data-for-existing-issues-cases-for-tiers-1-2-day.