### PR TITLE
Improve initial generated Tiers

### DIFF
--- a/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
+++ b/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
@@ -63,6 +63,11 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
   end
 
   def create_initial_level_2_tiers_for_non_special_issues
+    generate_level_2_tiers_from_details_templates
+    tweak_generated_level_2_tiers
+  end
+
+  def generate_level_2_tiers_from_details_templates
     non_special_issues.each do |issue|
       # Turn existing `details_template`s for Issues into initial fields for
       # level 2 Tiers by creating `input` field for each line in template.
@@ -72,6 +77,44 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
         .map { |f| {type: 'input', name: f.strip.chomp(':')} }
 
       issue.tiers.create!(level: 2, fields: fields)
+    end
+  end
+
+  def tweak_generated_level_2_tiers
+    modify_level_2_tier_for('From available Alces Gridware') do |tier|
+      # This field should just be some markdown info rather than an input.
+      tier.fields[0] = {
+        type: 'markdown',
+        content: <<~MARKDOWN.squish
+          See package listing at https://gridware.alces-flight.com for full
+          details of available Alces Gridware.
+        MARKDOWN
+      }
+    end
+
+    storage_quota_issue = 'File System storage quota changes'
+
+    # We want to increase space available in the last field of several level 2
+    # Tiers.
+    [
+      'Application problems/bugs',
+      'Job script how-to/assistance',
+      'Self application install assistance',
+      'Suspected hardware issue',
+      storage_quota_issue,
+    ].each do |issue_name|
+      modify_level_2_tier_for(issue_name) do |tier|
+        last_field = tier.fields.last
+        last_field['type'] = 'textarea'
+        tier.fields[-1] = last_field
+      end
+    end
+
+    # Tweak the wording for this field to read a bit better.
+    modify_level_2_tier_for(storage_quota_issue) do |tier|
+      last_field = tier.fields.last
+      last_field['name'] = 'Details of the required storage quota changes'
+      tier.fields[-1] = last_field
     end
   end
 
@@ -123,5 +166,13 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
         yield kase
       end
     end
+  end
+
+  def modify_level_2_tier_for(issue_name)
+    tier = Issue.find_by_name!(issue_name)
+      .tiers
+      .find_by_level!(2)
+    yield tier
+    tier.save!
   end
 end

--- a/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
+++ b/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
@@ -7,6 +7,7 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
   private
 
   def create_tiers
+    create_some_level_0_tiers
     create_level_1_tiers_for_support_type_change_issues
     create_initial_level_2_tiers_for_non_special_issues
     create_level_3_tiers_for_non_special_issues
@@ -24,6 +25,29 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
       # Tier for new Issues, so just delegate to this.
       issue.send(:create_standard_consultancy_tier)
     end
+  end
+
+  def create_some_level_0_tiers
+    Issue.find_by_name('Job running how-to/assistance').tiers.create!(
+      level: 0,
+      fields: [{
+        type: 'markdown',
+        content: <<~MARKDOWN.strip_heredoc
+          See the corresponding documentation for a scheduler available in your
+          environment:
+
+          - [Slurm Scheduler](http://docs.alces-flight.com/en/stable/slurm/slurm.html)
+
+          - [Open Grid Scheduler (SGE)](http://docs.alces-flight.com/en/stable/sge/sge.html)
+
+          - [OpenLava Scheduler](http://docs.alces-flight.com/en/stable/openlava/openlava.html)
+
+          - [TORQUE Scheduler](http://docs.alces-flight.com/en/stable/torque/torque.html)
+
+          - [PBS Pro Scheduler](http://docs.alces-flight.com/en/stable/pbspro/pbspro.html)
+        MARKDOWN
+      }]
+    )
   end
 
   def create_level_1_tiers_for_support_type_change_issues


### PR DESCRIPTION
This PR makes some tweaks to the initial Tiers generated for the existing Flight Center Issues, to:

- add a level 0/guides Tier, so can test out and demonstrate using this;

- tweak the various level 2 Tiers already generated for each Issue, to adjust some of their fields to be of a better `type` or have better wording.

No corresponding card for this, just a needed change to have things appear better in the Case form.