### PR TITLE
Prevent creating Tier 0 cases

### DIFF
--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -263,11 +263,27 @@ dynamicFields state =
     -- These fields are very dynamic, and either appear/disappear entirely or
     -- have their content changed based on the currently selected Issue and
     -- Tier.
-    [ subjectField state |> Just
-    , maybeComponentsField state
-    , dynamicTierFields state |> Just
-    , submitButton state |> Just
-    ]
+    let
+        selectedTier =
+            State.selectedTier state
+
+        tierFields =
+            dynamicTierFields state |> Just
+    in
+    case selectedTier.level of
+        Tier.Zero ->
+            -- When a level 0 Tier is selected we want to prevent filling in
+            -- any fields or submitting the form, and only show the rendered
+            -- Tier fields, which should include the relevant links to
+            -- documentation.
+            [ tierFields ]
+
+        _ ->
+            [ subjectField state |> Just
+            , maybeComponentsField state
+            , tierFields
+            , submitButton state |> Just
+            ]
 
 
 maybeClustersField : State -> Maybe (Html Msg)

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -235,20 +235,39 @@ caseForm state =
                 StartSubmit
 
         formElements =
-            Maybe.Extra.values
-                [ maybeClustersField state
-                , maybeServicesField state
-                , maybeCategoriesField state
-                , issuesField state |> Just
-                , tierSelectField state |> Just
-                , hr [] [] |> Just
-                , subjectField state |> Just
-                , maybeComponentsField state
-                , dynamicTierFields state |> Just
-                , submitButton state |> Just
+            List.concat
+                [ issueDrillDownFields state
+                , [ hr [] [] |> Just ]
+                , dynamicFields state
                 ]
+                |> Maybe.Extra.values
     in
     Html.form [ onSubmit submitMsg ] formElements
+
+
+issueDrillDownFields : State -> List (Maybe (Html Msg))
+issueDrillDownFields state =
+    -- These fields allow a user to drill down to identify the particular Issue
+    -- and possible solutions (via different Tiers) to a problem they are
+    -- having.
+    [ maybeClustersField state
+    , maybeServicesField state
+    , maybeCategoriesField state
+    , issuesField state |> Just
+    , tierSelectField state |> Just
+    ]
+
+
+dynamicFields : State -> List (Maybe (Html Msg))
+dynamicFields state =
+    -- These fields are very dynamic, and either appear/disappear entirely or
+    -- have their content changed based on the currently selected Issue and
+    -- Tier.
+    [ subjectField state |> Just
+    , maybeComponentsField state
+    , dynamicTierFields state |> Just
+    , submitButton state |> Just
+    ]
 
 
 maybeClustersField : State -> Maybe (Html Msg)

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -2,6 +2,7 @@ module Tier
     exposing
         ( Field(..)
         , Id(..)
+        , Level(..)
         , TextInputData
         , Tier
         , decoder


### PR DESCRIPTION
This PR prevents the creation of Tier 0 Cases in the Case form, since for Tier 0 we just want to show rendered markdown links to relevant documentation to try to help people solve issues without needing to create Cases.

Trello: https://trello.com/c/gS87kzAB/230-hide-submit-button-of-case-form-when-tier-0-selected-1-4-day.