### PR TITLE
Assign users to cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "sentry-raven"
 gem 'state_machines-activerecord'
 gem 'state_machines-audit_trail'
 gem 'business_time'
+gem "audited", "~> 4.7"
 
 gem 'bootstrap', '~> 4.0.0'
 gem 'jquery-rails' # Required for Bootstrap.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
+    audited (4.7.1)
+      activerecord (>= 4.0, < 5.3)
     autoprefixer-rails (8.1.0)
       execjs
     aws-partitions (1.68.0)
@@ -395,6 +397,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_doctor
+  audited (~> 4.7)
   aws-sdk-s3
   bootsnap
   bootstrap (~> 4.0.0)

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -72,8 +72,13 @@ class CasesController < ApplicationController
   end
 
   def assign
-    new_assignee = User.find(params[:assignee_id])
-    change_action "Support case %s assigned to #{new_assignee.name}." do |kase|
+    new_assignee_id = params[:case][:assignee_id]
+    new_assignee = new_assignee_id.empty? ? nil : User.find(new_assignee_id)
+    success_flash = new_assignee ?
+                        "Support case %s assigned to #{new_assignee.name}."
+                        : 'Support case %s unassigned.'
+
+    change_action success_flash, redirect_path: case_path do |kase|
       kase.assignee = new_assignee
     end
   end
@@ -98,7 +103,7 @@ class CasesController < ApplicationController
     )
   end
 
-  def change_action(success_flash, &block)
+  def change_action(success_flash, redirect_path: case_path, &block)
     @case = Case.find(params[:id]).decorate
     begin
       block.call(@case)
@@ -107,6 +112,6 @@ class CasesController < ApplicationController
     rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
       flash[:error] = "Error updating support case: #{format_errors(@case)}"
     end
-    redirect_to @case
+    redirect_to redirect_path
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -71,6 +71,13 @@ class CasesController < ApplicationController
     end
   end
 
+  def assign
+    new_assignee = User.find(params[:assignee_id])
+    change_action "Support case %s assigned to #{new_assignee.name}." do |kase|
+      kase.assignee = new_assignee
+    end
+  end
+
   def resolve
     change_action "Support case %s resolved." do |kase|
       kase.resolve!(current_user)

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -21,7 +21,7 @@ module Audited
       type = send("#{field}_type")
       text = send("#{field}_text", from, to)
 
-      render_card(date, user.name, type, text)
+      render_card(date, user&.name || 'Flight Center', type, text)
     end
 
     def render_card(date, name, type, text)

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -31,12 +31,12 @@ module Audited
     def assignee_id_text(from, to)
       if from
         if to
-          "Changed assignee from #{User.find(from).name} to #{User.find(to).name}."
+          "Changed the assignee of this case from #{User.find(from).name} to #{User.find(to).name}."
         else
-          "Unassigned #{User.find(from).name} from this case."
+          "Unassigned this case from #{User.find(from).name}."
         end
       else
-        "Assigned #{User.find(to).name} to this case."
+        "Assigned this case to #{User.find(to).name}."
       end
     end
 

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -1,0 +1,47 @@
+module Audited
+  class AuditDecorator < ApplicationDecorator
+    def event_card
+      # Make some assertions about the sort of thing we're being used to display.
+      # In both cases, we could easily make this decorator flexible enough to cope
+      # with a wider variety of things, but this isn't needed yet. Having these
+      # exceptions here means that we'll know if we try and invalidate some of the
+      # assumptions made in our implementation.
+      raise "Unsupported auditable class: #{object.auditable_type}" unless object.auditable_type == 'Case'
+      raise "Unsupported audit action: #{object.action}" unless object.action == 'update'
+
+      h.raw(object.audited_changes.map { |c| change_card(object.created_at, object.user, c) }.join(''))
+    end
+
+    private
+
+    def change_card(date, user, change)
+      field = change[0]
+      from, to = *change[1]
+
+      type = send("#{field}_type")
+      text = send("#{field}_text", from, to)
+
+      render_card(date, user.name, type, text)
+    end
+
+    def render_card(date, name, type, text)
+      h.render 'cases/event', date: date, name: name, type: type, text: text
+    end
+
+    def assignee_id_text(from, to)
+      if from
+        if to
+          "Changed assignee from #{User.find(from).name} to #{User.find(to).name}."
+        else
+          "Unassigned #{User.find(from).name} from this case."
+        end
+      else
+        "Assigned #{User.find(to).name} to this case."
+      end
+    end
+
+    def assignee_id_type
+      'user'
+    end
+  end
+end

--- a/app/mailer_previews/case_mailer_preview.rb
+++ b/app/mailer_previews/case_mailer_preview.rb
@@ -3,6 +3,11 @@ class CaseMailerPreview < ApplicationMailerPreview
     CaseMailer.new_case(get_case)
   end
 
+  def change_assignee
+    my_case = get_case
+    CaseMailer.change_assignee(my_case, user)
+  end
+
   def comment
     my_comment = CaseComment.first || FactoryBot.build_stubbed(:case_comment)
     CaseMailer.comment(my_comment)

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -12,6 +12,15 @@ class CaseMailer < ApplicationMailer
     )
   end
 
+  def change_assignee(my_case, previous_assignee)
+    @case = my_case
+    @previous = previous_assignee
+    mail(
+      cc: (@case.email_recipients + [@case.assignee&.email]).uniq, # Send to all including new assignee
+      subject: @case.email_subject
+    )
+  end
+
   def comment(comment)
     @comment = comment
     @case = @comment.case

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -46,6 +46,8 @@ class Case < ApplicationRecord
 
   end
 
+  audited only: :assignee_id
+
   validates :token, presence: true
   validates :subject, presence: true
   validates :rt_ticket_id, uniqueness: true, if: :rt_ticket_id

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -75,6 +75,8 @@ class Case < ApplicationRecord
 
   validates_with AssociatedModelValidator
 
+  validate :validates_user_assignment
+
   after_initialize :assign_cluster_if_necessary
   after_initialize :generate_token, on: :create
 
@@ -263,5 +265,10 @@ class Case < ApplicationRecord
 
   def send_new_case_email
     CaseMailer.new_case(self).deliver_later
+  end
+
+  def validates_user_assignment
+    return if assignee.nil?
+    errors.add(:assignee, 'must belong to this site, or be an admin') unless assignee.site == site or assignee.admin?
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -46,7 +46,7 @@ class Case < ApplicationRecord
 
   end
 
-  audited only: :assignee_id
+  audited only: :assignee_id, on: [ :update ]
 
   validates :token, presence: true
   validates :subject, presence: true

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -22,6 +22,7 @@ class Case < ApplicationRecord
   belongs_to :component, required: false
   belongs_to :service, required: false
   belongs_to :user
+  belongs_to :assignee, class_name: 'User', required: false
   has_one :credit_charge, required: false
   has_many :maintenance_windows
   has_and_belongs_to_many :log

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -187,6 +187,11 @@ class Case < ApplicationRecord
     Utils.rt_format(case_properties)
   end
 
+  def potential_assignees
+    User.where(site: site).order(:name) +
+        User.where(admin: true).order(:name)
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -156,7 +156,8 @@ class Case < ApplicationRecord
         # so there will be one included in this set without a created_at
         # date. We clearly don't want to include that in the events stream.
       maintenance_windows.map(&:transitions).flatten.select(&:event) +
-      case_state_transitions
+      case_state_transitions +
+      audits
     ).sort_by(&:created_at)
   end
 

--- a/app/views/case_mailer/change_assignee.html.erb
+++ b/app/views/case_mailer/change_assignee.html.erb
@@ -3,7 +3,7 @@
 <% if @case.assignee %>
     <p>
       This case has been assigned to
-      <em><%= @case.assignee.name %></em><% if @previous %>(previously assigned
+      <em><%= @case.assignee.name %></em><% if @previous %> (previously assigned
         to <%= @previous.name %>)<% end %>.
     </p>
 <% else %>

--- a/app/views/case_mailer/change_assignee.html.erb
+++ b/app/views/case_mailer/change_assignee.html.erb
@@ -1,0 +1,13 @@
+<h3><%= @case.ticket_subject %></h3>
+
+<% if @case.assignee %>
+    <p>
+      This case has been assigned to
+      <em><%= @case.assignee.name %></em><% if @previous %>(previously assigned
+        to <%= @previous.name %>)<% end %>.
+    </p>
+<% else %>
+  <p>
+    This case is no longer assigned<% if @previous %> to <%= @previous.name %><% end %>.
+  </p>
+<% end %>

--- a/app/views/case_mailer/change_assignee.text.erb
+++ b/app/views/case_mailer/change_assignee.text.erb
@@ -1,0 +1,8 @@
+  <%= @case.ticket_subject %>
+
+<% if @case.assignee %>
+  This case has been assigned to <%= @case.assignee.name %><% if @previous %> (previously
+      assigned to <%= @previous.name %>)<% end %>.
+<% else %>
+  This case is no longer assigned<% if @previous %> to <%= @previous.name %><% end %>.
+<% end %>

--- a/app/views/cases/_case_assignment_controls.html.erb
+++ b/app/views/cases/_case_assignment_controls.html.erb
@@ -1,0 +1,28 @@
+<% if current_user.admin? %>
+  <%= form_for @case, url: assign_case_path, method: :post do |f| %>
+    <div class="form-group">
+      <div class="input-group">
+      <%= f.collection_select(
+            :assignee_id,
+            @case.potential_assignees,
+            :id,
+            Proc.new { |a| "#{a.admin ? '* ' : ''}#{a.name}"},
+            {
+              include_blank: 'Nobody',
+            },
+            {
+              class: 'form-control'
+            }
+          )
+      %>
+        <div class="input-group-append">
+      <%= f.submit "Change assignment",
+                   class: 'btn btn-primary btn-sm'
+      %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <%= @case.assignee&.name or 'Nobody' %>
+<% end %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -14,6 +14,7 @@ end %>
           <th>State</th>
           <th>Creator</th>
           <th>Subject</th>
+          <th>Assigned to</th>
           <th>Association</th>
           <% if manage_cases_page %>
             <th>Chargeable</th>
@@ -48,6 +49,7 @@ end %>
               <td><%= c.user_facing_state %></td>
               <td><%= c.user.name %></td>
               <td><%= link_to c.subject, case_path(c) %></td>
+              <td><%= c.assignee&.name || 'Nobody' %></td>
               <td><%= c.association_info %></td>
               <% if manage_cases_page %>
                 <td><%= c.chargeable_symbol %></td>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -7,9 +7,15 @@
     <table class="table case-table">
       <tr style="width: 100%;">
         <th>Created</th>
-        <td><%= @case.created_at.to_formatted_s(:long) %></td>
-        <th>By</th>
-        <td><%= @case.user.name %></td>
+        <td>
+          <%= @case.created_at.to_formatted_s(:long) %>
+          by
+          <%= @case.user.name %>
+        </td>
+        <th>Assigned to</th>
+        <td>
+          <%= @case.assignee&.name or 'Nobody' %>
+        </td>
       </tr>
       <tr>
         <th>Association</th>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -13,8 +13,8 @@
           <%= @case.user.name %>
         </td>
         <th>Assigned to</th>
-        <td>
-          <%= @case.assignee&.name or 'Nobody' %>
+        <td id="case-assignment">
+          <%= render 'cases/case_assignment_controls' %>
         </td>
       </tr>
       <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
       member do
         post :resolve  # Only admins may resolve a case
         post :archive  # Only admins may archive a case
+        post :assign  # Only admins may (re)assign a case
       end
     end
 

--- a/db/migrate/20180424145344_add_assignee_to_cases.rb
+++ b/db/migrate/20180424145344_add_assignee_to_cases.rb
@@ -1,0 +1,5 @@
+class AddAssigneeToCases < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :cases, :assignee, foreign_key: { to_table: :users }, null: true
+  end
+end

--- a/db/migrate/20180425134112_install_audited.rb
+++ b/db/migrate/20180425134112_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :jsonb
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180424145344) do
+ActiveRecord::Schema.define(version: 20180425134112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,28 @@ ActiveRecord::Schema.define(version: 20180424145344) do
     t.index ["asset_record_field_definition_id"], name: "index_asset_record_fields_on_asset_record_field_definition_id"
     t.index ["component_group_id"], name: "index_asset_record_fields_on_component_group_id"
     t.index ["component_id"], name: "index_asset_record_fields_on_component_id"
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.jsonb "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "case_comments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180423170804) do
+ActiveRecord::Schema.define(version: 20180424145344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,8 @@ ActiveRecord::Schema.define(version: 20180423170804) do
     t.integer "tier_level"
     t.json "fields"
     t.text "state", default: "open", null: false
+    t.bigint "assignee_id"
+    t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"
     t.index ["issue_id"], name: "index_cases_on_issue_id"
@@ -326,6 +328,7 @@ ActiveRecord::Schema.define(version: 20180423170804) do
   add_foreign_key "cases", "issues"
   add_foreign_key "cases", "services"
   add_foreign_key "cases", "users"
+  add_foreign_key "cases", "users", column: "assignee_id"
   add_foreign_key "clusters", "sites"
   add_foreign_key "component_groups", "clusters"
   add_foreign_key "component_groups", "component_makes"

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -131,15 +131,22 @@ RSpec.describe 'Case page' do
       )
       create(:case_comment, case: open_case, user: admin, created_at: 4.hours.ago, text: 'First')
 
+      # Generate an assignee-change audit entry
+      open_case.assignee = admin
+      open_case.save
+
       visit case_path(open_case, as: admin)
 
       event_cards = all('.event-card')
-      expect(event_cards.size).to eq(3)
+      expect(event_cards.size).to eq(4)
 
       expect(event_cards[0].find('.card-body').text).to eq('First')
       expect(event_cards[1].find('.card-body').text).to eq('Second')
       expect(event_cards[2].find('.card-body').text).to match(
         /Maintenance requested for .* from .* until .* by A Scientist; to proceed this maintenance must be confirmed on the cluster dashboard/
+      )
+      expect(event_cards[3].find('.card-body').text).to eq(
+          'Assigned this case to A Scientist.'
       )
     end
   end

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -125,4 +125,36 @@ EOF
     expect(mail.body.encoded).to match('I can haz comment')
   end
 
+  it 'sends an email on case assignment' do
+    kase.assignee = another_user
+    mail = CaseMailer.change_assignee(kase, nil)
+
+    expect(mail.to).to eq nil
+    expect(mail.cc).to eq %w(another.user@somecluster.com someuser@somecluster.com mailing-list@somecluster.com)
+    expect(mail.bcc).to eq(['tickets@alces-software.com'])
+
+    expect(mail.body.encoded).to match('This case has been assigned to A Scientist.')
+  end
+
+  it 'sends an email on case assignment change' do
+    kase.assignee = another_user
+    mail = CaseMailer.change_assignee(kase, requestor)
+
+    expect(mail.to).to eq nil
+    expect(mail.cc).to eq %w(another.user@somecluster.com someuser@somecluster.com mailing-list@somecluster.com)
+    expect(mail.bcc).to eq(['tickets@alces-software.com'])
+
+    expect(mail.body.encoded).to match(/This case has been assigned to A Scientist \(previously\s+assigned to Some User\)\./)
+  end
+
+  it 'sends an email on case assignee removal' do
+    mail = CaseMailer.change_assignee(kase, another_user)
+
+    expect(mail.to).to eq nil
+    expect(mail.cc).to eq %w(another.user@somecluster.com someuser@somecluster.com mailing-list@somecluster.com)
+    expect(mail.bcc).to eq(['tickets@alces-software.com'])
+
+    expect(mail.body.encoded).to match('This case is no longer assigned to A Scientist.')
+  end
+
 end

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -125,7 +125,7 @@ EOF
     expect(mail.body.encoded).to match('I can haz comment')
   end
 
-  it 'sends an email on case assignment' do
+  it 'sends an email on initial case assignment' do
     kase.assignee = another_user
     mail = CaseMailer.change_assignee(kase, nil)
 

--- a/spec/models/case/assignee_validation_spec.rb
+++ b/spec/models/case/assignee_validation_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Case, type: :model do
+  let(:site) { create(:site) }
+  let(:other_site) { create(:site) }
+  let(:cluster) { create(:cluster, site: site) }
+
+  let(:admin) { create(:admin) }
+  let(:site_contact) { create(:contact, site: site) }
+  let(:other_contact) { create(:contact, site: other_site) }
+
+  subject do
+    build(:case, cluster: cluster, assignee: assignee)
+  end
+
+  context 'when not assigned to anyone' do
+    let(:assignee) { nil }
+    it { is_expected.to be_valid }
+  end
+
+  context 'when assigned to a contact in this site' do
+    let(:assignee) { site_contact }
+    it { is_expected.to be_valid }
+  end
+
+  context 'when assigned to an admin' do
+    let(:assignee) { admin }
+    it { is_expected.to be_valid }
+  end
+
+  context 'when assigned to another site\'s contact' do
+    let(:assignee) { other_contact }
+    it 'should be invalid' do
+      expect(subject).to be_invalid
+      expect(subject.errors.messages).to eq(
+        assignee: ['must belong to this site, or be an admin']
+      )
+    end
+  end
+
+end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Case, type: :model do
     end
   end
 
+
   describe 'Email creation on Case creation' do
     subject do
       build(:case)
@@ -112,6 +113,52 @@ RSpec.describe Case, type: :model do
       subject.reload
 
       expect(subject.mailto_url).to include(created_ticket_token)
+    end
+  end
+
+  describe 'Email creation on assignee change' do
+
+    let(:initial_assignee) { nil }
+    let(:site) { create(:site) }
+    let(:cluster) { create(:cluster, site: site) }
+
+    subject do
+      create(:case, assignee: initial_assignee, cluster: cluster)
+    end
+
+    let :stub_mail do
+      obj = double
+      expect(obj).to receive(:deliver_later)
+      obj
+    end
+
+    context 'with no previous assignee' do
+      it 'sends an email' do
+        assignee = create(:admin)
+        subject.assignee = assignee
+
+        expect(CaseMailer).to receive(:change_assignee).with(
+          subject,
+          nil
+        ).and_return(stub_mail)
+
+        subject.save!
+      end
+    end
+
+    context 'with a previous assignee' do
+      let(:initial_assignee) { create(:user, site: site) }
+      it 'sends an email' do
+        assignee = create(:admin)
+        subject.assignee = assignee
+
+        expect(CaseMailer).to receive(:change_assignee).with(
+          subject,
+          initial_assignee
+        ).and_return(stub_mail)
+
+        subject.save!
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds the concept of an "assignee" to `Case`s, and provides UI for admins to set or clear an assignee for a case.

The current assignee of a case is displayed in both the cases table and the case show page. Only admins are given UI for changing the assignee of a case. A case may be assigned to any contact that is a member of the same site as the case, or to any admin, or to nobody.

Change of assignee is recorded by the `audited` gem, and displayed in the case history feed alongside other events. When an assignee is changed, an email is sent to all contacts of the appropriate site (plus the admin to whom the case is being assigned, where appropriate).

This work was originally done in `feature/assign-cases-to-users` but trying to rebase or merge that with `develop` was a nightmare, so I cherry-picked into this fresh branch instead.

Trello: https://trello.com/c/6rxwL4sG/244-add-user-assignment-to-cases