### PR TITLE
Fix issue with creating Case for advice-only Issue

### DIFF
--- a/app/models/case/issue_validator.rb
+++ b/app/models/case/issue_validator.rb
@@ -60,7 +60,7 @@ class Case
     end
 
     def advice_only_issue_for_managed_cluster?
-      record.issue.advice_only? && record.cluster.managed?
+      record.issue.advice_only? && no_parts_required? && record.cluster.managed?
     end
 
     def advice_only_issue_for_managed_part?(part_name)

--- a/spec/models/case/validation_spec.rb
+++ b/spec/models/case/validation_spec.rb
@@ -112,6 +112,12 @@ RSpec.shared_examples 'associated Cluster part validation' do |part_name|
         it { is_expected.to be_valid }
       end
 
+      context "with `managed` cluster but `advice` #{part_name}" do
+        let :cluster { create(:managed_cluster) }
+        let :part { create(advice_part_name, cluster: cluster) }
+        it { is_expected.to be_valid }
+      end
+
       context "with `advice` #{part_name} which is later switched to `managed`" do
         let :part { create(advice_part_name, cluster: cluster) }
 


### PR DESCRIPTION
In the particular situation where an attempt is made to create a Case
with:

- an `advice-only` Issue which requires a Component or Service;

- a `managed` Cluster;

- an `advice` Component or Service (as appropriate to match the Issue);

the Case would be invalid with the error that an advice-only Issue
cannot be created for a managed Cluster.

However, this is surprising and not what we want to happen, as just the
Component/Service's `support_type` should be considered in this
situation to determine if the Issue can be associated. This changed
behaviour is also consistent with what we already did when creating a
Case with a `managed` Issue which requires a part and an `advice`
Cluster.