### PR TITLE
Allow selecting tiers in Case form

### DIFF
--- a/app/javascript/packs/Cluster.elm
+++ b/app/javascript/packs/Cluster.elm
@@ -10,6 +10,7 @@ module Cluster
         , setSelectedIssue
         , setSelectedService
         , setSelectedServiceWhere
+        , setSelectedTier
         , setServices
         , updateSelectedIssue
         )
@@ -23,6 +24,7 @@ import SelectList exposing (Position(..), SelectList)
 import SelectList.Extra
 import Service exposing (Service)
 import SupportType exposing (SupportType)
+import Tier
 import Utils
 
 
@@ -112,6 +114,11 @@ setSelectedIssue clusters issueId =
         .services
         asServicesIn
         updateService
+
+
+setSelectedTier : SelectList Cluster -> Tier.Id -> SelectList Cluster
+setSelectedTier clusters tierId =
+    updateSelectedIssue clusters (Issue.selectTier tierId)
 
 
 updateSelectedIssue : SelectList Cluster -> (Issue -> Issue) -> SelectList Cluster

--- a/app/javascript/packs/Cluster.elm
+++ b/app/javascript/packs/Cluster.elm
@@ -5,10 +5,10 @@ module Cluster
         , asServicesIn
         , decoder
         , extractId
+        , setSelectedCategory
         , setSelectedComponent
+        , setSelectedIssue
         , setSelectedService
-        , setSelectedServiceSelectedCategory
-        , setSelectedServiceSelectedIssue
         , setSelectedServiceWhere
         , setServices
         )
@@ -86,8 +86,8 @@ setSelectedServiceWhere clusters shouldSelect =
         shouldSelect
 
 
-setSelectedServiceSelectedCategory : SelectList Cluster -> Category.Id -> SelectList Cluster
-setSelectedServiceSelectedCategory clusters categoryId =
+setSelectedCategory : SelectList Cluster -> Category.Id -> SelectList Cluster
+setSelectedCategory clusters categoryId =
     let
         updateService =
             SelectList.Extra.mapSelected (Service.setSelectedCategory categoryId)
@@ -99,8 +99,8 @@ setSelectedServiceSelectedCategory clusters categoryId =
         updateService
 
 
-setSelectedServiceSelectedIssue : SelectList Cluster -> Issue.Id -> SelectList Cluster
-setSelectedServiceSelectedIssue clusters issueId =
+setSelectedIssue : SelectList Cluster -> Issue.Id -> SelectList Cluster
+setSelectedIssue clusters issueId =
     let
         updateService =
             SelectList.Extra.mapSelected (Service.setSelectedIssue issueId)

--- a/app/javascript/packs/Cluster.elm
+++ b/app/javascript/packs/Cluster.elm
@@ -9,7 +9,6 @@ module Cluster
         , setSelectedComponent
         , setSelectedIssue
         , setSelectedService
-        , setSelectedServiceWhere
         , setSelectedTier
         , setServices
         , updateSelectedIssue
@@ -78,16 +77,11 @@ asComponentsIn cluster components =
 
 setSelectedService : SelectList Cluster -> Service.Id -> SelectList Cluster
 setSelectedService clusters serviceId =
-    setSelectedServiceWhere clusters (Utils.sameId serviceId)
-
-
-setSelectedServiceWhere : SelectList Cluster -> (Service -> Bool) -> SelectList Cluster
-setSelectedServiceWhere clusters shouldSelect =
     SelectList.Extra.nestedSelect
         clusters
         .services
         asServicesIn
-        shouldSelect
+        (Utils.sameId serviceId)
 
 
 setSelectedCategory : SelectList Cluster -> Category.Id -> SelectList Cluster

--- a/app/javascript/packs/Cluster.elm
+++ b/app/javascript/packs/Cluster.elm
@@ -11,11 +11,13 @@ module Cluster
         , setSelectedService
         , setSelectedServiceWhere
         , setServices
+        , updateSelectedIssue
         )
 
 import Category
 import Component exposing (Component)
-import Issue
+import Issue exposing (Issue)
+import Issues
 import Json.Decode as D
 import SelectList exposing (Position(..), SelectList)
 import SelectList.Extra
@@ -110,6 +112,30 @@ setSelectedIssue clusters issueId =
         .services
         asServicesIn
         updateService
+
+
+updateSelectedIssue : SelectList Cluster -> (Issue -> Issue) -> SelectList Cluster
+updateSelectedIssue clusters changeIssue =
+    let
+        updateCluster =
+            \cluster ->
+                SelectList.Extra.mapSelected updateService cluster.services
+                    |> asServicesIn cluster
+
+        updateService =
+            \service ->
+                updateIssues service.issues
+                    |> Service.asIssuesIn service
+
+        updateIssues =
+            Issues.mapIssue changeIssue
+
+        updateCategory =
+            \category ->
+                SelectList.Extra.mapSelected changeIssue category.issues
+                    |> Category.asIssuesIn category
+    in
+    SelectList.Extra.mapSelected updateCluster clusters
 
 
 setServices : SelectList Service -> Cluster -> Cluster

--- a/app/javascript/packs/Field.elm
+++ b/app/javascript/packs/Field.elm
@@ -6,6 +6,7 @@ type Field
     | Service
     | Category
     | Issue
+    | Tier
     | Component
     | Subject
     | Details

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -9,6 +9,7 @@ module Issue
         , name
         , requiresComponent
         , sameId
+        , selectTier
         , setDetails
         , setSubject
         , subject
@@ -121,6 +122,17 @@ setDetails details =
 setSubject : String -> Issue -> Issue
 setSubject subject =
     updateIssueData (\data -> { data | subject = subject })
+
+
+selectTier : Tier.Id -> Issue -> Issue
+selectTier tierId issue =
+    updateIssueData
+        (\data ->
+            { data
+                | tiers = SelectList.select (Utils.sameId tierId) (tiers issue)
+            }
+        )
+        issue
 
 
 updateIssueData : (IssueData -> IssueData) -> Issue -> Issue

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -13,6 +13,7 @@ module Issue
         , setSubject
         , subject
         , supportType
+        , tiers
         )
 
 import Json.Decode as D
@@ -105,6 +106,11 @@ details issue =
 subject : Issue -> String
 subject issue =
     data issue |> .subject
+
+
+tiers : Issue -> SelectList Tier
+tiers issue =
+    data issue |> .tiers
 
 
 setDetails : String -> Issue -> Issue

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -47,29 +47,22 @@ decoder : D.Decoder Issue
 decoder =
     let
         createIssue =
-            \id ->
-                \name ->
-                    \requiresComponent ->
-                        \detailsTemplate ->
-                            \defaultSubject ->
-                                \supportType ->
-                                    \chargeable ->
-                                        \tiers ->
-                                            let
-                                                data =
-                                                    IssueData
-                                                        id
-                                                        name
-                                                        detailsTemplate
-                                                        defaultSubject
-                                                        supportType
-                                                        chargeable
-                                                        tiers
-                                            in
-                                            if requiresComponent then
-                                                ComponentRequiredIssue data
-                                            else
-                                                StandardIssue data
+            \id name requiresComponent detailsTemplate defaultSubject supportType chargeable tiers ->
+                let
+                    data =
+                        IssueData
+                            id
+                            name
+                            detailsTemplate
+                            defaultSubject
+                            supportType
+                            chargeable
+                            tiers
+                in
+                if requiresComponent then
+                    ComponentRequiredIssue data
+                else
+                    StandardIssue data
     in
     D.map8 createIssue
         (D.field "id" D.int |> D.map Id)

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -16,7 +16,10 @@ module Issue
         )
 
 import Json.Decode as D
+import SelectList exposing (SelectList)
+import SelectList.Extra
 import SupportType exposing (SupportType(..))
+import Tier exposing (Tier)
 import Utils
 
 
@@ -32,6 +35,7 @@ type alias IssueData =
     , subject : String
     , supportType : SupportType
     , chargeable : Bool
+    , tiers : SelectList Tier
     }
 
 
@@ -50,22 +54,24 @@ decoder =
                             \defaultSubject ->
                                 \supportType ->
                                     \chargeable ->
-                                        let
-                                            data =
-                                                IssueData
-                                                    id
-                                                    name
-                                                    detailsTemplate
-                                                    defaultSubject
-                                                    supportType
-                                                    chargeable
-                                        in
-                                        if requiresComponent then
-                                            ComponentRequiredIssue data
-                                        else
-                                            StandardIssue data
+                                        \tiers ->
+                                            let
+                                                data =
+                                                    IssueData
+                                                        id
+                                                        name
+                                                        detailsTemplate
+                                                        defaultSubject
+                                                        supportType
+                                                        chargeable
+                                                        tiers
+                                            in
+                                            if requiresComponent then
+                                                ComponentRequiredIssue data
+                                            else
+                                                StandardIssue data
     in
-    D.map7 createIssue
+    D.map8 createIssue
         (D.field "id" D.int |> D.map Id)
         (D.field "name" D.string)
         (D.field "requiresComponent" D.bool)
@@ -73,6 +79,7 @@ decoder =
         (D.field "defaultSubject" D.string)
         (D.field "supportType" SupportType.decoder)
         (D.field "chargeable" D.bool)
+        (D.field "tiers" <| SelectList.Extra.orderedDecoder Tier.levelAsInt Tier.decoder)
 
 
 extractId : Issue -> Int

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -314,8 +314,7 @@ tiersField state =
         selectedIssueTiers
         Tier.extractId
         Tier.description
-        -- XXX Use new message for this and actually handle it.
-        ChangeSelectedIssue
+        ChangeSelectedTier
         state
 
 
@@ -408,6 +407,7 @@ type Msg
     = ChangeSelectedCluster String
     | ChangeSelectedCategory String
     | ChangeSelectedIssue String
+    | ChangeSelectedTier String
     | ChangeSelectedComponent String
     | ChangeSelectedService String
     | ChangeSubject String
@@ -452,6 +452,10 @@ updateState msg state =
         ChangeSelectedIssue id ->
             stringToId Issue.Id id
                 |> Maybe.map (handleChangeSelectedIssue state)
+
+        ChangeSelectedTier id ->
+            stringToId Tier.Id id
+                |> Maybe.map (handleChangeSelectedTier state)
 
         ChangeSelectedComponent id ->
             stringToId Component.Id id
@@ -534,6 +538,16 @@ handleChangeSelectedIssue state issueId =
     ( { state
         | clusters =
             Cluster.setSelectedIssue state.clusters issueId
+      }
+    , Cmd.none
+    )
+
+
+handleChangeSelectedTier : State -> Tier.Id -> ( State, Cmd Msg )
+handleChangeSelectedTier state tierId =
+    ( { state
+        | clusters =
+            Cluster.setSelectedTier state.clusters tierId
       }
     , Cmd.none
     )

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -21,6 +21,7 @@ import SelectList exposing (Position(..), SelectList)
 import SelectList.Extra
 import Service exposing (Service)
 import State exposing (State)
+import Tier
 import Utils
 import Validation
 import View.Fields as Fields
@@ -238,6 +239,7 @@ caseForm state =
                 , maybeServicesField state
                 , maybeCategoriesField state
                 , issuesField state |> Just
+                , tiersField state |> Just
                 , maybeComponentsField state
                 , subjectField state |> Just
                 , detailsField state |> Just
@@ -299,6 +301,21 @@ issuesField state =
         selectedServiceAvailableIssues
         Issue.extractId
         Issue.name
+        ChangeSelectedIssue
+        state
+
+
+tiersField : State -> Html Msg
+tiersField state =
+    let
+        selectedIssueTiers =
+            State.selectedIssue state |> Issue.tiers
+    in
+    Fields.selectField Field.Tier
+        selectedIssueTiers
+        Tier.extractId
+        Tier.description
+        -- XXX Use new message for this and actually handle it.
         ChangeSelectedIssue
         state
 

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -74,6 +74,9 @@ view model =
                     , chargeableIssuePreSubmissionModal state |> Just
                     , State.selectedIssue state |> chargeableIssueAlert
                     , submitErrorAlert state
+
+                    -- XXX Do something better with Tiers
+                    , div [] [ text <| "Tier: " ++ toString (State.selectedTier state) ] |> Just
                     , caseForm state |> Just
                     ]
                 )

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -18,7 +18,6 @@ import Maybe.Extra
 import Navigation
 import Rails
 import SelectList exposing (Position(..), SelectList)
-import SelectList.Extra
 import Service exposing (Service)
 import State exposing (State)
 import Tier
@@ -562,62 +561,18 @@ handleChangeSelectedService state serviceId =
 
 handleChangeSubject : State -> String -> State
 handleChangeSubject state subject =
-    let
-        newClusters =
-            SelectList.Extra.mapSelected updateCluster state.clusters
-
-        updateCluster =
-            \cluster ->
-                SelectList.Extra.mapSelected updateService cluster.services
-                    |> Cluster.asServicesIn cluster
-
-        updateService =
-            \service ->
-                updateIssues service.issues
-                    |> Service.asIssuesIn service
-
-        updateIssues =
-            Issues.mapIssue updateIssueSubject
-
-        updateCategory =
-            \category ->
-                SelectList.Extra.mapSelected updateIssueSubject category.issues
-                    |> Category.asIssuesIn category
-
-        updateIssueSubject =
-            Issue.setSubject subject
-    in
-    { state | clusters = newClusters }
+    { state
+        | clusters =
+            Cluster.updateSelectedIssue state.clusters (Issue.setSubject subject)
+    }
 
 
 handleChangeDetails : State -> String -> State
 handleChangeDetails state details =
-    let
-        newClusters =
-            SelectList.Extra.mapSelected updateCluster state.clusters
-
-        updateCluster =
-            \cluster ->
-                SelectList.Extra.mapSelected updateService cluster.services
-                    |> Cluster.asServicesIn cluster
-
-        updateService =
-            \service ->
-                updateIssues service.issues
-                    |> Service.asIssuesIn service
-
-        updateIssues =
-            Issues.mapIssue updateIssueDetails
-
-        updateCategory =
-            \category ->
-                SelectList.Extra.mapSelected updateIssueDetails category.issues
-                    |> Category.asIssuesIn category
-
-        updateIssueDetails =
-            Issue.setDetails details
-    in
-    { state | clusters = newClusters }
+    { state
+        | clusters =
+            Cluster.updateSelectedIssue state.clusters (Issue.setDetails details)
+    }
 
 
 submitForm : State -> Cmd Msg

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -524,7 +524,7 @@ handleChangeSelectedCategory : State -> Category.Id -> ( State, Cmd Msg )
 handleChangeSelectedCategory state categoryId =
     ( { state
         | clusters =
-            Cluster.setSelectedServiceSelectedCategory state.clusters categoryId
+            Cluster.setSelectedCategory state.clusters categoryId
       }
     , Cmd.none
     )
@@ -534,7 +534,7 @@ handleChangeSelectedIssue : State -> Issue.Id -> ( State, Cmd Msg )
 handleChangeSelectedIssue state issueId =
     ( { state
         | clusters =
-            Cluster.setSelectedServiceSelectedIssue state.clusters issueId
+            Cluster.setSelectedIssue state.clusters issueId
       }
     , Cmd.none
     )

--- a/app/javascript/packs/SelectList/Extra.elm
+++ b/app/javascript/packs/SelectList/Extra.elm
@@ -60,9 +60,8 @@ fromList list =
             ( List.head list, List.tail list )
     in
     Maybe.map2
-        (\head ->
-            \tail ->
-                SelectList.fromLists [] head tail
+        (\head tail ->
+            SelectList.fromLists [] head tail
         )
         maybeHead
         maybeTail
@@ -77,12 +76,11 @@ fromList list =
 mapSelected : (a -> a) -> SelectList a -> SelectList a
 mapSelected transform selectList =
     SelectList.mapBy
-        (\position ->
-            \item ->
-                if position == Selected then
-                    transform item
-                else
-                    item
+        (\position item ->
+            if position == Selected then
+                transform item
+            else
+                item
         )
         selectList
 

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -11,7 +11,6 @@ module State
 
 import Bootstrap.Modal as Modal
 import Cluster exposing (Cluster)
-import ClusterPart exposing (ClusterPart)
 import Component exposing (Component)
 import Issue exposing (Issue)
 import Issues
@@ -20,7 +19,6 @@ import Json.Encode as E
 import SelectList exposing (SelectList)
 import SelectList.Extra
 import Service exposing (Service)
-import SupportType exposing (SupportType(..))
 
 
 type alias State =

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -159,13 +159,11 @@ encoder state =
             SelectList.selected state.clusters
 
         partIdValue =
-            \required ->
-                \selected ->
-                    \extractId ->
-                        if required issue then
-                            selected state |> extractId |> E.int
-                        else
-                            E.null
+            \required selected extractId ->
+                if required issue then
+                    selected state |> extractId |> E.int
+                else
+                    E.null
 
         componentIdValue =
             partIdValue

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -7,6 +7,7 @@ module State
         , selectedIssue
         , selectedService
         , selectedServiceAvailableIssues
+        , selectedTier
         )
 
 import Bootstrap.Modal as Modal
@@ -19,6 +20,7 @@ import Json.Encode as E
 import SelectList exposing (SelectList)
 import SelectList.Extra
 import Service exposing (Service)
+import Tier exposing (Tier)
 
 
 type alias State =
@@ -208,6 +210,13 @@ selectedService : State -> Service
 selectedService state =
     SelectList.selected state.clusters
         |> .services
+        |> SelectList.selected
+
+
+selectedTier : State -> Tier
+selectedTier state =
+    selectedIssue state
+        |> Issue.tiers
         |> SelectList.selected
 
 

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -1,4 +1,4 @@
-module Tier exposing (..)
+module Tier exposing (Tier, decoder, levelAsInt)
 
 import Json.Decode as D
 
@@ -47,12 +47,75 @@ type
 
 decoder : D.Decoder Tier
 decoder =
-    -- XXX Actually decode Tiers
-    D.succeed
-        { id = Id -1
-        , level = One
-        , fields = []
-        }
+    let
+        intermediateData =
+            \id levelResult fields ->
+                { id = id
+                , levelResult = levelResult
+                , fields = fields
+                }
+
+        createTier =
+            \intermediate ->
+                case intermediate.levelResult of
+                    Ok level ->
+                        D.succeed <|
+                            Tier intermediate.id level intermediate.fields
+
+                    Err error ->
+                        D.fail error
+    in
+    D.map3 intermediateData
+        (D.field "id" D.int |> D.map Id)
+        (D.field "level" D.int |> D.map intToLevel)
+        (D.field "fields" <| D.list fieldDecoder)
+        |> D.andThen createTier
+
+
+fieldDecoder : D.Decoder Field
+fieldDecoder =
+    let
+        fieldTypeDecoder =
+            \type_ ->
+                case type_ of
+                    "markdown" ->
+                        markdownDecoder
+
+                    "input" ->
+                        textInputDecoder Input
+
+                    "textarea" ->
+                        textInputDecoder Textarea
+
+                    _ ->
+                        D.fail <| "Invalid type: " ++ type_
+    in
+    D.field "type" D.string
+        |> D.andThen fieldTypeDecoder
+
+
+markdownDecoder : D.Decoder Field
+markdownDecoder =
+    D.map Markdown <| D.field "content" D.string
+
+
+textInputDecoder : TextInputType -> D.Decoder Field
+textInputDecoder type_ =
+    let
+        initialValueDecoder =
+            D.succeed ""
+
+        optionalDecoder =
+            D.field "optional" D.bool
+                |> D.maybe
+                |> D.map (Maybe.withDefault False)
+    in
+    D.map TextInput <|
+        D.map4 TextInputData
+            (D.succeed type_)
+            (D.field "name" D.string)
+            initialValueDecoder
+            optionalDecoder
 
 
 levelAsInt : Tier -> Int
@@ -69,3 +132,22 @@ levelAsInt tier =
 
         Three ->
             3
+
+
+intToLevel : Int -> Result String Level
+intToLevel int =
+    case int of
+        0 ->
+            Ok Zero
+
+        1 ->
+            Ok One
+
+        2 ->
+            Ok Two
+
+        3 ->
+            Ok Three
+
+        _ ->
+            Err <| "Invalid level: " ++ toString int

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -1,4 +1,4 @@
-module Tier exposing (Tier, decoder, levelAsInt)
+module Tier exposing (Tier, decoder, description, extractId, levelAsInt)
 
 import Json.Decode as D
 
@@ -151,3 +151,34 @@ intToLevel int =
 
         _ ->
             Err <| "Invalid level: " ++ toString int
+
+
+extractId : Tier -> Int
+extractId tier =
+    case tier.id of
+        Id id ->
+            id
+
+
+description : Tier -> String
+description tier =
+    let
+        humanTierDescription =
+            case tier.level of
+                Zero ->
+                    "Guides"
+
+                One ->
+                    "Tool"
+
+                Two ->
+                    "Support"
+
+                Three ->
+                    "Consultancy"
+
+        tierNumberPrefix =
+            toString (levelAsInt tier) ++ ":"
+    in
+    String.join " "
+        [ "Tier", tierNumberPrefix, humanTierDescription ]

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -1,5 +1,7 @@
 module Tier exposing (..)
 
+import Json.Decode as D
+
 
 type alias Tier =
     { id : Id
@@ -41,3 +43,29 @@ type
     -- XXX Could unify with `View.Fields.TextField`.
     = Input
     | Textarea
+
+
+decoder : D.Decoder Tier
+decoder =
+    -- XXX Actually decode Tiers
+    D.succeed
+        { id = Id -1
+        , level = One
+        , fields = []
+        }
+
+
+levelAsInt : Tier -> Int
+levelAsInt tier =
+    case tier.level of
+        Zero ->
+            0
+
+        One ->
+            1
+
+        Two ->
+            2
+
+        Three ->
+            3

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -1,0 +1,43 @@
+module Tier exposing (..)
+
+
+type alias Tier =
+    { id : Id
+    , level : Level
+    , fields : List Field
+    }
+
+
+type Id
+    = Id Int
+
+
+type Level
+    = Zero
+    | One
+    | Two
+    | Three
+
+
+type Field
+    = Markdown String
+    | TextInput TextInputData
+
+
+type alias TextInputData =
+    { type_ : TextInputType
+    , name : String
+    , value : String
+
+    -- XXX Could encode `optional` in `Field` type like:
+    -- | RequiredTextInput TextInput
+    -- | OptionalTextInput TextInput
+    , optional : Bool
+    }
+
+
+type
+    TextInputType
+    -- XXX Could unify with `View.Fields.TextField`.
+    = Input
+    | Textarea

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -1,4 +1,12 @@
-module Tier exposing (Tier, decoder, description, extractId, levelAsInt)
+module Tier
+    exposing
+        ( Id(..)
+        , Tier
+        , decoder
+        , description
+        , extractId
+        , levelAsInt
+        )
 
 import Json.Decode as D
 

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -27,13 +27,12 @@ selectField :
 selectField field items toId toOptionLabel changeMsg state =
     let
         fieldOption =
-            \position ->
-                \item ->
-                    option
-                        [ toId item |> toString |> value
-                        , position == Selected |> selected
-                        ]
-                        [ toOptionLabel item |> text ]
+            \position item ->
+                option
+                    [ toId item |> toString |> value
+                    , position == Selected |> selected
+                    ]
+                    [ toOptionLabel item |> text ]
 
         options =
             SelectList.mapBy fieldOption items

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -79,7 +79,8 @@ class Issue < ApplicationRecord
       defaultSubject: default_subject,
       requiresComponent: requires_component,
       supportType: support_type,
-      chargeable: chargeable
+      chargeable: chargeable,
+      tiers: tiers.map(&:case_form_json)
     }
   end
 

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -14,4 +14,12 @@ class Tier < ApplicationRecord
   def self.globally_available?
     true
   end
+
+  def case_form_json
+    {
+      id: id,
+      level: level,
+      fields: fields,
+    }
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -70,6 +70,15 @@ FactoryBot.define do
     name 'User management'
   end
 
+  factory :tier do
+    issue
+    level 2
+    fields [{
+      type: 'input',
+      name: 'some_field',
+    }]
+  end
+
   factory :asset_record_field_definition, aliases: [:definition] do
     field_name 'Manufacturer/model name'
     level :group

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -43,11 +43,18 @@ RSpec.describe Issue, type: :model do
         requires_service: service_type.present?,
         service_type: service_type,
         support_type: :managed,
-        chargeable: true
-      )
+        chargeable: true,
+        tiers: [tier]
+      ).tap do |issue|
+        # Issue creates a Tier by default on create, so remove any associated
+        # Tier other than the one we want for straightforward tests.
+        issue.tiers.each { |t| t.destroy! unless t == tier }
+        issue.tiers.reload
+      end
     end
 
     let :service_type { create(:service_type) }
+    let :tier { create(:tier) }
 
     it 'gives correct JSON' do
       expect(subject.case_form_json).to eq(
@@ -57,7 +64,8 @@ RSpec.describe Issue, type: :model do
         defaultSubject: 'New user request',
         requiresComponent: false,
         supportType: 'managed',
-        chargeable: true
+        chargeable: true,
+        tiers: [tier.case_form_json]
       )
     end
   end

--- a/spec/models/tier_spec.rb
+++ b/spec/models/tier_spec.rb
@@ -10,4 +10,27 @@ RSpec.describe Tier, type: :model do
       .is_greater_than_or_equal_to(0)
       .is_less_than_or_equal_to(3)
   end
+
+  describe '#case_form_json' do
+    subject do
+      create(
+        :tier,
+        id: 1,
+        level: 2,
+        fields: [{
+          type: 'input',
+          name: 'Some field',
+          optional: true,
+        }]
+      )
+    end
+
+    it 'gives correct JSON' do
+      expect(subject.case_form_json).to eq(
+        id: 1,
+        level: 2,
+        fields: subject.fields,
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR:

- encodes `Tier`s for use in the `Case` form, as an additional level under `Issue`s;

- decodes this encoded data into an appropriate structure in the `Case` form;

- displays a select box of the available `Tier`s for the currently selected `Issue`, with `Tier`s ordered by `level`;

- supports changing the selected `Tier` using this select box.

It does not actually do anything with the selected `Tier` (other than dump it into the page for debugging purposes); this is still to come in a future PR and for now the `Case` form otherwise functions as before.

Trello: https://trello.com/c/nG4gEcKr/222-update-case-form-to-render-tier-select-1-2-day.