### PR TITLE
Show unavailable Tiers as disabled

### DIFF
--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -25,4 +25,10 @@
     border-radius: 5px;
     opacity: 0.5;
   }
+
+  // Make disabled select options look disabled.
+  select option:disabled {
+   background: #ccc;
+   color: #000;
+  }
 }

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -1,8 +1,8 @@
 class CaseDecorator < ApplicationDecorator
   delegate_all
 
-  # Note: These should match values used in `Tier.description` in Case form
-  # app.
+  # Note: These should match values used in `Tier.Level.description` in Case
+  # form app.
   TIER_DESCRIPTIONS = {
     1 => 'Tool',
     2 => 'Support',

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -65,7 +65,11 @@ decoder =
         (D.field "requiresComponent" D.bool)
         (D.field "defaultSubject" D.string)
         (D.field "chargeable" D.bool)
-        (D.field "tiers" <| SelectList.Extra.orderedDecoder Tier.levelAsInt Tier.decoder)
+        (D.field "tiers" <|
+            SelectList.Extra.orderedDecoder
+                (.level >> Tier.levelAsInt)
+                Tier.decoder
+        )
 
 
 extractId : Issue -> Int

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -19,6 +19,7 @@ import Json.Decode as D
 import SelectList exposing (SelectList)
 import SelectList.Extra
 import Tier exposing (Tier)
+import Tier.Level
 import Utils
 
 
@@ -67,7 +68,7 @@ decoder =
         (D.field "chargeable" D.bool)
         (D.field "tiers" <|
             SelectList.Extra.orderedDecoder
-                (.level >> Tier.levelAsInt)
+                (.level >> Tier.Level.asInt)
                 Tier.decoder
         )
 

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -201,7 +201,7 @@ encoder state =
                 , ( "component_id", componentIdValue )
                 , ( "service_id", serviceIdValue )
                 , ( "subject", Issue.subject issue |> E.string )
-                , ( "tier_level", Tier.levelAsInt tier |> E.int )
+                , ( "tier_level", Tier.levelAsInt tier.level |> E.int )
                 , ( "fields", Tier.fieldsEncoder tier )
                 ]
           )

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -24,6 +24,7 @@ import SelectList.Extra
 import Service exposing (Service)
 import SupportType exposing (SupportType)
 import Tier exposing (Tier)
+import Tier.Level
 
 
 type alias State =
@@ -201,7 +202,7 @@ encoder state =
                 , ( "component_id", componentIdValue )
                 , ( "service_id", serviceIdValue )
                 , ( "subject", Issue.subject issue |> E.string )
-                , ( "tier_level", Tier.levelAsInt tier.level |> E.int )
+                , ( "tier_level", Tier.Level.asInt tier.level |> E.int )
                 , ( "fields", Tier.fieldsEncoder tier )
                 ]
           )
@@ -248,7 +249,7 @@ selectedTierSupportUnavailable state =
             selectedTier state
     in
     case tier.level of
-        Tier.Three ->
+        Tier.Level.Three ->
             -- Can always request Tier 3 support.
             False
 

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -2,14 +2,11 @@ module Tier
     exposing
         ( Field(..)
         , Id(..)
-        , Level(..)
         , TextInputData
         , Tier
         , decoder
-        , description
         , extractId
         , fieldsEncoder
-        , levelAsInt
         , setFieldValue
         )
 
@@ -18,6 +15,7 @@ import Dict exposing (Dict)
 import Json.Decode as D
 import Json.Encode as E
 import Maybe.Extra
+import Tier.Level as Level exposing (Level)
 import Types
 
 
@@ -30,13 +28,6 @@ type alias Tier =
 
 type Id
     = Id Int
-
-
-type Level
-    = Zero
-    | One
-    | Two
-    | Three
 
 
 type Field
@@ -59,7 +50,7 @@ type alias TextInputData =
 decoder : D.Decoder Tier
 decoder =
     D.field "level" D.int
-        |> D.map intToLevel
+        |> D.map Level.fromInt
         |> D.andThen
             (\levelResult ->
                 case levelResult of
@@ -162,70 +153,11 @@ textFieldTypeToString field =
             "input"
 
 
-levelAsInt : Level -> Int
-levelAsInt level =
-    case level of
-        Zero ->
-            0
-
-        One ->
-            1
-
-        Two ->
-            2
-
-        Three ->
-            3
-
-
-intToLevel : Int -> Result String Level
-intToLevel int =
-    case int of
-        0 ->
-            Ok Zero
-
-        1 ->
-            Ok One
-
-        2 ->
-            Ok Two
-
-        3 ->
-            Ok Three
-
-        _ ->
-            Err <| "Invalid level: " ++ toString int
-
-
 extractId : Tier -> Int
 extractId tier =
     case tier.id of
         Id id ->
             id
-
-
-description : Level -> String
-description level =
-    let
-        humanTierDescription =
-            case level of
-                Zero ->
-                    "Guides"
-
-                One ->
-                    "Tool"
-
-                Two ->
-                    "Support"
-
-                Three ->
-                    "Consultancy"
-
-        tierNumberPrefix =
-            toString (levelAsInt level) ++ ":"
-    in
-    String.join " "
-        [ "Tier", tierNumberPrefix, humanTierDescription ]
 
 
 setFieldValue : Tier -> Int -> String -> Tier

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -162,9 +162,9 @@ textFieldTypeToString field =
             "input"
 
 
-levelAsInt : Tier -> Int
-levelAsInt tier =
-    case tier.level of
+levelAsInt : Level -> Int
+levelAsInt level =
+    case level of
         Zero ->
             0
 
@@ -204,11 +204,11 @@ extractId tier =
             id
 
 
-description : Tier -> String
-description tier =
+description : Level -> String
+description level =
     let
         humanTierDescription =
-            case tier.level of
+            case level of
                 Zero ->
                     "Guides"
 
@@ -222,7 +222,7 @@ description tier =
                     "Consultancy"
 
         tierNumberPrefix =
-            toString (levelAsInt tier) ++ ":"
+            toString (levelAsInt level) ++ ":"
     in
     String.join " "
         [ "Tier", tierNumberPrefix, humanTierDescription ]

--- a/app/javascript/packs/Tier/DisplayWrapper.elm
+++ b/app/javascript/packs/Tier/DisplayWrapper.elm
@@ -1,6 +1,6 @@
 module Tier.DisplayWrapper
     exposing
-        ( DisplayWrapper(..)
+        ( DisplayWrapper
         , description
         , extractId
         , isUnavailable

--- a/app/javascript/packs/Tier/DisplayWrapper.elm
+++ b/app/javascript/packs/Tier/DisplayWrapper.elm
@@ -3,6 +3,7 @@ module Tier.DisplayWrapper
         ( DisplayWrapper(..)
         , description
         , extractId
+        , isUnavailable
         , wrap
         )
 
@@ -91,3 +92,13 @@ toTier wrapper =
 
         UnavailableTier _ ->
             Nothing
+
+
+isUnavailable : DisplayWrapper -> Bool
+isUnavailable wrapper =
+    case wrapper of
+        AvailableTier _ ->
+            False
+
+        UnavailableTier _ ->
+            True

--- a/app/javascript/packs/Tier/DisplayWrapper.elm
+++ b/app/javascript/packs/Tier/DisplayWrapper.elm
@@ -3,15 +3,55 @@ module Tier.DisplayWrapper
         ( DisplayWrapper(..)
         , description
         , extractId
+        , wrap
         )
 
+import SelectList exposing (SelectList)
 import Tier exposing (Tier)
 import Tier.Level as Level exposing (Level)
+import Utils
 
 
 type DisplayWrapper
     = AvailableTier Tier
     | UnavailableTier Level
+
+
+wrap : SelectList Tier -> SelectList DisplayWrapper
+wrap availableTiers =
+    let
+        allLevels =
+            SelectList.fromLists []
+                Level.Zero
+                [ Level.One, Level.Two, Level.Three ]
+
+        wrapTierToDisplay =
+            \level ->
+                case tierWithLevel level of
+                    Just tier ->
+                        AvailableTier tier
+
+                    Nothing ->
+                        UnavailableTier level
+
+        tierWithLevel =
+            \level ->
+                List.filter
+                    (\tier -> tier.level == level)
+                    (SelectList.toList availableTiers)
+                    |> List.head
+
+        reselectSelectedTier =
+            \wrapper ->
+                case wrapper of
+                    AvailableTier tier ->
+                        Utils.sameId tier.id (SelectList.selected availableTiers)
+
+                    UnavailableTier _ ->
+                        False
+    in
+    SelectList.map wrapTierToDisplay allLevels
+        |> SelectList.select reselectSelectedTier
 
 
 extractId : DisplayWrapper -> Int

--- a/app/javascript/packs/Tier/DisplayWrapper.elm
+++ b/app/javascript/packs/Tier/DisplayWrapper.elm
@@ -71,7 +71,19 @@ extractId wrapper =
 
 description : DisplayWrapper -> String
 description wrapper =
-    Level.description <| getLevel wrapper
+    let
+        levelDescription =
+            Level.description <| getLevel wrapper
+    in
+    case wrapper of
+        AvailableTier _ ->
+            levelDescription
+
+        UnavailableTier _ ->
+            String.join " "
+                [ levelDescription
+                , "(unavailable for selected issue)"
+                ]
 
 
 getLevel : DisplayWrapper -> Level

--- a/app/javascript/packs/Tier/DisplayWrapper.elm
+++ b/app/javascript/packs/Tier/DisplayWrapper.elm
@@ -1,0 +1,53 @@
+module Tier.DisplayWrapper
+    exposing
+        ( DisplayWrapper(..)
+        , description
+        , extractId
+        )
+
+import Tier exposing (Tier)
+import Tier.Level as Level exposing (Level)
+
+
+type DisplayWrapper
+    = AvailableTier Tier
+    | UnavailableTier Level
+
+
+extractId : DisplayWrapper -> Int
+extractId wrapper =
+    case toTier wrapper of
+        Just tier ->
+            Tier.extractId tier
+
+        Nothing ->
+            -- Use this as a placeholder ID when we don't have a real Tier and
+            -- so a real ID. Not ideal, but unlikely to ever cause a problem
+            -- and simpler than changing everywhere we expect an Int id to
+            -- accept a Maybe Int.
+            -1
+
+
+description : DisplayWrapper -> String
+description wrapper =
+    Level.description <| getLevel wrapper
+
+
+getLevel : DisplayWrapper -> Level
+getLevel wrapper =
+    case wrapper of
+        AvailableTier tier ->
+            tier.level
+
+        UnavailableTier level ->
+            level
+
+
+toTier : DisplayWrapper -> Maybe Tier
+toTier wrapper =
+    case wrapper of
+        AvailableTier tier ->
+            Just tier
+
+        UnavailableTier _ ->
+            Nothing

--- a/app/javascript/packs/Tier/Level.elm
+++ b/app/javascript/packs/Tier/Level.elm
@@ -1,0 +1,73 @@
+module Tier.Level
+    exposing
+        ( Level(..)
+        , asInt
+        , description
+        , fromInt
+        )
+
+
+type Level
+    = Zero
+    | One
+    | Two
+    | Three
+
+
+asInt : Level -> Int
+asInt level =
+    case level of
+        Zero ->
+            0
+
+        One ->
+            1
+
+        Two ->
+            2
+
+        Three ->
+            3
+
+
+fromInt : Int -> Result String Level
+fromInt int =
+    case int of
+        0 ->
+            Ok Zero
+
+        1 ->
+            Ok One
+
+        2 ->
+            Ok Two
+
+        3 ->
+            Ok Three
+
+        _ ->
+            Err <| "Invalid level: " ++ toString int
+
+
+description : Level -> String
+description level =
+    let
+        humanTierDescription =
+            case level of
+                Zero ->
+                    "Guides"
+
+                One ->
+                    "Tool"
+
+                Two ->
+                    "Support"
+
+                Three ->
+                    "Consultancy"
+
+        tierNumberPrefix =
+            toString (asInt level) ++ ":"
+    in
+    String.join " "
+        [ "Tier", tierNumberPrefix, humanTierDescription ]

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -163,7 +163,7 @@ tierSelectField state =
     Fields.selectField Field.Tier
         selectedIssueTiers
         Tier.extractId
-        Tier.description
+        (.level >> Tier.description)
         ChangeSelectedTier
         state
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -20,7 +20,6 @@ import State exposing (State)
 import Tier exposing (Tier)
 import Tier.DisplayWrapper
 import Tier.Level as Level exposing (Level)
-import Utils
 import Validation
 import View.Fields as Fields
 import View.PartsField as PartsField exposing (PartsFieldConfig(..))
@@ -160,43 +159,13 @@ issuesField state =
 tierSelectField : State -> Html Msg
 tierSelectField state =
     let
-        selectedIssueTiers =
-            State.selectedIssue state |> Issue.tiers
-
-        displayedTiers =
-            SelectList.fromLists
-                []
-                Level.Zero
-                [ Level.One, Level.Two, Level.Three ]
-                |> SelectList.map wrapTierToDisplay
-                |> SelectList.select
-                    (\wrapper ->
-                        case wrapper of
-                            Tier.DisplayWrapper.AvailableTier tier ->
-                                Utils.sameId tier.id (State.selectedTier state)
-
-                            Tier.DisplayWrapper.UnavailableTier _ ->
-                                False
-                    )
-
-        wrapTierToDisplay =
-            \level ->
-                case tierWithLevel level of
-                    Just tier ->
-                        Tier.DisplayWrapper.AvailableTier tier
-
-                    Nothing ->
-                        Tier.DisplayWrapper.UnavailableTier level
-
-        tierWithLevel =
-            \level ->
-                List.filter
-                    (\tier -> tier.level == level)
-                    (SelectList.toList selectedIssueTiers)
-                    |> List.head
+        wrappedTiers =
+            State.selectedIssue state
+                |> Issue.tiers
+                |> Tier.DisplayWrapper.wrap
     in
     Fields.selectField Field.Tier
-        displayedTiers
+        wrappedTiers
         Tier.DisplayWrapper.extractId
         Tier.DisplayWrapper.description
         ChangeSelectedTier

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -18,6 +18,7 @@ import SelectList
 import Service
 import State exposing (State)
 import Tier exposing (Tier)
+import Tier.DisplayWrapper
 import Tier.Level as Level exposing (Level)
 import Utils
 import Validation
@@ -171,10 +172,10 @@ tierSelectField state =
                 |> SelectList.select
                     (\wrapper ->
                         case wrapper of
-                            AvailableTier tier ->
+                            Tier.DisplayWrapper.AvailableTier tier ->
                                 Utils.sameId tier.id (State.selectedTier state)
 
-                            UnavailableTier _ ->
+                            Tier.DisplayWrapper.UnavailableTier _ ->
                                 False
                     )
 
@@ -182,10 +183,10 @@ tierSelectField state =
             \level ->
                 case tierWithLevel level of
                     Just tier ->
-                        AvailableTier tier
+                        Tier.DisplayWrapper.AvailableTier tier
 
                     Nothing ->
-                        UnavailableTier level
+                        Tier.DisplayWrapper.UnavailableTier level
 
         tierWithLevel =
             \level ->
@@ -196,54 +197,10 @@ tierSelectField state =
     in
     Fields.selectField Field.Tier
         displayedTiers
-        extractId
-        description
+        Tier.DisplayWrapper.extractId
+        Tier.DisplayWrapper.description
         ChangeSelectedTier
         state
-
-
-type TierDisplayWrapper
-    = AvailableTier Tier
-    | UnavailableTier Level
-
-
-extractId : TierDisplayWrapper -> Int
-extractId wrapper =
-    case toTier wrapper of
-        Just tier ->
-            Tier.extractId tier
-
-        Nothing ->
-            -- Use this as a placeholder ID when we don't have a real Tier and
-            -- so a real ID. Not ideal, but unlikely to ever cause a problem
-            -- and simpler than changing everywhere we expect an Int id to
-            -- accept a Maybe Int.
-            -1
-
-
-description : TierDisplayWrapper -> String
-description wrapper =
-    Level.description <| getLevel wrapper
-
-
-getLevel : TierDisplayWrapper -> Level
-getLevel wrapper =
-    case wrapper of
-        AvailableTier tier ->
-            tier.level
-
-        UnavailableTier level ->
-            level
-
-
-toTier : TierDisplayWrapper -> Maybe Tier
-toTier wrapper =
-    case wrapper of
-        AvailableTier tier ->
-            Just tier
-
-        UnavailableTier _ ->
-            Nothing
 
 
 maybeComponentsField : State -> Maybe (Html Msg)

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -121,6 +121,7 @@ maybeClustersField state =
                 clusters
                 Cluster.extractId
                 .name
+                (always False)
                 ChangeSelectedCluster
                 state
             )
@@ -137,6 +138,7 @@ maybeCategoriesField state =
                     categories_
                     Category.extractId
                     .name
+                    (always False)
                     ChangeSelectedCategory
                     state
             )
@@ -152,6 +154,7 @@ issuesField state =
         selectedServiceAvailableIssues
         Issue.extractId
         Issue.name
+        (always False)
         ChangeSelectedIssue
         state
 
@@ -168,6 +171,7 @@ tierSelectField state =
         wrappedTiers
         Tier.DisplayWrapper.extractId
         Tier.DisplayWrapper.description
+        (always False)
         ChangeSelectedTier
         state
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -171,7 +171,7 @@ tierSelectField state =
         wrappedTiers
         Tier.DisplayWrapper.extractId
         Tier.DisplayWrapper.description
-        (always False)
+        Tier.DisplayWrapper.isUnavailable
         ChangeSelectedTier
         state
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -18,6 +18,7 @@ import SelectList
 import Service
 import State exposing (State)
 import Tier exposing (Tier)
+import Tier.Level as Level exposing (Level)
 import Utils
 import Validation
 import View.Fields as Fields
@@ -66,7 +67,7 @@ dynamicFields state =
     let
         fields =
             case selectedTier.level of
-                Tier.Zero ->
+                Level.Zero ->
                     -- When a level 0 Tier is selected we want to prevent filling in
                     -- any fields or submitting the form, and only show the rendered
                     -- Tier fields, which should include the relevant links to
@@ -162,7 +163,10 @@ tierSelectField state =
             State.selectedIssue state |> Issue.tiers
 
         displayedTiers =
-            SelectList.fromLists [] Tier.Zero [ Tier.One, Tier.Two, Tier.Three ]
+            SelectList.fromLists
+                []
+                Level.Zero
+                [ Level.One, Level.Two, Level.Three ]
                 |> SelectList.map wrapTierToDisplay
                 |> SelectList.select
                     (\wrapper ->
@@ -200,7 +204,7 @@ tierSelectField state =
 
 type TierDisplayWrapper
     = AvailableTier Tier
-    | UnavailableTier Tier.Level
+    | UnavailableTier Level
 
 
 extractId : TierDisplayWrapper -> Int
@@ -219,10 +223,10 @@ extractId wrapper =
 
 description : TierDisplayWrapper -> String
 description wrapper =
-    Tier.description <| getLevel wrapper
+    Level.description <| getLevel wrapper
 
 
-getLevel : TierDisplayWrapper -> Tier.Level
+getLevel : TierDisplayWrapper -> Level
 getLevel wrapper =
     case wrapper of
         AvailableTier tier ->

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -23,16 +23,18 @@ selectField :
     -> SelectList a
     -> (a -> Int)
     -> (a -> String)
+    -> (a -> Bool)
     -> (String -> msg)
     -> State
     -> Html msg
-selectField field items toId toOptionLabel changeMsg state =
+selectField field items toId toOptionLabel isDisabled changeMsg state =
     let
         fieldOption =
             \position item ->
                 option
                     [ toId item |> toString |> value
                     , position == Selected |> selected
+                    , isDisabled item |> disabled
                     ]
                     [ toOptionLabel item |> text ]
 

--- a/app/javascript/packs/View/PartsField.elm
+++ b/app/javascript/packs/View/PartsField.elm
@@ -45,6 +45,7 @@ maybePartsField field partsFieldConfig toId state changeMsg =
                     parts
                     toId
                     labelForPart
+                    (always False)
                     changeMsg
                     state
                     |> Just


### PR DESCRIPTION
This PR makes it so an option for every possible Tier is always shown in the Case form, but only those which are actually available for the currently selected Issue are able to be selected. Quite a bit of related refactoring done along with this is also included.

Trello: https://trello.com/c/SpYA8Nvh/237-always-show-all-tiers-in-select-box-grey-out-non-available-ones.