### PR TITLE
Render dynamic Tier fields in Case form

### DIFF
--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -6,3 +6,13 @@
 .credit-charge-required-case-row {
   background-color: lightgreen;
 }
+
+.case-form {
+  hr {
+    background-color: #777;
+
+    $margin: 25px;
+    margin-top: $margin;
+    margin-bottom: $margin;
+  }
+}

--- a/app/javascript/packs/Field.elm
+++ b/app/javascript/packs/Field.elm
@@ -1,5 +1,7 @@
 module Field exposing (..)
 
+import Tier
+
 
 type Field
     = Cluster
@@ -9,4 +11,5 @@ type Field
     | Tier
     | Component
     | Subject
+    | TierField Tier.TextInputData
     | Details

--- a/app/javascript/packs/Field.elm
+++ b/app/javascript/packs/Field.elm
@@ -12,4 +12,3 @@ type Field
     | Component
     | Subject
     | TierField Tier.TextInputData
-    | Details

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -15,6 +15,7 @@ module Issue
         , subject
         , supportType
         , tiers
+        , updateSelectedTierField
         )
 
 import Json.Decode as D
@@ -130,6 +131,20 @@ selectTier tierId issue =
         (\data ->
             { data
                 | tiers = SelectList.select (Utils.sameId tierId) (tiers issue)
+            }
+        )
+        issue
+
+
+updateSelectedTierField : Int -> String -> Issue -> Issue
+updateSelectedTierField fieldIndex value issue =
+    updateIssueData
+        (\data ->
+            { data
+                | tiers =
+                    SelectList.Extra.mapSelected
+                        (\tier -> Tier.setFieldValue tier fieldIndex value)
+                        data.tiers
             }
         )
         issue

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -3,14 +3,12 @@ module Issue
         ( Id(..)
         , Issue
         , decoder
-        , details
         , extractId
         , isChargeable
         , name
         , requiresComponent
         , sameId
         , selectTier
-        , setDetails
         , setSubject
         , subject
         , supportType
@@ -34,7 +32,6 @@ type Issue
 type alias IssueData =
     { id : Id
     , name : String
-    , details : String
     , subject : String
     , supportType : SupportType
     , chargeable : Bool
@@ -50,13 +47,12 @@ decoder : D.Decoder Issue
 decoder =
     let
         createIssue =
-            \id name requiresComponent detailsTemplate defaultSubject supportType chargeable tiers ->
+            \id name requiresComponent defaultSubject supportType chargeable tiers ->
                 let
                     data =
                         IssueData
                             id
                             name
-                            detailsTemplate
                             defaultSubject
                             supportType
                             chargeable
@@ -67,11 +63,10 @@ decoder =
                 else
                     StandardIssue data
     in
-    D.map8 createIssue
+    D.map7 createIssue
         (D.field "id" D.int |> D.map Id)
         (D.field "name" D.string)
         (D.field "requiresComponent" D.bool)
-        (D.field "detailsTemplate" D.string)
         (D.field "defaultSubject" D.string)
         (D.field "supportType" SupportType.decoder)
         (D.field "chargeable" D.bool)
@@ -100,11 +95,6 @@ name issue =
     data issue |> .name
 
 
-details : Issue -> String
-details issue =
-    data issue |> .details
-
-
 subject : Issue -> String
 subject issue =
     data issue |> .subject
@@ -113,11 +103,6 @@ subject issue =
 tiers : Issue -> SelectList Tier
 tiers issue =
     data issue |> .tiers
-
-
-setDetails : String -> Issue -> Issue
-setDetails details =
-    updateIssueData (\data -> { data | details = details })
 
 
 setSubject : String -> Issue -> Issue

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -57,7 +57,7 @@ decodeInitialModel value =
 
 init : D.Value -> ( Model, Cmd Msg )
 init flags =
-    ( decodeInitialModel flags, Cmd.none )
+    decodeInitialModel flags ! []
 
 
 
@@ -463,7 +463,7 @@ update msg model =
             let
                 ( newState, cmd ) =
                     updateState msg state
-                        |> Maybe.withDefault ( state, Cmd.none )
+                        |> Maybe.withDefault (state ! [])
             in
             ( Initialized newState, cmd )
 
@@ -503,8 +503,7 @@ updateState msg state =
                 ( handleChangeSubject state subject, Cmd.none )
 
         ChangeDetails details ->
-            Just
-                ( handleChangeDetails state details, Cmd.none )
+            Just <| handleChangeDetails state details ! []
 
         StartSubmit ->
             Just
@@ -520,16 +519,15 @@ updateState msg state =
                     Just ( state, Navigation.load "/" )
 
                 Err error ->
-                    Just
-                        ( { state
+                    Just <|
+                        { state
                             | error = Just (formatSubmitError error)
                             , isSubmitting = False
-                          }
-                        , Cmd.none
-                        )
+                        }
+                            ! []
 
         ClearError ->
-            Just ( { state | error = Nothing }, Cmd.none )
+            Just <| { state | error = Nothing } ! []
 
         ClusterChargingInfoModal modalState ->
             Just ({ state | clusterChargingInfoModal = modalState } ! [])
@@ -551,59 +549,52 @@ handleChangeSelectedCluster state clusterId =
         newClusters =
             SelectList.select (Utils.sameId clusterId) state.clusters
     in
-    ( { state | clusters = newClusters }
-    , Cmd.none
-    )
+    { state | clusters = newClusters } ! []
 
 
 handleChangeSelectedCategory : State -> Category.Id -> ( State, Cmd Msg )
 handleChangeSelectedCategory state categoryId =
-    ( { state
+    { state
         | clusters =
             Cluster.setSelectedCategory state.clusters categoryId
-      }
-    , Cmd.none
-    )
+    }
+        ! []
 
 
 handleChangeSelectedIssue : State -> Issue.Id -> ( State, Cmd Msg )
 handleChangeSelectedIssue state issueId =
-    ( { state
+    { state
         | clusters =
             Cluster.setSelectedIssue state.clusters issueId
-      }
-    , Cmd.none
-    )
+    }
+        ! []
 
 
 handleChangeSelectedTier : State -> Tier.Id -> ( State, Cmd Msg )
 handleChangeSelectedTier state tierId =
-    ( { state
+    { state
         | clusters =
             Cluster.setSelectedTier state.clusters tierId
-      }
-    , Cmd.none
-    )
+    }
+        ! []
 
 
 handleChangeSelectedComponent : State -> Component.Id -> ( State, Cmd Msg )
 handleChangeSelectedComponent state componentId =
-    ( { state
+    { state
         | clusters =
             Cluster.setSelectedComponent state.clusters componentId
-      }
-    , Cmd.none
-    )
+    }
+        ! []
 
 
 handleChangeSelectedService : State -> Service.Id -> ( State, Cmd Msg )
 handleChangeSelectedService state serviceId =
-    ( { state
+    { state
         | clusters =
             Cluster.setSelectedService state.clusters serviceId
-      }
-    , Cmd.none
-    )
+    }
+        ! []
 
 
 handleChangeSubject : State -> String -> State

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -245,7 +245,6 @@ caseForm state =
                 , subjectField state |> Just
                 , maybeComponentsField state
                 , dynamicTierFields state |> Just
-                , detailsField state |> Just
                 , submitButton state |> Just
                 ]
     in
@@ -407,19 +406,6 @@ renderTierField state ( index, field ) =
                 state
 
 
-detailsField : State -> Html Msg
-detailsField state =
-    let
-        selectedIssue =
-            State.selectedIssue state
-    in
-    Fields.textareaField Field.Details
-        selectedIssue
-        Issue.details
-        ChangeDetails
-        state
-
-
 submitButton : State -> Html Msg
 submitButton state =
     input
@@ -443,7 +429,6 @@ type Msg
     | ChangeSelectedComponent String
     | ChangeSelectedService String
     | ChangeSubject String
-    | ChangeDetails String
     | ChangeTierField Int String
     | StartSubmit
     | SubmitResponse (Result (Rails.Error String) ())
@@ -500,9 +485,6 @@ updateState msg state =
 
         ChangeSubject subject ->
             Just <| handleChangeSubject state subject ! []
-
-        ChangeDetails details ->
-            Just <| handleChangeDetails state details ! []
 
         ChangeTierField index value ->
             Just <| handleChangeTierField state index value ! []
@@ -604,14 +586,6 @@ handleChangeSubject state subject =
     { state
         | clusters =
             Cluster.updateSelectedIssue state.clusters (Issue.setSubject subject)
-    }
-
-
-handleChangeDetails : State -> String -> State
-handleChangeDetails state details =
-    { state
-        | clusters =
-            Cluster.updateSelectedIssue state.clusters (Issue.setDetails details)
     }
 
 

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -69,7 +69,7 @@ view : Model -> Html Msg
 view model =
     case model of
         Initialized state ->
-            div []
+            div [ class "case-form" ]
                 (Maybe.Extra.values
                     [ chargingInfoModal state |> Just
                     , chargeableIssuePreSubmissionModal state |> Just
@@ -240,8 +240,9 @@ caseForm state =
                 , maybeCategoriesField state
                 , issuesField state |> Just
                 , tierSelectField state |> Just
-                , maybeComponentsField state
+                , hr [] [] |> Just
                 , subjectField state |> Just
+                , maybeComponentsField state
                 , dynamicTierFields state |> Just
                 , detailsField state |> Just
                 , submitButton state |> Just

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -6,6 +6,7 @@ import Bootstrap.Modal as Modal
 import Category
 import Cluster exposing (Cluster)
 import Component exposing (Component)
+import Dict
 import Field exposing (Field)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -385,7 +386,8 @@ dynamicTierFields state =
             State.selectedTier state
 
         renderedFields =
-            List.map (renderTierField state) tier.fields
+            Dict.values tier.fields
+                |> List.map (renderTierField state)
     in
     div [] renderedFields
 

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -14,6 +14,7 @@ import Http
 import Issue exposing (Issue)
 import Issues
 import Json.Decode as D
+import Markdown
 import Maybe.Extra
 import Navigation
 import Rails
@@ -395,8 +396,7 @@ renderTierField : State -> Tier.Field -> Html Msg
 renderTierField state field =
     case field of
         Tier.Markdown content ->
-            -- XXX render this
-            text content
+            Markdown.toHtml [] content
 
         Tier.TextInput fieldData ->
             Fields.textField fieldData.type_

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -244,6 +244,7 @@ caseForm state =
                 , tierSelectField state |> Just
                 , maybeComponentsField state
                 , subjectField state |> Just
+                , dynamicTierFields state |> Just
                 , detailsField state |> Just
                 , submitButton state |> Just
                 ]
@@ -376,6 +377,35 @@ subjectField state =
         Issue.subject
         ChangeSubject
         state
+
+
+dynamicTierFields : State -> Html Msg
+dynamicTierFields state =
+    let
+        tier =
+            State.selectedTier state
+
+        renderedFields =
+            List.map (renderTierField state) tier.fields
+    in
+    div [] renderedFields
+
+
+renderTierField : State -> Tier.Field -> Html Msg
+renderTierField state field =
+    case field of
+        Tier.Markdown content ->
+            -- XXX render this
+            text content
+
+        Tier.TextInput fieldData ->
+            Fields.textField fieldData.type_
+                (Field.TierField fieldData)
+                fieldData
+                .value
+                -- XXX Use proper message type.
+                ChangeDetails
+                state
 
 
 detailsField : State -> Html Msg

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -241,7 +241,7 @@ caseForm state =
                 , maybeServicesField state
                 , maybeCategoriesField state
                 , issuesField state |> Just
-                , tiersField state |> Just
+                , tierSelectField state |> Just
                 , maybeComponentsField state
                 , subjectField state |> Just
                 , detailsField state |> Just
@@ -307,8 +307,8 @@ issuesField state =
         state
 
 
-tiersField : State -> Html Msg
-tiersField state =
+tierSelectField : State -> Html Msg
+tierSelectField state =
     let
         selectedIssueTiers =
             State.selectedIssue state |> Issue.tiers

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -75,9 +75,6 @@ view model =
                     , chargeableIssuePreSubmissionModal state |> Just
                     , State.selectedIssue state |> chargeableIssueAlert
                     , submitErrorAlert state
-
-                    -- XXX Do something better with Tiers
-                    , div [] [ text <| "Tier: " ++ toString (State.selectedTier state) ] |> Just
                     , caseForm state |> Just
                     ]
                 )

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -13,10 +13,12 @@ module State
 import Bootstrap.Modal as Modal
 import Cluster exposing (Cluster)
 import Component exposing (Component)
+import Dict
 import Issue exposing (Issue)
 import Issues
 import Json.Decode as D
 import Json.Encode as E
+import Maybe.Extra
 import SelectList exposing (SelectList)
 import SelectList.Extra
 import Service exposing (Service)
@@ -177,6 +179,23 @@ encoder state =
             selectedService state
                 |> Service.extractId
                 |> E.int
+
+        details =
+            selectedTier state
+                |> .fields
+                |> Dict.values
+                |> List.map tierFieldAsString
+                |> Maybe.Extra.values
+                |> String.join "\n"
+
+        tierFieldAsString =
+            \field ->
+                case field of
+                    Tier.Markdown _ ->
+                        Nothing
+
+                    Tier.TextInput data ->
+                        Just <| data.name ++ ": " ++ data.value
     in
     E.object
         [ ( "case"
@@ -186,7 +205,7 @@ encoder state =
                 , ( "component_id", componentIdValue )
                 , ( "service_id", serviceIdValue )
                 , ( "subject", Issue.subject issue |> E.string )
-                , ( "details", Issue.details issue |> E.string )
+                , ( "details", details |> E.string )
                 ]
           )
         ]

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -1,6 +1,8 @@
 module Tier
     exposing
-        ( Id(..)
+        ( Field(..)
+        , Id(..)
+        , TextInputData
         , Tier
         , decoder
         , description

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -10,6 +10,7 @@ module Tier
         , levelAsInt
         )
 
+import Dict exposing (Dict)
 import Json.Decode as D
 import Types
 
@@ -17,7 +18,7 @@ import Types
 type alias Tier =
     { id : Id
     , level : Level
-    , fields : List Field
+    , fields : Dict Int Field
     }
 
 
@@ -72,8 +73,14 @@ decoder =
     D.map3 intermediateData
         (D.field "id" D.int |> D.map Id)
         (D.field "level" D.int |> D.map intToLevel)
-        (D.field "fields" <| D.list fieldDecoder)
+        (D.field "fields" fieldsDecoder)
         |> D.andThen createTier
+
+
+fieldsDecoder : D.Decoder (Dict Int Field)
+fieldsDecoder =
+    D.list fieldDecoder
+        |> D.map (List.indexedMap (,) >> Dict.fromList)
 
 
 fieldDecoder : D.Decoder Field

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -9,6 +9,7 @@ module Tier
         )
 
 import Json.Decode as D
+import Types
 
 
 type alias Tier =
@@ -35,7 +36,7 @@ type Field
 
 
 type alias TextInputData =
-    { type_ : TextInputType
+    { type_ : Types.TextField
     , name : String
     , value : String
 
@@ -44,13 +45,6 @@ type alias TextInputData =
     -- | OptionalTextInput TextInput
     , optional : Bool
     }
-
-
-type
-    TextInputType
-    -- XXX Could unify with `View.Fields.TextField`.
-    = Input
-    | Textarea
 
 
 decoder : D.Decoder Tier
@@ -90,10 +84,10 @@ fieldDecoder =
                         markdownDecoder
 
                     "input" ->
-                        textInputDecoder Input
+                        textInputDecoder Types.Input
 
                     "textarea" ->
-                        textInputDecoder Textarea
+                        textInputDecoder Types.TextArea
 
                     _ ->
                         D.fail <| "Invalid type: " ++ type_
@@ -107,7 +101,7 @@ markdownDecoder =
     D.map Markdown <| D.field "content" D.string
 
 
-textInputDecoder : TextInputType -> D.Decoder Field
+textInputDecoder : Types.TextField -> D.Decoder Field
 textInputDecoder type_ =
     let
         initialValueDecoder =

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -8,6 +8,7 @@ module Tier
         , description
         , extractId
         , levelAsInt
+        , setFieldValue
         )
 
 import Dict exposing (Dict)
@@ -193,3 +194,24 @@ description tier =
     in
     String.join " "
         [ "Tier", tierNumberPrefix, humanTierDescription ]
+
+
+setFieldValue : Tier -> Int -> String -> Tier
+setFieldValue tier index value =
+    let
+        updateFieldValue =
+            \maybeField ->
+                case maybeField of
+                    Just (Markdown f) ->
+                        Just (Markdown f)
+
+                    Just (TextInput f) ->
+                        Just <| TextInput { f | value = value }
+
+                    Nothing ->
+                        Nothing
+    in
+    { tier
+        | fields =
+            Dict.update index updateFieldValue tier.fields
+    }

--- a/app/javascript/packs/Types.elm
+++ b/app/javascript/packs/Types.elm
@@ -1,0 +1,9 @@
+module Types exposing (..)
+
+-- Module to hold simple types without many/any related functions, shared
+-- between a few places in app.
+
+
+type TextField
+    = Input
+    | TextArea

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -51,8 +51,7 @@ validateField field state =
 stateValidator : Validator Error State
 stateValidator =
     Validate.all
-        [ Validate.ifBlank (State.selectedIssue >> Issue.details) ( Field.Details, Empty )
-        , Validate.ifBlank (State.selectedIssue >> Issue.subject) ( Field.Subject, Empty )
+        [ Validate.ifBlank (State.selectedIssue >> Issue.subject) ( Field.Subject, Empty )
 
         -- XXX Not handling any other validations for now, as these are
         -- currently either very improbable or impossible to trigger (at least

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -2,6 +2,7 @@ module View.Fields
     exposing
         ( inputField
         , selectField
+        , textField
         , textareaField
         )
 
@@ -119,7 +120,12 @@ formField :
 formField field item htmlFn additionalAttributes children state =
     let
         fieldName =
-            toString field
+            case field of
+                Field.TierField data ->
+                    data.name
+
+                _ ->
+                    toString field
 
         identifier =
             fieldIdentifier fieldName

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -3,7 +3,6 @@ module View.Fields
         ( inputField
         , selectField
         , textField
-        , textareaField
         )
 
 import Field exposing (Field)
@@ -46,17 +45,6 @@ selectField field items toId toOptionLabel changeMsg state =
         [ Html.Events.on "change" (D.map changeMsg Html.Events.targetValue) ]
         options
         state
-
-
-textareaField :
-    Field
-    -> a
-    -> (a -> String)
-    -> (String -> msg)
-    -> State
-    -> Html msg
-textareaField =
-    textField Types.TextArea
 
 
 inputField :

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -13,6 +13,7 @@ import Json.Decode as D
 import SelectList exposing (Position(..), SelectList)
 import State exposing (State)
 import String.Extra
+import Types
 import Validation exposing (Error, ErrorMessage(..))
 
 
@@ -54,7 +55,7 @@ textareaField :
     -> State
     -> Html msg
 textareaField =
-    textField TextArea
+    textField Types.TextArea
 
 
 inputField :
@@ -65,16 +66,11 @@ inputField :
     -> State
     -> Html msg
 inputField =
-    textField Input
-
-
-type TextField
-    = Input
-    | TextArea
+    textField Types.Input
 
 
 textField :
-    TextField
+    Types.TextField
     -> Field
     -> a
     -> (a -> String)
@@ -88,10 +84,10 @@ textField textFieldType field item toContent inputMsg state =
 
         ( element, additionalAttributes ) =
             case textFieldType of
-                Input ->
+                Types.Input ->
                     ( input, [] )
 
-                TextArea ->
+                Types.TextArea ->
                     ( textarea, [ rows 10 ] )
 
         attributes =

--- a/app/models/concerns/admin_config/issue.rb
+++ b/app/models/concerns/admin_config/issue.rb
@@ -5,10 +5,6 @@ module AdminConfig::Issue
   included do
     rails_admin do
       edit do
-        configure :details_template, :text do
-          html_attributes rows: 5, cols: 100
-        end
-
         configure :identifier do
           hide
         end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -44,7 +44,6 @@ class Issue < ApplicationRecord
   has_many :tiers
 
   validates :name, presence: true
-  validates :details_template, presence: true
   validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true
   validates :identifier, uniqueness: true, if: :identifier
   validates :chargeable, inclusion: {in: [true, false]}
@@ -75,7 +74,6 @@ class Issue < ApplicationRecord
     {
       id: id,
       name: name,
-      detailsTemplate: details_template,
       defaultSubject: default_subject,
       requiresComponent: requires_component,
       supportType: support_type,

--- a/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
+++ b/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
@@ -101,6 +101,7 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
       'Job script how-to/assistance',
       'Self application install assistance',
       'Suspected hardware issue',
+      'Suspected service issue',
       storage_quota_issue,
     ].each do |issue_name|
       modify_level_2_tier_for(issue_name) do |tier|

--- a/db/migrate/20180412163928_make_issue_details_template_nullable.rb
+++ b/db/migrate/20180412163928_make_issue_details_template_nullable.rb
@@ -1,0 +1,5 @@
+class MakeIssueDetailsTemplateNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :issues, :details_template, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180409150804) do
+ActiveRecord::Schema.define(version: 20180412163928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -183,7 +183,7 @@ ActiveRecord::Schema.define(version: 20180409150804) do
     t.boolean "requires_component", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "details_template", null: false
+    t.string "details_template"
     t.string "support_type", null: false
     t.string "identifier"
     t.boolean "requires_service", default: false, null: false

--- a/elm-package.json
+++ b/elm-package.json
@@ -15,6 +15,7 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
         "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
+        "evancz/elm-markdown": "3.0.2 <= v < 4.0.0",
         "rtfeldman/elm-validate": "3.0.0 <= v < 4.0.0",
         "rtfeldman/selectlist": "1.0.0 <= v < 2.0.0",
         "rundis/elm-bootstrap": "3.0.0 <= v < 4.0.0"

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
   factory :issue do
     name 'New user/group'
     requires_component false
-    details_template 'Enter the usernames to create'
     support_type :managed
 
     factory :advice_issue do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Issue, type: :model do
         :issue,
         id: 1,
         name: 'New user request',
-        details_template: 'Give a username',
         requires_component: false,
         requires_service: service_type.present?,
         service_type: service_type,
@@ -60,7 +59,6 @@ RSpec.describe Issue, type: :model do
       expect(subject.case_form_json).to eq(
         id: 1,
         name: 'New user request',
-        detailsTemplate: 'Give a username',
         defaultSubject: 'New user request',
         requiresComponent: false,
         supportType: 'managed',


### PR DESCRIPTION
This PR removes the 'Details' field previously always shown in the Case form, and instead dynamically renders all `fields` appropriately for the currently selected Tier. When submitted the Case form then uses the entered values for these fields to form the `details` for the Case to be created (for now; later we will submit JSON for the fields themselves and handle this).

Trello: https://trello.com/c/S0TAsPRq/224-update-case-form-to-render-dynamic-tier-fields-2-days, with the validation part of this still to come.