### PR TITLE
Disable non consultancy support for self managed things

### DIFF
--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -15,4 +15,14 @@
     margin-top: $margin;
     margin-bottom: $margin;
   }
+
+  section {
+    padding: 10px;
+  }
+
+  .disabled-section {
+    border: 1px #111 solid;
+    border-radius: 5px;
+    opacity: 0.5;
+  }
 }

--- a/app/javascript/packs/Field.elm
+++ b/app/javascript/packs/Field.elm
@@ -12,3 +12,20 @@ type Field
     | Component
     | Subject
     | TierField Tier.TextInputData
+
+
+{-| The 'dynamic' fields are those shown in the lower section of the form,
+whose value and/or presence frequently changes based on the selected Issue and
+Tier.
+-}
+isDynamicField : Field -> Bool
+isDynamicField field =
+    case field of
+        Subject ->
+            True
+
+        TierField _ ->
+            True
+
+        _ ->
+            False

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -11,7 +11,6 @@ module Issue
         , selectTier
         , setSubject
         , subject
-        , supportType
         , tiers
         , updateSelectedTierField
         )
@@ -19,7 +18,6 @@ module Issue
 import Json.Decode as D
 import SelectList exposing (SelectList)
 import SelectList.Extra
-import SupportType exposing (SupportType(..))
 import Tier exposing (Tier)
 import Utils
 
@@ -33,7 +31,6 @@ type alias IssueData =
     { id : Id
     , name : String
     , subject : String
-    , supportType : SupportType
     , chargeable : Bool
     , tiers : SelectList Tier
     }
@@ -47,14 +44,13 @@ decoder : D.Decoder Issue
 decoder =
     let
         createIssue =
-            \id name requiresComponent defaultSubject supportType chargeable tiers ->
+            \id name requiresComponent defaultSubject chargeable tiers ->
                 let
                     data =
                         IssueData
                             id
                             name
                             defaultSubject
-                            supportType
                             chargeable
                             tiers
                 in
@@ -63,12 +59,11 @@ decoder =
                 else
                     StandardIssue data
     in
-    D.map7 createIssue
+    D.map6 createIssue
         (D.field "id" D.int |> D.map Id)
         (D.field "name" D.string)
         (D.field "requiresComponent" D.bool)
         (D.field "defaultSubject" D.string)
-        (D.field "supportType" SupportType.decoder)
         (D.field "chargeable" D.bool)
         (D.field "tiers" <| SelectList.Extra.orderedDecoder Tier.levelAsInt Tier.decoder)
 
@@ -147,11 +142,6 @@ updateIssueData changeData issue =
 
         StandardIssue _ ->
             StandardIssue newData
-
-
-supportType : Issue -> SupportType
-supportType issue =
-    data issue |> .supportType
 
 
 isChargeable : Issue -> Bool

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -1,6 +1,7 @@
 module State
     exposing
         ( State
+        , associatedModelTypeName
         , canRequestSupportForSelectedTier
         , decoder
         , encoder
@@ -277,3 +278,11 @@ associatedModelSupportType state =
         selectedComponent state |> .supportType
     else
         selectedService state |> .supportType
+
+
+associatedModelTypeName : State -> String
+associatedModelTypeName state =
+    if selectedIssue state |> Issue.requiresComponent then
+        "component"
+    else
+        "service"

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -2,7 +2,6 @@ module State
     exposing
         ( State
         , associatedModelTypeName
-        , canRequestSupportForSelectedTier
         , decoder
         , encoder
         , selectedComponent
@@ -10,6 +9,7 @@ module State
         , selectedService
         , selectedServiceAvailableIssues
         , selectedTier
+        , selectedTierSupportUnavailable
         )
 
 import Bootstrap.Modal as Modal
@@ -241,8 +241,8 @@ selectedServiceAvailableIssues state =
     selectedService state |> .issues |> Issues.availableIssues
 
 
-canRequestSupportForSelectedTier : State -> Bool
-canRequestSupportForSelectedTier state =
+selectedTierSupportUnavailable : State -> Bool
+selectedTierSupportUnavailable state =
     let
         tier =
             selectedTier state
@@ -250,19 +250,19 @@ canRequestSupportForSelectedTier state =
     case tier.level of
         Tier.Three ->
             -- Can always request Tier 3 support.
-            True
+            False
 
         _ ->
             case associatedModelSupportType state of
                 SupportType.Managed ->
                     -- Can request any Tier support for managed
                     -- Components/Services.
-                    True
+                    False
 
                 SupportType.Advice ->
                     -- Cannot request any other Tier support for advice-only
                     -- Components/Services.
-                    False
+                    True
 
 
 {-| Returns the SupportType for the currently selected 'associated model'.

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -13,12 +13,10 @@ module State
 import Bootstrap.Modal as Modal
 import Cluster exposing (Cluster)
 import Component exposing (Component)
-import Dict
 import Issue exposing (Issue)
 import Issues
 import Json.Decode as D
 import Json.Encode as E
-import Maybe.Extra
 import SelectList exposing (SelectList)
 import SelectList.Extra
 import Service exposing (Service)

--- a/app/javascript/packs/SupportType.elm
+++ b/app/javascript/packs/SupportType.elm
@@ -6,9 +6,6 @@ import Json.Decode as D
 type SupportType
     = Managed
     | Advice
-      -- `advice-only` only makes sense for Issues; indicates the Issue can only
-      -- be associated with an `advice` Component.
-    | AdviceOnly
 
 
 type alias HasSupportType a =
@@ -26,9 +23,6 @@ decoder =
 
                     "advice" ->
                         D.succeed Advice
-
-                    "advice-only" ->
-                        D.succeed AdviceOnly
 
                     other ->
                         D.fail ("Unknown support type: " ++ other)

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -71,8 +71,8 @@ subjectPresentValidator =
 
 createAvailableTierValidator : State -> Validator Error State
 createAvailableTierValidator state =
-    Validate.ifFalse
-        State.canRequestSupportForSelectedTier
+    Validate.ifTrue
+        State.selectedTierSupportUnavailable
         ( Field.Tier, Message <| unavailableTierErrorMessage state )
 
 

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -29,7 +29,11 @@ invalidState state =
 
 validateState : State -> List Error
 validateState state =
-    Validate.validate stateValidator state
+    let
+        validator =
+            createStateValidator state
+    in
+    Validate.validate validator state
 
 
 validateField : Field -> State -> List Error
@@ -44,13 +48,18 @@ validateField field state =
     validateState state |> errorsForField
 
 
-stateValidator : Validator Error State
-stateValidator =
+createStateValidator : State -> Validator Error State
+createStateValidator state =
+    let
+        tierErrorMessage =
+            "Selected "
+                ++ State.associatedModelTypeName state
+                ++ """ is self-managed; if required you may only request
+            consultancy support from Alces Software."""
+    in
     Validate.all
         [ Validate.ifBlank (State.selectedIssue >> Issue.subject) ( Field.Subject, Empty )
-
-        -- XXX Display error message for this error.
-        , Validate.ifFalse State.canRequestSupportForSelectedTier ( Field.Tier, Empty )
+        , Validate.ifFalse State.canRequestSupportForSelectedTier ( Field.Tier, Message tierErrorMessage )
 
         -- XXX Not handling any other validations for now, as these are
         -- currently either very improbable or impossible to trigger (at least

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -19,11 +19,7 @@ type alias Error =
 
 type ErrorMessage
     = Empty
-
-
-
--- XXX Add and handle this ErrorMessage case when we actually need it.
--- | Message String
+    | Message String
 
 
 invalidState : State -> Bool

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -53,6 +53,9 @@ stateValidator =
     Validate.all
         [ Validate.ifBlank (State.selectedIssue >> Issue.subject) ( Field.Subject, Empty )
 
+        -- XXX Display error message for this error.
+        , Validate.ifFalse State.canRequestSupportForSelectedTier ( Field.Tier, Empty )
+
         -- XXX Not handling any other validations for now, as these are
         -- currently either very improbable or impossible to trigger (at least
         -- with the current production data and how we initialize the Case form

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -80,5 +80,5 @@ unavailableTierErrorMessage : State -> String
 unavailableTierErrorMessage state =
     "Selected "
         ++ State.associatedModelTypeName state
-        ++ """ is self-managed; if required you may only request consultancy
-        support from Alces Software."""
+        ++ " is self-managed; if required you may only request consultancy"
+        ++ " support from Alces Software."

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -3,6 +3,7 @@ module Validation
         ( Error
         , ErrorMessage(..)
         , invalidState
+        , unavailableTierErrorMessage
         , validateField
         , validateState
         )
@@ -70,13 +71,14 @@ subjectPresentValidator =
 
 createAvailableTierValidator : State -> Validator Error State
 createAvailableTierValidator state =
-    let
-        errorMessage =
-            "Selected "
-                ++ State.associatedModelTypeName state
-                ++ """ is self-managed; if required you may only request
-                consultancy support from Alces Software."""
-    in
     Validate.ifFalse
         State.canRequestSupportForSelectedTier
-        ( Field.Tier, Message errorMessage )
+        ( Field.Tier, Message <| unavailableTierErrorMessage state )
+
+
+unavailableTierErrorMessage : State -> String
+unavailableTierErrorMessage state =
+    "Selected "
+        ++ State.associatedModelTypeName state
+        ++ """ is self-managed; if required you may only request consultancy
+        support from Alces Software."""

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -52,6 +52,7 @@ issueDrillDownFields state =
     , maybeServicesField state
     , maybeCategoriesField state
     , issuesField state |> Just
+    , maybeComponentsField state
     , tierSelectField state |> Just
     ]
 
@@ -78,7 +79,6 @@ dynamicFields state =
 
         _ ->
             [ subjectField state |> Just
-            , maybeComponentsField state
             , tierFields
             , submitButton state |> Just
             ]

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -87,7 +87,7 @@ dynamicFields state =
                 []
 
         sectionDisabled =
-            not <| State.canRequestSupportForSelectedTier state
+            State.selectedTierSupportUnavailable state
 
         selectedTier =
             State.selectedTier state

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -33,55 +33,58 @@ view state =
                 StartSubmit
 
         formElements =
-            List.concat
-                [ issueDrillDownFields state
-                , [ hr [] [] |> Just ]
-                , dynamicFields state
-                ]
-                |> Maybe.Extra.values
+            [ issueDrillDownFields state
+            , hr [] []
+            , dynamicFields state
+            ]
     in
     Html.form [ onSubmit submitMsg ] formElements
 
 
-issueDrillDownFields : State -> List (Maybe (Html Msg))
+issueDrillDownFields : State -> Html Msg
 issueDrillDownFields state =
     -- These fields allow a user to drill down to identify the particular Issue
     -- and possible solutions (via different Tiers) to a problem they are
     -- having.
-    [ maybeClustersField state
-    , maybeServicesField state
-    , maybeCategoriesField state
-    , issuesField state |> Just
-    , maybeComponentsField state
-    , tierSelectField state |> Just
-    ]
+    section [] <|
+        Maybe.Extra.values
+            [ maybeClustersField state
+            , maybeServicesField state
+            , maybeCategoriesField state
+            , issuesField state |> Just
+            , maybeComponentsField state
+            , tierSelectField state |> Just
+            ]
 
 
-dynamicFields : State -> List (Maybe (Html Msg))
+dynamicFields : State -> Html Msg
 dynamicFields state =
     -- These fields are very dynamic, and either appear/disappear entirely or
     -- have their content changed based on the currently selected Issue and
     -- Tier.
     let
+        fields =
+            case selectedTier.level of
+                Tier.Zero ->
+                    -- When a level 0 Tier is selected we want to prevent filling in
+                    -- any fields or submitting the form, and only show the rendered
+                    -- Tier fields, which should include the relevant links to
+                    -- documentation.
+                    [ tierFields ]
+
+                _ ->
+                    [ subjectField state
+                    , tierFields
+                    , submitButton state
+                    ]
+
         selectedTier =
             State.selectedTier state
 
         tierFields =
-            dynamicTierFields state |> Just
+            dynamicTierFields state
     in
-    case selectedTier.level of
-        Tier.Zero ->
-            -- When a level 0 Tier is selected we want to prevent filling in
-            -- any fields or submitting the form, and only show the rendered
-            -- Tier fields, which should include the relevant links to
-            -- documentation.
-            [ tierFields ]
-
-        _ ->
-            [ subjectField state |> Just
-            , tierFields
-            , submitButton state |> Just
-            ]
+    section [] fields
 
 
 maybeClustersField : State -> Maybe (Html Msg)

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -78,13 +78,24 @@ dynamicFields state =
                     , submitButton state
                     ]
 
+        attributes =
+            if sectionDisabled then
+                [ class "disabled-section"
+                , title <| Validation.unavailableTierErrorMessage state
+                ]
+            else
+                []
+
+        sectionDisabled =
+            not <| State.canRequestSupportForSelectedTier state
+
         selectedTier =
             State.selectedTier state
 
         tierFields =
             dynamicTierFields state
     in
-    section [] fields
+    section attributes fields
 
 
 maybeClustersField : State -> Maybe (Html Msg)

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -120,7 +120,7 @@ formField field item htmlFn additionalAttributes children state =
             tierIsUnavailable && Field.isDynamicField field
 
         tierIsUnavailable =
-            not <| State.canRequestSupportForSelectedTier state
+            State.selectedTierSupportUnavailable state
 
         identifier =
             fieldIdentifier fieldName

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -116,6 +116,12 @@ formField field item htmlFn additionalAttributes children state =
                 _ ->
                     toString field
 
+        fieldIsUnavailable =
+            tierIsUnavailable && Field.isDynamicField field
+
+        tierIsUnavailable =
+            not <| State.canRequestSupportForSelectedTier state
+
         identifier =
             fieldIdentifier fieldName
 
@@ -123,6 +129,7 @@ formField field item htmlFn additionalAttributes children state =
             List.append
                 [ id identifier
                 , class (formControlClasses errors)
+                , disabled fieldIsUnavailable
                 ]
                 additionalAttributes
 

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -10,6 +10,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
 import Json.Decode as D
+import Maybe.Extra
 import SelectList exposing (Position(..), SelectList)
 import State exposing (State)
 import String.Extra
@@ -162,18 +163,23 @@ bootstrapValidationClass errors =
 validationFeedback : List Error -> Html msg
 validationFeedback errors =
     let
-        errorMessage =
-            -- This elaborate pattern matching to just get an empty string is
-            -- to remind me to actually display the error message(s) once we
-            -- make it possible to set these (as this will then fail to
-            -- compile).
-            case List.head errors of
-                Just ( field, Empty ) ->
-                    ""
+        combinedErrorMessages =
+            List.map unpackErrorMessage errorMessages
+                |> Maybe.Extra.values
+                |> String.join "; "
 
-                Nothing ->
-                    ""
+        errorMessages =
+            List.map Tuple.second errors
+
+        unpackErrorMessage =
+            \error ->
+                case error of
+                    Empty ->
+                        Nothing
+
+                    Message message ->
+                        Just message
     in
     div
         [ class "invalid-feedback" ]
-        [ text errorMessage ]
+        [ text combinedErrorMessages ]

--- a/app/javascript/packs/View/PartsField.elm
+++ b/app/javascript/packs/View/PartsField.elm
@@ -75,14 +75,3 @@ maybePartsField field partsFieldConfig toId state changeMsg =
             -- Issue does not require a part of this type => do not show any
             -- select.
             Nothing
-
-
-errorForClusterPart : String -> HasSupportType a -> String
-errorForClusterPart partName part =
-    if SupportType.isManaged part then
-        "This " ++ partName ++ " is already fully managed."
-    else
-        "This "
-            ++ partName
-            ++ """ is self-managed; if required you may only request
-            consultancy support from Alces Software."""


### PR DESCRIPTION
This PR changes the behaviour of the Case form so that when a Tier is unavailable for the currently selected Component, or Service if a Component is not required, then:

- the Tier is indicated as invalid with a relevant error message;

- submitting the form is correspondingly disabled;

- all inputs in the lower section of the form are disabled, and this section is faded out with title text indicating why this is the case.

Trello: https://trello.com/c/V3JLLsLh/235-disable-tier-0-2-support-for-self-managed-clusters-services-components-1-2-day