### PR TITLE
Disable non-consultancy Case comments

### DIFF
--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -69,4 +69,8 @@ class CaseDecorator < ApplicationDecorator
     description = TIER_DESCRIPTIONS[tier_level]
     "#{tier_level} (#{description})"
   end
+
+  def commenting_disabled?
+    current_user.contact? && !consultancy?
+  end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -184,6 +184,10 @@ class Case < ApplicationRecord
     Utils.rt_format(case_properties)
   end
 
+  def consultancy?
+    tier_level >= 3
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/case/available_support_validator.rb
+++ b/app/models/case/available_support_validator.rb
@@ -18,7 +18,8 @@ class Case
       # via separate buttons outside of the standard Case form.
       return if record.issue.special?
 
-      if associated_model&.advice? && record.tier_level < 3
+      return if record.consultancy?
+      if associated_model&.advice?
         record.errors.add(associated_model_name, advice_part_error)
       end
     end

--- a/app/views/case_comments/_form.html.erb
+++ b/app/views/case_comments/_form.html.erb
@@ -1,9 +1,8 @@
 
 <%
 
-  commenting_disabled = current_user.contact? && !@case.consultancy?
   additional_attributes =
-    if commenting_disabled
+    if @case.commenting_disabled?
       {
         disabled: true,
         title: <<~TITLE.squish

--- a/app/views/case_comments/_form.html.erb
+++ b/app/views/case_comments/_form.html.erb
@@ -1,14 +1,36 @@
+
+<%
+
+  commenting_disabled = current_user.contact? && !@case.consultancy?
+  additional_attributes =
+    if commenting_disabled
+      {
+        disabled: true,
+        title: <<~TITLE.squish
+          This is a non-consultancy support case and so additional discussion is
+          not available. If you wish to request additional support please open a
+          new support case.
+        TITLE
+      }
+    else
+      {}
+    end
+
+%>
+
 <% if @case.state == 'open' %>
   <%= form_for [@case, @comment] do |f| %>
     <div class="form-group">
       <%= f.text_area :text,
             class: 'form-control',
-            rows: 3
+            rows: 3,
+            **additional_attributes
       %>
     </div>
     <div class="form-group">
       <%= f.submit "Add new comment",
-            class: 'btn btn-primary float-right'
+        class: 'btn btn-primary float-right',
+        **additional_attributes
       %>
     </div>
   <% end %>

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -183,4 +183,15 @@ RSpec.describe 'Case page' do
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
   end
 
+  context 'for open non-consultancy Case' do
+    subject { create(:open_case, cluster: cluster, tier_level: 2) }
+
+    it 'disables commenting for site contact' do
+      visit case_path(subject, as: contact)
+
+      form = find(comment_form_class)
+      expect(form.find('textarea')).to be_disabled
+      expect(form).to have_button(comment_button_text, disabled: true)
+    end
+  end
 end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -119,6 +119,9 @@ RSpec.describe 'Case page' do
 
   let (:mw) { create(:maintenance_window, case: open_case) }
 
+  let :comment_form_class { '#new_case_comment' }
+  let :comment_button_text { 'Add new comment' }
+
   it 'shows events in chronological order' do
     create(:case_comment, case: open_case, user: admin, created_at: 2.hours.ago, text: 'Second')
     create(
@@ -144,39 +147,39 @@ RSpec.describe 'Case page' do
   it 'shows or hides add comment form for contacts' do
     visit case_path(open_case, as: contact)
 
-    form = find('#new_case_comment')
+    form = find(comment_form_class)
     form.find('#case_comment_text')
 
-    expect(form.find('input').value).to eq 'Add new comment'
+    expect(form.find('input').value).to eq comment_button_text
 
     # No resolve/archive controls
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
 
     visit case_path(resolved_case, as: contact)
-    expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+    expect { find(comment_form_class) }.to raise_error(Capybara::ElementNotFound)
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
 
     visit case_path(archived_case, as: contact)
-    expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+    expect { find(comment_form_class) }.to raise_error(Capybara::ElementNotFound)
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
   end
 
   it 'shows or hides add comment form and state controls for admins' do
     visit case_path(open_case, as: admin)
 
-    form = find('#new_case_comment')
+    form = find(comment_form_class)
     form.find('#case_comment_text')
 
-    expect(form.find('input').value).to eq 'Add new comment'
+    expect(form.find('input').value).to eq comment_button_text
 
     expect(find('#case-state-controls').find('a').text).to eq 'Resolve this case'
 
     visit case_path(resolved_case, as: admin)
-    expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+    expect { find(comment_form_class) }.to raise_error(Capybara::ElementNotFound)
     expect(find('#case-state-controls').find('a').text).to eq 'Archive this case'
 
     visit case_path(archived_case, as: admin)
-    expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+    expect { find(comment_form_class) }.to raise_error(Capybara::ElementNotFound)
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
   end
 

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'Cases table', type: :feature do
 end
 
 RSpec.describe 'Case page' do
-  let (:user) { create(:contact, site: site) }
+  let (:contact) { create(:contact, site: site) }
   let (:admin) { create(:admin) }
   let (:site) { create(:site, name: 'My Site') }
   let (:cluster) { create(:cluster, site: site) }
@@ -142,7 +142,7 @@ RSpec.describe 'Case page' do
   end
 
   it 'shows or hides add comment form for contacts' do
-    visit case_path(open_case, as: user)
+    visit case_path(open_case, as: contact)
 
     form = find('#new_case_comment')
     form.find('#case_comment_text')
@@ -152,11 +152,11 @@ RSpec.describe 'Case page' do
     # No resolve/archive controls
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
 
-    visit case_path(resolved_case, as: user)
+    visit case_path(resolved_case, as: contact)
     expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
 
-    visit case_path(archived_case, as: user)
+    visit case_path(archived_case, as: contact)
     expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
     expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
   end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -213,4 +213,18 @@ RSpec.describe Case, type: :model do
     subject { create(:case_with_component).associated_model_type }
     it { is_expected.to eq 'component' }
   end
+
+  describe '#consultancy?' do
+    it 'returns true when tier_level == 3' do
+      kase = create(:case, tier_level: 3)
+
+      expect(kase).to be_consultancy
+    end
+
+    it 'returns false when tier_level < 3' do
+      kase = create(:case, tier_level: 2)
+
+      expect(kase).not_to be_consultancy
+    end
+  end
 end


### PR DESCRIPTION
This PR disables commenting on Cases for Site contacts when the Case is not consultancy (with our business reasoning for doing this being that theoretically the original Case should contain all relevant information in this situation). 

@jamesremuscat would you be able to take a quick look at this, since this touches the stuff you've been working on? :slightly_smiling_face: 

Trello: https://trello.com/c/Wqcy44Py/233-disable-case-commenting-with-standard-reason-displayed-for-tier-1-2-cases-1-4-day