### PR TITLE
Handle Case Tier field submission

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -37,10 +37,7 @@ class CasesController < ApplicationController
   end
 
   def create
-    # XXX Set `fields` and `tier_level` to real rather than junk values.
-    @case = Case.new(
-      case_params.merge(user: current_user, fields: '[]', tier_level: 2)
-    )
+    @case = Case.new(case_params.merge(user: current_user))
 
     respond_to do |format|
       if @case.save
@@ -92,6 +89,8 @@ class CasesController < ApplicationController
       :service_id,
       :subject,
       :details,
+      :tier_level,
+      fields: [:type, :name, :value, :optional],
     )
   end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -88,7 +88,6 @@ class CasesController < ApplicationController
       :component_id,
       :service_id,
       :subject,
-      :details,
       :tier_level,
       fields: [:type, :name, :value, :optional],
     )

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -1,6 +1,14 @@
 class CaseDecorator < ApplicationDecorator
   delegate_all
 
+  # Note: These should match values used in `Tier.description` in Case form
+  # app.
+  TIER_DESCRIPTIONS = {
+    1 => 'Tool',
+    2 => 'Support',
+    3 => 'Consultancy',
+  }.freeze
+
   def case_select_details
     [
       "RT ticket #{rt_ticket_id}",
@@ -35,5 +43,13 @@ class CaseDecorator < ApplicationDecorator
     else
       'N/A'
     end
+  end
+
+  def tier_description
+    unless TIER_DESCRIPTIONS.has_key?(tier_level)
+      raise "Unhandled tier_level: #{tier_level}"
+    end
+    description = TIER_DESCRIPTIONS[tier_level]
+    "#{tier_level} (#{description})"
   end
 end

--- a/app/decorators/cluster_part_decorator.rb
+++ b/app/decorators/cluster_part_decorator.rb
@@ -52,7 +52,6 @@ class ClusterPartDecorator < ApplicationDecorator
           cluster_id: cluster.id,
           part_id_symbol => id,
           issue_id: issue.id,
-          details: 'User-requested from management dashboard',
           fields: tier.fields,
           tier_level: tier.level
         }

--- a/app/decorators/cluster_part_decorator.rb
+++ b/app/decorators/cluster_part_decorator.rb
@@ -41,6 +41,8 @@ class ClusterPartDecorator < ApplicationDecorator
     issue:,
     part_id_symbol:
   )
+    tier = issue.tiers.find_by_level!(1)
+
     h.button_to "Request #{change_description}",
       h.cases_path,
       class: "btn #{button_class} support-type-button",
@@ -50,7 +52,9 @@ class ClusterPartDecorator < ApplicationDecorator
           cluster_id: cluster.id,
           part_id_symbol => id,
           issue_id: issue.id,
-          details: 'User-requested from management dashboard'
+          details: 'User-requested from management dashboard',
+          fields: tier.fields,
+          tier_level: tier.level
         }
       },
       data: {

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -183,13 +183,6 @@ encoder state =
         tier =
             selectedTier state
 
-        details =
-            tier.fields
-                |> Dict.values
-                |> List.map tierFieldAsString
-                |> Maybe.Extra.values
-                |> String.join "\n"
-
         tierFieldAsString =
             \field ->
                 case field of
@@ -207,7 +200,6 @@ encoder state =
                 , ( "component_id", componentIdValue )
                 , ( "service_id", serviceIdValue )
                 , ( "subject", Issue.subject issue |> E.string )
-                , ( "details", details |> E.string )
                 , ( "tier_level", Tier.levelAsInt tier |> E.int )
                 , ( "fields", Tier.fieldsEncoder tier )
                 ]

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -180,9 +180,11 @@ encoder state =
                 |> Service.extractId
                 |> E.int
 
-        details =
+        tier =
             selectedTier state
-                |> .fields
+
+        details =
+            tier.fields
                 |> Dict.values
                 |> List.map tierFieldAsString
                 |> Maybe.Extra.values
@@ -206,6 +208,8 @@ encoder state =
                 , ( "service_id", serviceIdValue )
                 , ( "subject", Issue.subject issue |> E.string )
                 , ( "details", details |> E.string )
+                , ( "tier_level", Tier.levelAsInt tier |> E.int )
+                , ( "fields", Tier.fieldsEncoder tier )
                 ]
           )
         ]

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -8,12 +8,16 @@ module Tier
         , decoder
         , description
         , extractId
+        , fieldsEncoder
         , levelAsInt
         , setFieldValue
         )
 
+import Array
 import Dict exposing (Dict)
 import Json.Decode as D
+import Json.Encode as E
+import Maybe.Extra
 import Types
 
 
@@ -120,6 +124,42 @@ textInputDecoder type_ =
             (D.field "name" D.string)
             initialValueDecoder
             optionalDecoder
+
+
+fieldsEncoder : Tier -> E.Value
+fieldsEncoder tier =
+    E.array
+        (Dict.values tier.fields
+            |> List.map fieldEncoder
+            |> Maybe.Extra.values
+            |> Array.fromList
+        )
+
+
+fieldEncoder : Field -> Maybe E.Value
+fieldEncoder field =
+    case field of
+        Markdown _ ->
+            Nothing
+
+        TextInput data ->
+            Just <|
+                E.object
+                    [ ( "type", textFieldTypeToString data.type_ |> E.string )
+                    , ( "name", E.string data.name )
+                    , ( "value", E.string data.value )
+                    , ( "optional", E.bool data.optional )
+                    ]
+
+
+textFieldTypeToString : Types.TextField -> String
+textFieldTypeToString field =
+    case field of
+        Types.TextArea ->
+            "textarea"
+
+        Types.Input ->
+            "input"
 
 
 levelAsInt : Tier -> Int

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -28,7 +28,6 @@ class Case < ApplicationRecord
   delegate :category, :chargeable, to: :issue
   delegate :site, to: :cluster, allow_nil: true
 
-  validates :details, presence: true
   validates :token, presence: true
   validates :subject, presence: true
   validates :rt_ticket_id, presence: true, uniqueness: true

--- a/app/models/concerns/admin_config/case.rb
+++ b/app/models/concerns/admin_config/case.rb
@@ -5,10 +5,6 @@ module AdminConfig::Case
   included do
     rails_admin do
       edit do
-        configure :details, :text do
-          html_attributes rows: 10, cols: 100
-        end
-
         configure :rt_ticket_id do
           hide
         end

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -42,6 +42,10 @@
         <td><%= boolean_symbol(@case.archived) %></td>
       </tr>
       <tr>
+        <th>Tier</th>
+        <td><%= @case.tier_description %></td>
+      </tr>
+      <tr>
         <th>Subject</th>
         <td><%= @case.subject %></td>
       </tr>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -46,8 +46,23 @@
         <td><%= @case.subject %></td>
       </tr>
       <tr>
-        <th>Details</th>
-        <td><%= simple_format(@case.details) %></td>
+        <th>Fields</th>
+        <td>
+          <div class="table-responsive">
+            <table class="table table-sm table-striped table-bordered">
+              <% @case.fields.each do |field| %>
+                <tr>
+                  <th scope="row">
+                    <%= field.fetch('name') %>
+                  </th>
+                  <td>
+                    <%= simple_format(field.fetch('value')) %>
+                  </td>
+                </tr>
+              <% end%>
+            </table>
+          </div>
+        </td>
       </tr>
       <tr>
         <th>Comments</th>

--- a/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
+++ b/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
@@ -56,7 +56,8 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
         level: 1,
         fields: [{
           type: 'input',
-          name: 'Info'
+          name: 'Info',
+          value: 'User-requested from management dashboard',
         }],
       )
     end

--- a/db/migrate/20180417164616_make_case_details_nullable.rb
+++ b/db/migrate/20180417164616_make_case_details_nullable.rb
@@ -1,0 +1,5 @@
+class MakeCaseDetailsNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :cases, :details, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180412163928) do
+ActiveRecord::Schema.define(version: 20180417164616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20180412163928) do
   end
 
   create_table "cases", force: :cascade do |t|
-    t.string "details", null: false
+    t.string "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "cluster_id", null: false

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -79,7 +79,9 @@ RSpec.describe CasesController, type: :controller do
           component_id: first_cluster_component.id,
           issue_id: create(:issue_requiring_component).id,
           subject: 'subject',
-          details: 'Useful info'
+          details: 'Useful info',
+          tier_level: 2,
+          fields: [type: 'textarea'],
         }
       }
     end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe CasesController, type: :controller do
           cluster_id: first_cluster.id,
           component_id: first_cluster_component.id,
           issue_id: create(:issue_requiring_component).id,
-          subject: 'subject',
+          subject: 'some_subject',
           details: 'Useful info',
           tier_level: 2,
           fields: [type: 'textarea'],
@@ -95,7 +95,7 @@ RSpec.describe CasesController, type: :controller do
     def expect_case_created
       user_cases = Case.where(user: user)
       expect(user_cases.length).to eq 1
-      expect(user_cases.first.details).to eq('Useful info')
+      expect(user_cases.first.subject).to eq('some_subject')
     end
 
     context 'when JSON request' do

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -103,4 +103,27 @@ RSpec.describe CaseDecorator do
       expect(link).to eq h.link_to('12345', h.case_path(kase))
     end
   end
+
+  describe '#tier_description' do
+    {
+      1 => 'Tool',
+      2 => 'Support',
+      3 => 'Consultancy',
+    }.each do |level, expected_description|
+      it "gives correct text for level #{level} Tier" do
+        kase = create(:case, tier_level: level).decorate
+
+        expect(kase.tier_description).to eq("#{level} (#{expected_description})")
+      end
+    end
+
+    it 'raises for unhandled tier_level' do
+      # Use `build` as Case with this `tier_level` is currently invalid.
+      kase = build(:case, tier_level: 4).decorate
+
+      expect do
+        kase.tier_description
+      end.to raise_error(RuntimeError, "Unhandled tier_level: 4")
+    end
+  end
 end

--- a/spec/decorators/component_decorator_spec.rb
+++ b/spec/decorators/component_decorator_spec.rb
@@ -1,17 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ComponentDecorator do
-  describe '#change_support_type_button' do
-    let! :request_advice_issue { create(:request_component_becomes_advice_issue) }
-    let! :request_managed_issue { create(:request_component_becomes_managed_issue) }
-
-    it 'gives nothing for internal Component' do
-      component = create(:component, internal: true).decorate
-
-      expect(component.change_support_type_button).to be nil
-    end
-  end
-
   describe '#links' do
     subject { create(:component).decorate }
 

--- a/spec/decorators/component_decorator_spec.rb
+++ b/spec/decorators/component_decorator_spec.rb
@@ -5,57 +5,6 @@ RSpec.describe ComponentDecorator do
     let! :request_advice_issue { create(:request_component_becomes_advice_issue) }
     let! :request_managed_issue { create(:request_component_becomes_managed_issue) }
 
-    context 'for managed component' do
-      subject do
-        create(:managed_component).decorate
-      end
-
-      it 'renders correctly' do
-        expect(subject.change_support_type_button).to eq(
-          h.button_to 'Request self-management',
-          h.cases_path,
-          class: 'btn btn-danger support-type-button',
-          title: request_advice_issue.name,
-          params: {
-            case: {
-              cluster_id: subject.cluster.id,
-              component_id: subject.id,
-              issue_id: request_advice_issue.id,
-              details: 'User-requested from management dashboard'
-            }
-          },
-          data: {
-            confirm: "Are you sure you want to request self-management of #{subject.name}?"
-          }
-        )
-      end
-    end
-
-    context 'for advice component' do
-      subject do
-        create(:advice_component).decorate
-      end
-
-      it 'renders correctly' do
-        expect(subject.change_support_type_button).to eq(
-          h.button_to 'Request Alces management',
-          h.cases_path,
-          class: 'btn btn-success support-type-button',
-          title: request_managed_issue.name,
-          params: {
-            case: {
-              cluster_id: subject.cluster.id,
-              component_id: subject.id,
-              issue_id: request_managed_issue.id,
-              details: 'User-requested from management dashboard'
-            }
-          },
-          data: {
-            confirm: "Are you sure you want to request Alces management of #{subject.name}?"
-          })
-      end
-    end
-
     it 'gives nothing for internal Component' do
       component = create(:component, internal: true).decorate
 

--- a/spec/decorators/service_decorator_spec.rb
+++ b/spec/decorators/service_decorator_spec.rb
@@ -2,62 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ServiceDecorator do
   describe '#change_support_type_button' do
-    # These tests are almost the same as those for
-    # `ComponentDecorator#change_support_type_button`.
-
     let! :request_advice_issue { create(:request_service_becomes_advice_issue) }
     let! :request_managed_issue { create(:request_service_becomes_managed_issue) }
-
-    context 'for managed service' do
-      subject do
-        create(:managed_service).decorate
-      end
-
-      it 'renders correctly' do
-        expect(subject.change_support_type_button).to eq(
-          h.button_to 'Request self-management',
-          h.cases_path,
-          class: 'btn btn-danger support-type-button',
-          title: request_advice_issue.name,
-          params: {
-            case: {
-              cluster_id: subject.cluster.id,
-              service_id: subject.id,
-              issue_id: request_advice_issue.id,
-              details: 'User-requested from management dashboard'
-            }
-          },
-          data: {
-            confirm: "Are you sure you want to request self-management of #{subject.name}?"
-          }
-        )
-      end
-    end
-
-    context 'for advice service' do
-      subject do
-        create(:advice_service).decorate
-      end
-
-      it 'renders correctly' do
-        expect(subject.change_support_type_button).to eq(
-          h.button_to 'Request Alces management',
-          h.cases_path,
-          class: 'btn btn-success support-type-button',
-          title: request_managed_issue.name,
-          params: {
-            case: {
-              cluster_id: subject.cluster.id,
-              service_id: subject.id,
-              issue_id: request_managed_issue.id,
-              details: 'User-requested from management dashboard'
-            }
-          },
-          data: {
-            confirm: "Are you sure you want to request Alces management of #{subject.name}?"
-          })
-      end
-    end
 
     it 'gives nothing for internal Service' do
       service = create(:service, internal: true).decorate

--- a/spec/decorators/service_decorator_spec.rb
+++ b/spec/decorators/service_decorator_spec.rb
@@ -1,17 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ServiceDecorator do
-  describe '#change_support_type_button' do
-    let! :request_advice_issue { create(:request_service_becomes_advice_issue) }
-    let! :request_managed_issue { create(:request_service_becomes_managed_issue) }
-
-    it 'gives nothing for internal Service' do
-      service = create(:service, internal: true).decorate
-
-      expect(service.change_support_type_button).to be nil
-    end
-  end
-
   describe '#links' do
     subject { create(:service).decorate }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -84,6 +84,10 @@ FactoryBot.define do
       type: 'input',
       name: 'some_field',
     }]
+
+    factory :level_1_tier do
+      level 1
+    end
   end
 
   factory :asset_record_field_definition, aliases: [:definition] do

--- a/spec/factories/case.rb
+++ b/spec/factories/case.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     issue
     cluster
     user
-    details "Oh no, my science isn't working"
     fields [{name: 'Details', value: 'some_details'}]
     tier_level 2
 

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -11,26 +11,30 @@ FactoryBot.define do
 
     factory :issue_requiring_component do
       requires_component true
+
+      factory :request_component_becomes_advice_issue do
+        identifier Issue::IDENTIFIERS.request_component_becomes_advice
+        support_type 'managed'
+      end
+
+      factory :request_component_becomes_managed_issue do
+        identifier Issue::IDENTIFIERS.request_component_becomes_managed
+        support_type 'advice-only'
+      end
     end
 
     factory :issue_requiring_service do
       requires_service true
-    end
 
-    factory :request_component_becomes_advice_issue do
-      identifier Issue::IDENTIFIERS.request_component_becomes_advice
-    end
+      factory :request_service_becomes_advice_issue do
+        identifier Issue::IDENTIFIERS.request_service_becomes_advice
+        support_type 'managed'
+      end
 
-    factory :request_component_becomes_managed_issue do
-      identifier Issue::IDENTIFIERS.request_component_becomes_managed
-    end
-
-    factory :request_service_becomes_advice_issue do
-      identifier Issue::IDENTIFIERS.request_service_becomes_advice
-    end
-
-    factory :request_service_becomes_managed_issue do
-      identifier Issue::IDENTIFIERS.request_service_becomes_managed
+      factory :request_service_becomes_managed_issue do
+        identifier Issue::IDENTIFIERS.request_service_becomes_managed
+        support_type 'advice-only'
+      end
     end
 
     factory :special_issue do

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -15,11 +15,13 @@ FactoryBot.define do
       factory :request_component_becomes_advice_issue do
         identifier Issue::IDENTIFIERS.request_component_becomes_advice
         support_type 'managed'
+        tiers { [create(:level_1_tier)] }
       end
 
       factory :request_component_becomes_managed_issue do
         identifier Issue::IDENTIFIERS.request_component_becomes_managed
         support_type 'advice-only'
+        tiers { [create(:level_1_tier)] }
       end
     end
 
@@ -29,11 +31,13 @@ FactoryBot.define do
       factory :request_service_becomes_advice_issue do
         identifier Issue::IDENTIFIERS.request_service_becomes_advice
         support_type 'managed'
+        tiers { [create(:level_1_tier)] }
       end
 
       factory :request_service_becomes_managed_issue do
         identifier Issue::IDENTIFIERS.request_service_becomes_managed
         support_type 'advice-only'
+        tiers { [create(:level_1_tier)] }
       end
     end
 

--- a/spec/features/components_spec.rb
+++ b/spec/features/components_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature '/components/', type: :feature do
+  before :each do
+    # Prevent attempting to retrieve documents from S3 when Cluster page
+    # visited.
+    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
+
+    create(:request_component_becomes_managed_issue)
+    create(:request_component_becomes_advice_issue)
+  end
+
+  let :site { create(:site) }
+  let :contact { create(:contact, site: site) }
+  let :cluster { create(:cluster, site: site) }
+
+  it 'can request self-management of a managed Component' do
+    component = create(:managed_component, cluster: cluster)
+
+    visit cluster_components_path(cluster, as: contact)
+    click_button 'Request self-management'
+
+    created_case = component.cases.first
+    expect(created_case.component).to eq(component)
+    issue = Issue.request_component_becomes_advice_issue
+    expect(created_case.issue).to eq(issue)
+    tier = issue.tiers.first
+    expect(created_case.fields).to eq(tier.fields)
+    expect(created_case.tier_level).to eq(tier.level)
+  end
+
+  it 'can request Alces management of an advice-only Component' do
+    component = create(:advice_component, cluster: cluster)
+
+    visit cluster_components_path(cluster, as: contact)
+    click_button 'Request Alces management'
+
+    created_case = component.cases.first
+    expect(created_case.component).to eq(component)
+    issue = Issue.request_component_becomes_managed_issue
+    expect(created_case.issue).to eq(issue)
+    tier = issue.tiers.first
+    expect(created_case.fields).to eq(tier.fields)
+    expect(created_case.tier_level).to eq(tier.level)
+  end
+end

--- a/spec/features/components_spec.rb
+++ b/spec/features/components_spec.rb
@@ -1,46 +1,5 @@
 require 'rails_helper'
 
 RSpec.feature '/components/', type: :feature do
-  before :each do
-    # Prevent attempting to retrieve documents from S3 when Cluster page
-    # visited.
-    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
-
-    create(:request_component_becomes_managed_issue)
-    create(:request_component_becomes_advice_issue)
-  end
-
-  let :site { create(:site) }
-  let :contact { create(:contact, site: site) }
-  let :cluster { create(:cluster, site: site) }
-
-  it 'can request self-management of a managed Component' do
-    component = create(:managed_component, cluster: cluster)
-
-    visit cluster_components_path(cluster, as: contact)
-    click_button 'Request self-management'
-
-    created_case = component.cases.first
-    expect(created_case.component).to eq(component)
-    issue = Issue.request_component_becomes_advice_issue
-    expect(created_case.issue).to eq(issue)
-    tier = issue.tiers.first
-    expect(created_case.fields).to eq(tier.fields)
-    expect(created_case.tier_level).to eq(tier.level)
-  end
-
-  it 'can request Alces management of an advice-only Component' do
-    component = create(:advice_component, cluster: cluster)
-
-    visit cluster_components_path(cluster, as: contact)
-    click_button 'Request Alces management'
-
-    created_case = component.cases.first
-    expect(created_case.component).to eq(component)
-    issue = Issue.request_component_becomes_managed_issue
-    expect(created_case.issue).to eq(issue)
-    tier = issue.tiers.first
-    expect(created_case.fields).to eq(tier.fields)
-    expect(created_case.tier_level).to eq(tier.level)
-  end
+  it_behaves_like 'can request support_type change via buttons', :component
 end

--- a/spec/features/log_spec.rb
+++ b/spec/features/log_spec.rb
@@ -11,9 +11,9 @@ RSpec.feature Log, type: :feature do
 
   # Create the components and cases for each spec
   before :each do
-    create(:case, details: 'Random other case')
-    ['details1', 'details2', 'details3'].each do |details|
-      create(:case, cluster: cluster, details: details)
+    create(:case, subject: 'Random other case')
+    ['subject1', 'subject2', 'subject3'].each do |case_subject|
+      create(:case, cluster: cluster, subject: case_subject)
     end
 
     create(:component, name: 'Random other component')
@@ -119,10 +119,10 @@ RSpec.feature Log, type: :feature do
     subject { cluster.components.first }
 
     before :each do
-      ['component_case1', 'component_case2'].each do |details|
+      ['component_case1', 'component_case2'].each do |case_subject|
         create :case_requiring_component,
                component: subject,
-               details: details
+               subject: case_subject
       end
       visit component_logs_path subject, as: engineer
     end

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -1,46 +1,5 @@
 require 'rails_helper'
 
 RSpec.feature '/services/', type: :feature do
-  before :each do
-    # Prevent attempting to retrieve documents from S3 when Cluster page
-    # visited.
-    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
-
-    create(:request_service_becomes_managed_issue)
-    create(:request_service_becomes_advice_issue)
-  end
-
-  let :site { create(:site) }
-  let :contact { create(:contact, site: site) }
-  let :cluster { create(:cluster, site: site) }
-
-  it 'can request self-management of a managed Service' do
-    service = create(:managed_service, cluster: cluster)
-
-    visit cluster_services_path(cluster, as: contact)
-    click_button 'Request self-management'
-
-    created_case = service.cases.first
-    expect(created_case.service).to eq(service)
-    issue = Issue.request_service_becomes_advice_issue
-    expect(created_case.issue).to eq(issue)
-    tier = issue.tiers.first
-    expect(created_case.fields).to eq(tier.fields)
-    expect(created_case.tier_level).to eq(tier.level)
-  end
-
-  it 'can request Alces management of an advice-only Service' do
-    service = create(:advice_service, cluster: cluster)
-
-    visit cluster_services_path(cluster, as: contact)
-    click_button 'Request Alces management'
-
-    created_case = service.cases.first
-    expect(created_case.service).to eq(service)
-    issue = Issue.request_service_becomes_managed_issue
-    expect(created_case.issue).to eq(issue)
-    tier = issue.tiers.first
-    expect(created_case.fields).to eq(tier.fields)
-    expect(created_case.tier_level).to eq(tier.level)
-  end
+  it_behaves_like 'can request support_type change via buttons', :service
 end

--- a/spec/features/services_spec.rb
+++ b/spec/features/services_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature '/services/', type: :feature do
+  before :each do
+    # Prevent attempting to retrieve documents from S3 when Cluster page
+    # visited.
+    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
+
+    create(:request_service_becomes_managed_issue)
+    create(:request_service_becomes_advice_issue)
+  end
+
+  let :site { create(:site) }
+  let :contact { create(:contact, site: site) }
+  let :cluster { create(:cluster, site: site) }
+
+  it 'can request self-management of a managed Service' do
+    service = create(:managed_service, cluster: cluster)
+
+    visit cluster_services_path(cluster, as: contact)
+    click_button 'Request self-management'
+
+    created_case = service.cases.first
+    expect(created_case.service).to eq(service)
+    issue = Issue.request_service_becomes_advice_issue
+    expect(created_case.issue).to eq(issue)
+    tier = issue.tiers.first
+    expect(created_case.fields).to eq(tier.fields)
+    expect(created_case.tier_level).to eq(tier.level)
+  end
+
+  it 'can request Alces management of an advice-only Service' do
+    service = create(:advice_service, cluster: cluster)
+
+    visit cluster_services_path(cluster, as: contact)
+    click_button 'Request Alces management'
+
+    created_case = service.cases.first
+    expect(created_case.service).to eq(service)
+    issue = Issue.request_service_becomes_managed_issue
+    expect(created_case.issue).to eq(issue)
+    tier = issue.tiers.first
+    expect(created_case.fields).to eq(tier.fields)
+    expect(created_case.tier_level).to eq(tier.level)
+  end
+end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -217,13 +217,13 @@ RSpec.describe Case, type: :model do
 
   describe '#active' do
     it 'returns all non-archived Cases' do
-      create(:case, details: 'one', archived: false)
-      create(:case, details: 'two', archived: true)
-      create(:case, details: 'three', archived: false)
+      create(:case, subject: 'one', archived: false)
+      create(:case, subject: 'two', archived: true)
+      create(:case, subject: 'three', archived: false)
 
       active_cases = Case.active
 
-      expect(active_cases.map(&:details)).to match_array(['one', 'three'])
+      expect(active_cases.map(&:subject)).to match_array(['one', 'three'])
     end
   end
 

--- a/spec/support/shared_examples/support_type_change_buttons.rb
+++ b/spec/support/shared_examples/support_type_change_buttons.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'can request support_type change via buttons' do |part_name|
+  part_class_name = part_name.to_s.titlecase
+
+  before :each do
+    # Prevent attempting to retrieve documents from S3 when Cluster page
+    # visited.
+    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
+
+    create(:"request_#{part_name}_becomes_managed_issue")
+    create(:"request_#{part_name}_becomes_advice_issue")
+  end
+
+  let :site { create(:site) }
+  let :contact { create(:contact, site: site) }
+  let :cluster { create(:cluster, site: site) }
+
+  let :cluster_parts_path do
+    send("cluster_#{part_name.to_s.pluralize}_path", cluster, as: contact)
+  end
+
+  it "can request self-management of a managed #{part_class_name}" do
+    part = create("managed_#{part_name}", cluster: cluster)
+
+    visit cluster_parts_path
+    click_button 'Request self-management'
+
+    created_case = part.cases.first
+    expect(created_case.send(part_name)).to eq(part)
+    issue = Issue.send("request_#{part_name}_becomes_advice_issue")
+    expect(created_case.issue).to eq(issue)
+    tier = issue.tiers.first
+    expect(created_case.fields).to eq(tier.fields)
+    expect(created_case.tier_level).to eq(tier.level)
+  end
+
+  it "can request Alces management of an advice-only #{part_class_name}" do
+    part = create("advice_#{part_name}", cluster: cluster)
+
+    visit cluster_parts_path
+    click_button 'Request Alces management'
+
+    created_case = part.cases.first
+    expect(created_case.send(part_name)).to eq(part)
+    issue = Issue.send("request_#{part_name}_becomes_managed_issue")
+    expect(created_case.issue).to eq(issue)
+    tier = issue.tiers.first
+    expect(created_case.fields).to eq(tier.fields)
+    expect(created_case.tier_level).to eq(tier.level)
+  end
+end

--- a/spec/support/shared_examples/support_type_change_buttons.rb
+++ b/spec/support/shared_examples/support_type_change_buttons.rb
@@ -12,6 +12,9 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
     create(:"request_#{part_name}_becomes_advice_issue")
   end
 
+  let :request_self_management_text { 'Request self-management' }
+  let :request_alces_management_text { 'Request Alces management' }
+
   let :site { create(:site) }
   let :contact { create(:contact, site: site) }
   let :cluster { create(:cluster, site: site) }
@@ -39,7 +42,7 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
     part = create("advice_#{part_name}", cluster: cluster)
 
     visit cluster_parts_path
-    click_button 'Request Alces management'
+    click_button request_alces_management_text
 
     created_case = part.cases.first
     expect(created_case.send(part_name)).to eq(part)
@@ -48,5 +51,16 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
     tier = issue.tiers.first
     expect(created_case.fields).to eq(tier.fields)
     expect(created_case.tier_level).to eq(tier.level)
+  end
+
+  it "displays no buttons for internal #{part_class_name}" do
+    part = create(part_name, internal: true, cluster: cluster)
+
+    visit cluster_parts_path
+    # Sanity check that part itself is actually being displayed.
+    expect(page).to have_text(part.name)
+
+    expect(page).not_to have_button(request_self_management_text)
+    expect(page).not_to have_button(request_alces_management_text)
   end
 end


### PR DESCRIPTION
This PR changes the Case form submission so the entered `fields`, as originally given by the selected Tier but with value entries also set, are submitted with the form as JSON rather than by forming a single `details` string as was previously done. These `fields` are then saved and can then be viewed on the Case page as a table of field names and values, rather than showing a single 'Details' section.

As part of doing this the buttons shown for Components and Services to request a change of support type also needed to be changed to submit the correct `fields` rather than `details`, and while doing this the test coverage of these was also improved.

Following this change the Case `details` column was then able to be made nullable and mostly be removed from being used in the app, and will be able to be removed entirely once the latest changes have been deployed.

Trello: https://trello.com/c/jhMKhdFQ/231-handle-submission-of-case-form-with-dynamic-tier-fields-1-day
