### PR TITLE
Validate Tier fields client-side

### DIFF
--- a/app/javascript/packs/Category.elm
+++ b/app/javascript/packs/Category.elm
@@ -3,7 +3,6 @@ module Category
         ( Category
         , Id(..)
         , asIssuesIn
-          -- , availableForSelectedCluster
         , decoder
         , extractId
         , setSelectedIssue

--- a/app/javascript/packs/Field.elm
+++ b/app/javascript/packs/Field.elm
@@ -29,3 +29,22 @@ isDynamicField field =
 
         _ ->
             False
+
+
+hasBeenTouched : Field -> Bool
+hasBeenTouched field =
+    case field of
+        TierField data ->
+            -- A Tier field has been touched if we have saved that we have
+            -- touched it.
+            case data.touched of
+                Tier.Field.Touched ->
+                    True
+
+                Tier.Field.Untouched ->
+                    False
+
+        _ ->
+            -- Always consider every other field touched, since they all start
+            -- pre-filled.
+            True

--- a/app/javascript/packs/Field.elm
+++ b/app/javascript/packs/Field.elm
@@ -1,6 +1,6 @@
 module Field exposing (..)
 
-import Tier
+import Tier.Field
 
 
 type Field
@@ -11,7 +11,7 @@ type Field
     | Tier
     | Component
     | Subject
-    | TierField Tier.TextInputData
+    | TierField Tier.Field.TextInputData
 
 
 {-| The 'dynamic' fields are those shown in the lower section of the form,

--- a/app/javascript/packs/Msg.elm
+++ b/app/javascript/packs/Msg.elm
@@ -16,5 +16,5 @@ type Msg
     | StartSubmit
     | SubmitResponse (Result (Rails.Error String) ())
     | ClearError
-    | ClusterChargingInfoModal Modal.State
-    | ChargeablePreSubmissionModal Modal.State
+    | ClusterChargingInfoModal Modal.Visibility
+    | ChargeablePreSubmissionModal Modal.Visibility

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -33,8 +33,8 @@ type alias State =
     , singleComponent : Bool
     , singleService : Bool
     , isSubmitting : Bool
-    , clusterChargingInfoModal : Modal.State
-    , chargeablePreSubmissionModal : Modal.State
+    , clusterChargingInfoModal : Modal.Visibility
+    , chargeablePreSubmissionModal : Modal.Visibility
     }
 
 
@@ -53,8 +53,8 @@ decoder =
                         , singleComponent = False
                         , singleService = False
                         , isSubmitting = False
-                        , clusterChargingInfoModal = Modal.hiddenState
-                        , chargeablePreSubmissionModal = Modal.hiddenState
+                        , clusterChargingInfoModal = Modal.hidden
+                        , chargeablePreSubmissionModal = Modal.hidden
                         }
                 in
                 case mode of

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -24,7 +24,6 @@ import SelectList.Extra
 import Service exposing (Service)
 import SupportType exposing (SupportType)
 import Tier exposing (Tier)
-import Tier.Field
 import Tier.Level
 
 
@@ -185,15 +184,6 @@ encoder state =
 
         tier =
             selectedTier state
-
-        tierFieldAsString =
-            \field ->
-                case field of
-                    Tier.Field.Markdown _ ->
-                        Nothing
-
-                    Tier.Field.TextInput data ->
-                        Just <| data.name ++ ": " ++ data.value
     in
     E.object
         [ ( "case"

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -24,6 +24,7 @@ import SelectList.Extra
 import Service exposing (Service)
 import SupportType exposing (SupportType)
 import Tier exposing (Tier)
+import Tier.Field
 import Tier.Level
 
 
@@ -188,10 +189,10 @@ encoder state =
         tierFieldAsString =
             \field ->
                 case field of
-                    Tier.Markdown _ ->
+                    Tier.Field.Markdown _ ->
                         Nothing
 
-                    Tier.TextInput data ->
+                    Tier.Field.TextInput data ->
                         Just <| data.name ++ ": " ++ data.value
     in
     E.object

--- a/app/javascript/packs/State/View.elm
+++ b/app/javascript/packs/State/View.elm
@@ -34,7 +34,11 @@ submitErrorAlert state =
     let
         displayError =
             \error ->
-                Alert.danger
+                -- XXX Update this to use new `Alert.dismissable` or
+                -- `Alert/dismissableWithAnimation` function from
+                -- elm-bootstrap, rather than handling dismissing ourselves.
+                Alert.simpleDanger
+                    []
                     [ button
                         [ type_ "button"
                         , class "close"

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -1,8 +1,6 @@
 module Tier
     exposing
-        ( Field(..)
-        , Id(..)
-        , TextInputData
+        ( Id(..)
         , Tier
         , decoder
         , extractId
@@ -16,6 +14,7 @@ import Dict exposing (Dict)
 import Json.Decode as D
 import Json.Encode as E
 import Maybe.Extra
+import Tier.Field as Field exposing (Field)
 import Tier.Level as Level exposing (Level)
 import Types
 
@@ -29,23 +28,6 @@ type alias Tier =
 
 type Id
     = Id Int
-
-
-type Field
-    = Markdown String
-    | TextInput TextInputData
-
-
-type alias TextInputData =
-    { type_ : Types.TextField
-    , name : String
-    , value : String
-
-    -- XXX Could encode `optional` in `Field` type like:
-    -- | RequiredTextInput TextInput
-    -- | OptionalTextInput TextInput
-    , optional : Bool
-    }
 
 
 decoder : D.Decoder Tier
@@ -68,90 +50,18 @@ decoder =
 
 fieldsDecoder : D.Decoder (Dict Int Field)
 fieldsDecoder =
-    D.list fieldDecoder
+    D.list Field.decoder
         |> D.map (List.indexedMap (,) >> Dict.fromList)
-
-
-fieldDecoder : D.Decoder Field
-fieldDecoder =
-    let
-        fieldTypeDecoder =
-            \type_ ->
-                case type_ of
-                    "markdown" ->
-                        markdownDecoder
-
-                    "input" ->
-                        textInputDecoder Types.Input
-
-                    "textarea" ->
-                        textInputDecoder Types.TextArea
-
-                    _ ->
-                        D.fail <| "Invalid type: " ++ type_
-    in
-    D.field "type" D.string
-        |> D.andThen fieldTypeDecoder
-
-
-markdownDecoder : D.Decoder Field
-markdownDecoder =
-    D.map Markdown <| D.field "content" D.string
-
-
-textInputDecoder : Types.TextField -> D.Decoder Field
-textInputDecoder type_ =
-    let
-        initialValueDecoder =
-            D.succeed ""
-
-        optionalDecoder =
-            D.field "optional" D.bool
-                |> D.maybe
-                |> D.map (Maybe.withDefault False)
-    in
-    D.map TextInput <|
-        D.map4 TextInputData
-            (D.succeed type_)
-            (D.field "name" D.string)
-            initialValueDecoder
-            optionalDecoder
 
 
 fieldsEncoder : Tier -> E.Value
 fieldsEncoder tier =
     E.array
         (Dict.values tier.fields
-            |> List.map fieldEncoder
+            |> List.map Field.encoder
             |> Maybe.Extra.values
             |> Array.fromList
         )
-
-
-fieldEncoder : Field -> Maybe E.Value
-fieldEncoder field =
-    case field of
-        Markdown _ ->
-            Nothing
-
-        TextInput data ->
-            Just <|
-                E.object
-                    [ ( "type", textFieldTypeToString data.type_ |> E.string )
-                    , ( "name", E.string data.name )
-                    , ( "value", E.string data.value )
-                    , ( "optional", E.bool data.optional )
-                    ]
-
-
-textFieldTypeToString : Types.TextField -> String
-textFieldTypeToString field =
-    case field of
-        Types.TextArea ->
-            "textarea"
-
-        Types.Input ->
-            "input"
 
 
 extractId : Tier -> Int
@@ -167,11 +77,11 @@ setFieldValue tier index value =
         updateFieldValue =
             \maybeField ->
                 case maybeField of
-                    Just (Markdown f) ->
-                        Just (Markdown f)
+                    Just (Field.Markdown f) ->
+                        Just (Field.Markdown f)
 
-                    Just (TextInput f) ->
-                        Just <| TextInput { f | value = value }
+                    Just (Field.TextInput f) ->
+                        Just <| Field.TextInput { f | value = value }
 
                     Nothing ->
                         Nothing

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -16,7 +16,6 @@ import Json.Encode as E
 import Maybe.Extra
 import Tier.Field as Field exposing (Field)
 import Tier.Level as Level exposing (Level)
-import Types
 
 
 type alias Tier =

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -74,16 +74,7 @@ setFieldValue : Tier -> Int -> String -> Tier
 setFieldValue tier index value =
     let
         updateFieldValue =
-            \maybeField ->
-                case maybeField of
-                    Just (Field.Markdown f) ->
-                        Just (Field.Markdown f)
-
-                    Just (Field.TextInput f) ->
-                        Just <| Field.TextInput { f | value = value }
-
-                    Nothing ->
-                        Nothing
+            Maybe.map <| Field.replaceValue value
     in
     { tier
         | fields =

--- a/app/javascript/packs/Tier/Field.elm
+++ b/app/javascript/packs/Tier/Field.elm
@@ -5,6 +5,7 @@ module Tier.Field
         , data
         , decoder
         , encoder
+        , replaceValue
         )
 
 import Json.Decode as D
@@ -109,3 +110,13 @@ data field =
 
         TextInput d ->
             Just d
+
+
+replaceValue : String -> Field -> Field
+replaceValue value field =
+    case field of
+        Markdown s ->
+            Markdown s
+
+        TextInput d ->
+            TextInput { d | value = value }

--- a/app/javascript/packs/Tier/Field.elm
+++ b/app/javascript/packs/Tier/Field.elm
@@ -1,4 +1,11 @@
-module Tier.Field exposing (Field(..), TextInputData, decoder, encoder)
+module Tier.Field
+    exposing
+        ( Field(..)
+        , TextInputData
+        , data
+        , decoder
+        , encoder
+        )
 
 import Json.Decode as D
 import Json.Encode as E
@@ -92,3 +99,13 @@ textFieldTypeToString field =
 
         Types.Input ->
             "input"
+
+
+data : Field -> Maybe TextInputData
+data field =
+    case field of
+        Markdown _ ->
+            Nothing
+
+        TextInput d ->
+            Just d

--- a/app/javascript/packs/Tier/Field.elm
+++ b/app/javascript/packs/Tier/Field.elm
@@ -1,0 +1,94 @@
+module Tier.Field exposing (Field(..), TextInputData, decoder, encoder)
+
+import Json.Decode as D
+import Json.Encode as E
+import Types
+
+
+type Field
+    = Markdown String
+    | TextInput TextInputData
+
+
+type alias TextInputData =
+    { type_ : Types.TextField
+    , name : String
+    , value : String
+
+    -- XXX Could encode `optional` in `Field` type like:
+    -- | RequiredTextInput TextInput
+    -- | OptionalTextInput TextInput
+    , optional : Bool
+    }
+
+
+decoder : D.Decoder Field
+decoder =
+    let
+        fieldTypeDecoder =
+            \type_ ->
+                case type_ of
+                    "markdown" ->
+                        markdownDecoder
+
+                    "input" ->
+                        textInputDecoder Types.Input
+
+                    "textarea" ->
+                        textInputDecoder Types.TextArea
+
+                    _ ->
+                        D.fail <| "Invalid type: " ++ type_
+    in
+    D.field "type" D.string
+        |> D.andThen fieldTypeDecoder
+
+
+markdownDecoder : D.Decoder Field
+markdownDecoder =
+    D.map Markdown <| D.field "content" D.string
+
+
+textInputDecoder : Types.TextField -> D.Decoder Field
+textInputDecoder type_ =
+    let
+        initialValueDecoder =
+            D.succeed ""
+
+        optionalDecoder =
+            D.field "optional" D.bool
+                |> D.maybe
+                |> D.map (Maybe.withDefault False)
+    in
+    D.map TextInput <|
+        D.map4 TextInputData
+            (D.succeed type_)
+            (D.field "name" D.string)
+            initialValueDecoder
+            optionalDecoder
+
+
+encoder : Field -> Maybe E.Value
+encoder field =
+    case field of
+        Markdown _ ->
+            Nothing
+
+        TextInput data ->
+            Just <|
+                E.object
+                    [ ( "type", textFieldTypeToString data.type_ |> E.string )
+                    , ( "name", E.string data.name )
+                    , ( "value", E.string data.value )
+                    , ( "optional", E.bool data.optional )
+                    ]
+
+
+textFieldTypeToString : Types.TextField -> String
+textFieldTypeToString field =
+    case field of
+        Types.TextArea ->
+            "textarea"
+
+        Types.Input ->
+            "input"

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -86,15 +86,16 @@ createTierFieldsValidator : State -> Validator Error State
 createTierFieldsValidator state =
     let
         tierFieldValidators =
-            List.map createTierFieldValidator tierFieldsTextInputData
+            List.map createRequiredFieldValidator requiredTierFieldsTextInputData
 
-        tierFieldsTextInputData =
+        requiredTierFieldsTextInputData =
             State.selectedTier state
                 |> .fields
                 |> Dict.values
                 |> List.filterMap Tier.Field.data
+                |> List.filter (not << .optional)
 
-        createTierFieldValidator =
+        createRequiredFieldValidator =
             \textInputData ->
                 Validate.ifBlank
                     (always textInputData.value)

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -92,15 +92,7 @@ createTierFieldsValidator state =
             State.selectedTier state
                 |> .fields
                 |> Dict.values
-                |> List.filterMap
-                    (\field ->
-                        case field of
-                            Tier.Field.Markdown _ ->
-                                Nothing
-
-                            Tier.Field.TextInput data ->
-                                Just data
-                    )
+                |> List.filterMap Tier.Field.data
 
         createTierFieldValidator =
             \textInputData ->

--- a/app/javascript/packs/Validation.elm
+++ b/app/javascript/packs/Validation.elm
@@ -12,7 +12,7 @@ import Dict
 import Field exposing (Field)
 import Issue
 import State exposing (State)
-import Tier
+import Tier.Field
 import Validate exposing (Validator)
 
 
@@ -95,10 +95,10 @@ createTierFieldsValidator state =
                 |> List.filterMap
                     (\field ->
                         case field of
-                            Tier.Markdown _ ->
+                            Tier.Field.Markdown _ ->
                                 Nothing
 
-                            Tier.TextInput data ->
+                            Tier.Field.TextInput data ->
                                 Just data
                     )
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -32,7 +32,7 @@ view state =
     let
         submitMsg =
             if State.selectedTier state |> Tier.isChargeable then
-                ChargeablePreSubmissionModal Modal.visibleState
+                ChargeablePreSubmissionModal Modal.shown
             else
                 StartSubmit
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -233,6 +233,7 @@ subjectField state =
         selectedIssue
         Issue.subject
         ChangeSubject
+        False
         state
 
 
@@ -261,6 +262,7 @@ renderTierField state ( index, field ) =
                 fieldData
                 .value
                 (ChangeTierField index)
+                fieldData.optional
                 state
 
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -19,6 +19,7 @@ import Service
 import State exposing (State)
 import Tier exposing (Tier)
 import Tier.DisplayWrapper
+import Tier.Field
 import Tier.Level as Level exposing (Level)
 import Validation
 import View.Charging as Charging
@@ -248,13 +249,13 @@ dynamicTierFields state =
     div [] renderedFields
 
 
-renderTierField : State -> ( Int, Tier.Field ) -> Html Msg
+renderTierField : State -> ( Int, Tier.Field.Field ) -> Html Msg
 renderTierField state ( index, field ) =
     case field of
-        Tier.Markdown content ->
+        Tier.Field.Markdown content ->
             Markdown.toHtml [] content
 
-        Tier.TextInput fieldData ->
+        Tier.Field.TextInput fieldData ->
             Fields.textField fieldData.type_
                 (Field.TierField fieldData)
                 fieldData

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -39,7 +39,7 @@ chargeableAlert state =
 
         chargingInfoModalLink =
             Alert.link
-                [ ClusterChargingInfoModal Modal.visibleState |> onClick
+                [ ClusterChargingInfoModal Modal.shown |> onClick
 
                 -- This makes this display as a normal link, but clicking on it
                 -- not reload the page. There may be a better way to do this;
@@ -49,7 +49,7 @@ chargeableAlert state =
                 [ text "Click here for the charging details for this cluster." ]
     in
     if isChargeable then
-        Just <| Alert.warning alertChildren
+        Just <| Alert.simpleWarning [] alertChildren
     else
         Nothing
 
@@ -74,14 +74,14 @@ infoModal state =
                 , text "."
                 ]
     in
-    Modal.config ClusterChargingInfoModal
+    Modal.config (ClusterChargingInfoModal Modal.hidden)
         |> Modal.h5 [] [ cluster.name ++ " charging info" |> text ]
         |> Modal.body [] [ chargingInfo ]
         |> Modal.footer []
             [ Button.button
                 [ Button.outlinePrimary
                 , Button.attrs
-                    [ ClusterChargingInfoModal Modal.hiddenState |> onClick ]
+                    [ ClusterChargingInfoModal Modal.hidden |> onClick ]
                 ]
                 [ text "Close" ]
             ]
@@ -96,14 +96,14 @@ chargeablePreSubmissionModal state =
             , p [] [ text "Do you wish to continue?" ]
             ]
     in
-    Modal.config ChargeablePreSubmissionModal
+    Modal.config (ChargeablePreSubmissionModal Modal.hidden)
         |> Modal.h5 [] [ text "This support case may incur charges" ]
         |> Modal.body [] bodyContent
         |> Modal.footer []
             [ Button.button
                 [ Button.outlinePrimary
                 , Button.attrs
-                    [ ChargeablePreSubmissionModal Modal.hiddenState |> onClick ]
+                    [ ChargeablePreSubmissionModal Modal.hidden |> onClick ]
                 ]
                 [ text "Cancel" ]
             , Button.button

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -5,6 +5,8 @@ module View.Fields
         , textField
         )
 
+import Bootstrap.Badge as Badge
+import Bootstrap.Utilities.Spacing as Spacing
 import Field exposing (Field)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -47,6 +49,7 @@ selectField field items toId toOptionLabel isDisabled changeMsg state =
         select
         [ Html.Events.on "change" (D.map changeMsg Html.Events.targetValue) ]
         options
+        False
         state
 
 
@@ -55,6 +58,7 @@ inputField :
     -> a
     -> (a -> String)
     -> (String -> msg)
+    -> Bool
     -> State
     -> Html msg
 inputField =
@@ -67,9 +71,10 @@ textField :
     -> a
     -> (a -> String)
     -> (String -> msg)
+    -> Bool
     -> State
     -> Html msg
-textField textFieldType field item toContent inputMsg state =
+textField textFieldType field item toContent inputMsg optional state =
     let
         content =
             toContent item
@@ -93,6 +98,7 @@ textField textFieldType field item toContent inputMsg state =
         element
         attributes
         []
+        optional
         state
 
 
@@ -106,9 +112,10 @@ formField :
     -> HtmlFunction msg
     -> List (Attribute msg)
     -> List (Html msg)
+    -> Bool
     -> State
     -> Html msg
-formField field item htmlFn additionalAttributes children state =
+formField field item htmlFn additionalAttributes children optional state =
     let
         fieldName =
             case field of
@@ -126,6 +133,12 @@ formField field item htmlFn additionalAttributes children state =
 
         identifier =
             fieldIdentifier fieldName
+
+        optionalBadge =
+            if optional then
+                Badge.badgeSuccess [ Spacing.ml1 ] [ text "Optional" ]
+            else
+                text ""
 
         attributes =
             List.append
@@ -145,6 +158,7 @@ formField field item htmlFn additionalAttributes children state =
         [ label
             [ for identifier ]
             [ text fieldName ]
+        , optionalBadge
         , formElement
         , validationFeedback errors
         ]

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -143,7 +143,7 @@ formField field item htmlFn additionalAttributes children optional state =
         attributes =
             List.append
                 [ id identifier
-                , class (formControlClasses errors)
+                , class (formControlClasses field errors)
                 , disabled fieldIsUnavailable
                 ]
                 additionalAttributes
@@ -170,17 +170,28 @@ fieldIdentifier fieldName =
         |> String.Extra.dasherize
 
 
-formControlClasses : List Error -> String
-formControlClasses errors =
-    "form-control " ++ bootstrapValidationClass errors
+formControlClasses : Field -> List Error -> String
+formControlClasses field errors =
+    "form-control " ++ bootstrapValidationClass field errors
 
 
-bootstrapValidationClass : List Error -> String
-bootstrapValidationClass errors =
-    if List.isEmpty errors then
-        "is-valid"
+bootstrapValidationClass : Field -> List Error -> String
+bootstrapValidationClass field errors =
+    let
+        validationClass =
+            if List.isEmpty errors then
+                "is-valid"
+            else
+                "is-invalid"
+    in
+    if Field.hasBeenTouched field then
+        validationClass
     else
-        "is-invalid"
+        -- If the field is not considered to have been touched yet then just
+        -- give nothing, rather than showing either success or failure, to
+        -- avoid showing the user many errors for fields they haven't yet
+        -- looked at.
+        ""
 
 
 validationFeedback : List Error -> Html msg

--- a/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
+++ b/db/data_migrations/20180409163843_migrate_existing_data_to_account_for_tiers.rb
@@ -91,6 +91,9 @@ class MigrateExistingDataToAccountForTiers < ActiveRecord::DataMigration
           details of available Alces Gridware.
         MARKDOWN
       }
+
+      # Make this field an example of an optional field.
+      tier.fields[-1] = tier.fields[-1].merge(optional: true)
     end
 
     storage_quota_issue = 'File System storage quota changes'

--- a/elm-package.json
+++ b/elm-package.json
@@ -18,7 +18,7 @@
         "evancz/elm-markdown": "3.0.2 <= v < 4.0.0",
         "rtfeldman/elm-validate": "3.0.0 <= v < 4.0.0",
         "rtfeldman/selectlist": "1.0.0 <= v < 2.0.0",
-        "rundis/elm-bootstrap": "3.0.0 <= v < 4.0.0"
+        "rundis/elm-bootstrap": "4.0.0 <= v < 5.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
This PR adds client-side validation that Tier fields are filled, where this is required. Currently this consists of:

- unless marked as `optional`, Tier fields with inputs are validated to check they have some non-whitespace text entered;

- if they are marked `optional`, this is now indicated using a badge alongside the field; a single example field marked as `optional` has also been added to the data migration to demonstrate this (to the 'From available Alces Gridware' Issue);

- these validations are run (so the form cannot be submitted) but are not shown for each field until it has been touched, to avoid overwhelming a user with many fields most of which are initially invalid.

Trello: https://trello.com/c/DkP7YQWz/241-validate-in-case-form-that-tier-fields-have-non-empty-values-unless-they-are-optional-1-day. Based on #175.