### PR TITLE
Show Tier charging info

### DIFF
--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -4,7 +4,6 @@ module Issue
         , Issue
         , decoder
         , extractId
-        , isChargeable
         , name
         , requiresComponent
         , sameId
@@ -32,7 +31,6 @@ type alias IssueData =
     { id : Id
     , name : String
     , subject : String
-    , chargeable : Bool
     , tiers : SelectList Tier
     }
 
@@ -45,14 +43,13 @@ decoder : D.Decoder Issue
 decoder =
     let
         createIssue =
-            \id name requiresComponent defaultSubject chargeable tiers ->
+            \id name requiresComponent defaultSubject tiers ->
                 let
                     data =
                         IssueData
                             id
                             name
                             defaultSubject
-                            chargeable
                             tiers
                 in
                 if requiresComponent then
@@ -60,12 +57,11 @@ decoder =
                 else
                     StandardIssue data
     in
-    D.map6 createIssue
+    D.map5 createIssue
         (D.field "id" D.int |> D.map Id)
         (D.field "name" D.string)
         (D.field "requiresComponent" D.bool)
         (D.field "defaultSubject" D.string)
-        (D.field "chargeable" D.bool)
         (D.field "tiers" <|
             SelectList.Extra.orderedDecoder
                 (.level >> Tier.Level.asInt)
@@ -147,11 +143,6 @@ updateIssueData changeData issue =
 
         StandardIssue _ ->
             StandardIssue newData
-
-
-isChargeable : Issue -> Bool
-isChargeable issue =
-    data issue |> .chargeable
 
 
 data : Issue -> IssueData

--- a/app/javascript/packs/Msg.elm
+++ b/app/javascript/packs/Msg.elm
@@ -17,4 +17,4 @@ type Msg
     | SubmitResponse (Result (Rails.Error String) ())
     | ClearError
     | ClusterChargingInfoModal Modal.State
-    | ChargeableIssuePreSubmissionModal Modal.State
+    | ChargeablePreSubmissionModal Modal.State

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -34,7 +34,7 @@ type alias State =
     , singleService : Bool
     , isSubmitting : Bool
     , clusterChargingInfoModal : Modal.State
-    , chargeableIssuePreSubmissionModal : Modal.State
+    , chargeablePreSubmissionModal : Modal.State
     }
 
 
@@ -54,7 +54,7 @@ decoder =
                         , singleService = False
                         , isSubmitting = False
                         , clusterChargingInfoModal = Modal.hiddenState
-                        , chargeableIssuePreSubmissionModal = Modal.hiddenState
+                        , chargeablePreSubmissionModal = Modal.hiddenState
                         }
                 in
                 case mode of

--- a/app/javascript/packs/State/Update.elm
+++ b/app/javascript/packs/State/Update.elm
@@ -76,8 +76,8 @@ update msg state =
         ClusterChargingInfoModal modalState ->
             Just ({ state | clusterChargingInfoModal = modalState } ! [])
 
-        ChargeableIssuePreSubmissionModal modalState ->
-            Just ({ state | chargeableIssuePreSubmissionModal = modalState } ! [])
+        ChargeablePreSubmissionModal modalState ->
+            Just ({ state | chargeablePreSubmissionModal = modalState } ! [])
 
 
 stringToId : (Int -> id) -> String -> Maybe id

--- a/app/javascript/packs/State/View.elm
+++ b/app/javascript/packs/State/View.elm
@@ -21,7 +21,6 @@ view state =
         (Maybe.Extra.values
             [ Charging.infoModal state |> Just
             , Charging.chargeablePreSubmissionModal state |> Just
-            , State.selectedIssue state |> Charging.chargeableAlert
             , submitErrorAlert state
             , CaseForm.view state |> Just
             ]

--- a/app/javascript/packs/State/View.elm
+++ b/app/javascript/packs/State/View.elm
@@ -1,18 +1,14 @@
 module State.View exposing (view)
 
 import Bootstrap.Alert as Alert
-import Bootstrap.Button as Button
-import Bootstrap.Modal as Modal
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, onSubmit)
-import Issue exposing (Issue)
+import Html.Events exposing (onClick)
 import Maybe.Extra
 import Msg exposing (..)
-import SelectList
 import State exposing (State)
 import View.CaseForm as CaseForm
-import View.Utils
+import View.Charging as Charging
 
 
 -- XXX Refactor functions in here and in `View.*` modules to use
@@ -23,79 +19,13 @@ view : State -> Html Msg
 view state =
     div [ class "case-form" ]
         (Maybe.Extra.values
-            [ chargingInfoModal state |> Just
-            , chargeableIssuePreSubmissionModal state |> Just
-            , State.selectedIssue state |> chargeableIssueAlert
+            [ Charging.infoModal state |> Just
+            , Charging.chargeablePreSubmissionModal state |> Just
+            , State.selectedIssue state |> Charging.chargeableAlert
             , submitErrorAlert state
             , CaseForm.view state |> Just
             ]
         )
-
-
-chargingInfoModal : State -> Html Msg
-chargingInfoModal state =
-    let
-        cluster =
-            SelectList.selected state.clusters
-
-        chargingInfo =
-            cluster.chargingInfo
-                |> Maybe.map text
-                |> Maybe.withDefault noChargingInfoAvailable
-
-        noChargingInfoAvailable =
-            span []
-                [ text "No charging info has been provided by Alces Software for "
-                , strong [] [ text cluster.name ]
-                , text "; if you require clarification on what charges you may incur please contact "
-                , View.Utils.supportEmailLink
-                , text "."
-                ]
-    in
-    Modal.config ClusterChargingInfoModal
-        |> Modal.h5 [] [ cluster.name ++ " charging info" |> text ]
-        |> Modal.body [] [ chargingInfo ]
-        |> Modal.footer []
-            [ Button.button
-                [ Button.outlinePrimary
-                , Button.attrs
-                    [ ClusterChargingInfoModal Modal.hiddenState |> onClick ]
-                ]
-                [ text "Close" ]
-            ]
-        |> Modal.view state.clusterChargingInfoModal
-
-
-chargeableIssuePreSubmissionModal : State -> Html Msg
-chargeableIssuePreSubmissionModal state =
-    let
-        bodyContent =
-            [ p []
-                [ text "The selected issue ("
-                , em [] [ State.selectedIssue state |> Issue.name |> text ]
-                , text ") is chargeable, and creating this support case may incur a support credit charge."
-                ]
-            , p [] [ text "Do you wish to continue?" ]
-            ]
-    in
-    Modal.config ChargeableIssuePreSubmissionModal
-        |> Modal.h5 [] [ text "This support case may incur charges" ]
-        |> Modal.body [] bodyContent
-        |> Modal.footer []
-            [ Button.button
-                [ Button.outlinePrimary
-                , Button.attrs
-                    [ ChargeableIssuePreSubmissionModal Modal.hiddenState |> onClick ]
-                ]
-                [ text "Cancel" ]
-            , Button.button
-                [ Button.outlineWarning
-                , Button.attrs
-                    [ onClick StartSubmit ]
-                ]
-                [ text "Create Case" ]
-            ]
-        |> Modal.view state.chargeableIssuePreSubmissionModal
 
 
 submitErrorAlert : State -> Maybe (Html Msg)
@@ -117,36 +47,3 @@ submitErrorAlert state =
                     ]
     in
     Maybe.map displayError state.error
-
-
-chargeableIssueAlert : Issue -> Maybe (Html Msg)
-chargeableIssueAlert issue =
-    let
-        dollar =
-            span [ class "fa fa-dollar" ] []
-
-        chargingInfo =
-            " This issue is chargeable and may incur a charge of support credits. "
-
-        clusterChargingInfoLinkText =
-            "Click here for the charging details for this cluster."
-    in
-    if Issue.isChargeable issue then
-        Alert.warning
-            [ dollar
-            , dollar
-            , dollar
-            , text chargingInfo
-            , Alert.link
-                [ ClusterChargingInfoModal Modal.visibleState |> onClick
-
-                -- This makes this display as a normal link, but clicking on it
-                -- not reload the page. There may be a better way to do this;
-                -- `href="#"` does not work.
-                , href "javascript:void(0)"
-                ]
-                [ text clusterChargingInfoLinkText ]
-            ]
-            |> Just
-    else
-        Nothing

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -7,6 +7,7 @@ module Tier
         , decoder
         , extractId
         , fieldsEncoder
+        , isChargeable
         , setFieldValue
         )
 
@@ -179,3 +180,13 @@ setFieldValue tier index value =
         | fields =
             Dict.update index updateFieldValue tier.fields
     }
+
+
+isChargeable : Tier -> Bool
+isChargeable tier =
+    case tier.level of
+        Level.Three ->
+            True
+
+        _ ->
+            False

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -30,7 +30,7 @@ view state =
     let
         submitMsg =
             if State.selectedIssue state |> Issue.isChargeable then
-                ChargeableIssuePreSubmissionModal Modal.visibleState
+                ChargeablePreSubmissionModal Modal.visibleState
             else
                 StartSubmit
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -21,6 +21,7 @@ import Tier exposing (Tier)
 import Tier.DisplayWrapper
 import Tier.Level as Level exposing (Level)
 import Validation
+import View.Charging as Charging
 import View.Fields as Fields
 import View.PartsField as PartsField exposing (PartsFieldConfig(..))
 
@@ -56,6 +57,7 @@ issueDrillDownFields state =
             , issuesField state |> Just
             , maybeComponentsField state
             , tierSelectField state |> Just
+            , Charging.chargeableAlert state
             ]
 
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -30,7 +30,7 @@ view : State -> Html Msg
 view state =
     let
         submitMsg =
-            if State.selectedIssue state |> Issue.isChargeable then
+            if State.selectedTier state |> Tier.isChargeable then
                 ChargeablePreSubmissionModal Modal.visibleState
             else
                 StartSubmit

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -1,0 +1,112 @@
+module View.Charging exposing (..)
+
+import Bootstrap.Alert as Alert
+import Bootstrap.Button as Button
+import Bootstrap.Modal as Modal
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
+import Issue exposing (Issue)
+import Msg exposing (..)
+import SelectList
+import State exposing (State)
+import View.Utils
+
+
+chargeableAlert : Issue -> Maybe (Html Msg)
+chargeableAlert issue =
+    let
+        dollar =
+            span [ class "fa fa-dollar" ] []
+
+        chargingInfo =
+            " This issue is chargeable and may incur a charge of support credits. "
+
+        clusterChargingInfoLinkText =
+            "Click here for the charging details for this cluster."
+    in
+    if Issue.isChargeable issue then
+        Alert.warning
+            [ dollar
+            , dollar
+            , dollar
+            , text chargingInfo
+            , Alert.link
+                [ ClusterChargingInfoModal Modal.visibleState |> onClick
+
+                -- This makes this display as a normal link, but clicking on it
+                -- not reload the page. There may be a better way to do this;
+                -- `href="#"` does not work.
+                , href "javascript:void(0)"
+                ]
+                [ text clusterChargingInfoLinkText ]
+            ]
+            |> Just
+    else
+        Nothing
+
+
+infoModal : State -> Html Msg
+infoModal state =
+    let
+        cluster =
+            SelectList.selected state.clusters
+
+        chargingInfo =
+            cluster.chargingInfo
+                |> Maybe.map text
+                |> Maybe.withDefault noChargingInfoAvailable
+
+        noChargingInfoAvailable =
+            span []
+                [ text "No charging info has been provided by Alces Software for "
+                , strong [] [ text cluster.name ]
+                , text "; if you require clarification on what charges you may incur please contact "
+                , View.Utils.supportEmailLink
+                , text "."
+                ]
+    in
+    Modal.config ClusterChargingInfoModal
+        |> Modal.h5 [] [ cluster.name ++ " charging info" |> text ]
+        |> Modal.body [] [ chargingInfo ]
+        |> Modal.footer []
+            [ Button.button
+                [ Button.outlinePrimary
+                , Button.attrs
+                    [ ClusterChargingInfoModal Modal.hiddenState |> onClick ]
+                ]
+                [ text "Close" ]
+            ]
+        |> Modal.view state.clusterChargingInfoModal
+
+
+chargeablePreSubmissionModal : State -> Html Msg
+chargeablePreSubmissionModal state =
+    let
+        bodyContent =
+            [ p []
+                [ text "The selected issue ("
+                , em [] [ State.selectedIssue state |> Issue.name |> text ]
+                , text ") is chargeable, and creating this support case may incur a support credit charge."
+                ]
+            , p [] [ text "Do you wish to continue?" ]
+            ]
+    in
+    Modal.config ChargeablePreSubmissionModal
+        |> Modal.h5 [] [ text "This support case may incur charges" ]
+        |> Modal.body [] bodyContent
+        |> Modal.footer []
+            [ Button.button
+                [ Button.outlinePrimary
+                , Button.attrs
+                    [ ChargeablePreSubmissionModal Modal.hiddenState |> onClick ]
+                ]
+                [ text "Cancel" ]
+            , Button.button
+                [ Button.outlineWarning
+                , Button.attrs
+                    [ onClick StartSubmit ]
+                ]
+                [ text "Create Case" ]
+            ]
+        |> Modal.view state.chargeablePreSubmissionModal

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -6,26 +6,31 @@ import Bootstrap.Modal as Modal
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
-import Issue exposing (Issue)
+import Issue
 import Msg exposing (..)
 import SelectList
 import State exposing (State)
+import Tier
 import View.Utils
 
 
-chargeableAlert : Issue -> Maybe (Html Msg)
-chargeableAlert issue =
+chargeableAlert : State -> Maybe (Html Msg)
+chargeableAlert state =
     let
+        isChargeable =
+            Tier.isChargeable <| State.selectedTier state
+
         dollar =
             span [ class "fa fa-dollar" ] []
 
         chargingInfo =
-            " This issue is chargeable and may incur a charge of support credits. "
+            """ Creating a support case at this tier is potentially chargeable,
+            and may incur a charge of support credits. """
 
         clusterChargingInfoLinkText =
             "Click here for the charging details for this cluster."
     in
-    if Issue.isChargeable issue then
+    if isChargeable then
         Alert.warning
             [ dollar
             , dollar

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -20,23 +20,25 @@ chargeableAlert state =
         isChargeable =
             Tier.isChargeable <| State.selectedTier state
 
+        alertChildren =
+            List.intersperse (text " ")
+                [ dollars
+                , chargeableText
+                , chargingInfoModalLink
+                ]
+
+        dollars =
+            span [] (List.repeat 3 dollar)
+
         dollar =
             span [ class "fa fa-dollar" ] []
 
-        chargingInfo =
-            """ Creating a support case at this tier is potentially chargeable,
-            and may incur a charge of support credits. """
+        chargeableText =
+            text """Creating a support case at this tier is potentially
+            chargeable, and may incur a charge of support credits."""
 
-        clusterChargingInfoLinkText =
-            "Click here for the charging details for this cluster."
-    in
-    if isChargeable then
-        Alert.warning
-            [ dollar
-            , dollar
-            , dollar
-            , text chargingInfo
-            , Alert.link
+        chargingInfoModalLink =
+            Alert.link
                 [ ClusterChargingInfoModal Modal.visibleState |> onClick
 
                 -- This makes this display as a normal link, but clicking on it
@@ -44,9 +46,10 @@ chargeableAlert state =
                 -- `href="#"` does not work.
                 , href "javascript:void(0)"
                 ]
-                [ text clusterChargingInfoLinkText ]
-            ]
-            |> Just
+                [ text "Click here for the charging details for this cluster." ]
+    in
+    if isChargeable then
+        Just <| Alert.warning alertChildren
     else
         Nothing
 

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -1,4 +1,9 @@
-module View.Charging exposing (..)
+module View.Charging
+    exposing
+        ( chargeableAlert
+        , chargeablePreSubmissionModal
+        , infoModal
+        )
 
 import Bootstrap.Alert as Alert
 import Bootstrap.Button as Button
@@ -6,7 +11,6 @@ import Bootstrap.Modal as Modal
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
-import Issue
 import Msg exposing (..)
 import SelectList
 import State exposing (State)
@@ -23,7 +27,7 @@ chargeableAlert state =
         alertChildren =
             List.intersperse (text " ")
                 [ dollars
-                , chargeableText
+                , potentiallyChargeableText
                 , chargingInfoModalLink
                 ]
 
@@ -32,10 +36,6 @@ chargeableAlert state =
 
         dollar =
             span [ class "fa fa-dollar" ] []
-
-        chargeableText =
-            text """Creating a support case at this tier is potentially
-            chargeable, and may incur a charge of support credits."""
 
         chargingInfoModalLink =
             Alert.link
@@ -92,11 +92,7 @@ chargeablePreSubmissionModal : State -> Html Msg
 chargeablePreSubmissionModal state =
     let
         bodyContent =
-            [ p []
-                [ text "The selected issue ("
-                , em [] [ State.selectedIssue state |> Issue.name |> text ]
-                , text ") is chargeable, and creating this support case may incur a support credit charge."
-                ]
+            [ p [] [ potentiallyChargeableText ]
             , p [] [ text "Do you wish to continue?" ]
             ]
     in
@@ -118,3 +114,9 @@ chargeablePreSubmissionModal state =
                 [ text "Create Case" ]
             ]
         |> Modal.view state.chargeablePreSubmissionModal
+
+
+potentiallyChargeableText : Html Msg
+potentiallyChargeableText =
+    text """Creating a support case at this tier is potentially
+    chargeable, and may incur a charge of support credits."""

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -30,7 +30,7 @@ class Case < ApplicationRecord
 
   validates :token, presence: true
   validates :subject, presence: true
-  validates :rt_ticket_id, uniqueness: true
+  validates :rt_ticket_id, uniqueness: true, if: :rt_ticket_id
   validates :fields, presence: true
 
   validates :tier_level,


### PR DESCRIPTION
This PR switches the Case form from displaying

- the chargeable alert, with link to Cluster charging info modal;

- the chargeable warning modal on submit of a potentially chargeable Case;

to be based on the `level` of the selected Tier rather than the `chargeable` value of the selected Issue. Currently level 3 Tiers are always chargeable and other Tiers are never chargeable.  

Trello: https://trello.com/c/HKj8Qi7t/238-indicate-on-case-form-that-tier-3-support-is-potentially-chargeable-1-2-day