### PR TITLE
Show tier fields in new Case emails

### DIFF
--- a/app/mailer_previews/case_mailer_preview.rb
+++ b/app/mailer_previews/case_mailer_preview.rb
@@ -23,9 +23,6 @@ class CaseMailerPreview < ApplicationMailerPreview
   private
 
   def get_case
-    Case.first || FactoryBot.build(
-        :case,
-        created_at: DateTime.now
-    )
+    @case_id ? Case.find(@case_id) : Case.last
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -177,10 +177,16 @@ class Case < ApplicationRecord
     "#{cluster.name}: #{subject} [#{token}]"
   end
 
-  def text_summary
-    # Ticket text does not need to be in this format, it is just text, but this
-    # is readable and an adequate format for now.
-    Utils.rt_format(case_properties)
+  def email_properties
+    {
+      Requestor: user.name,
+      Cluster: cluster.name,
+      Category: category&.name,
+      'Issue': issue.name,
+      'Associated component': component&.name,
+      'Associated service': service&.name,
+      Details: details,
+    }.reject { |_k, v| v.nil? }
   end
 
   def consultancy?
@@ -260,18 +266,6 @@ class Case < ApplicationRecord
       (0...length).map do |position|
         (position.even? ? letters : digits).sample
       end.join
-  end
-
-  def case_properties
-    {
-      Requestor: user.name,
-      Cluster: cluster.name,
-      Category: category&.name,
-      'Issue': issue.name,
-      'Associated component': component&.name,
-      'Associated service': service&.name,
-      Details: details,
-    }.reject { |_k, v| v.nil? }
   end
 
   def send_new_case_email

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -184,6 +184,7 @@ class Case < ApplicationRecord
       'Issue': issue.name,
       'Associated component': component&.name,
       'Associated service': service&.name,
+      Tier: decorate.tier_description,
       Fields: field_hash,
     }.reject { |_k, v| v.nil? }
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -284,7 +284,8 @@ class Case < ApplicationRecord
 
   def field_hash
     fields.map do |f|
-      [f['name'], f['value']]
+      f = f.with_indifferent_access
+      [f.fetch(:name), f.fetch(:value)]
     end.to_h.symbolize_keys
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -184,7 +184,7 @@ class Case < ApplicationRecord
       'Issue': issue.name,
       'Associated component': component&.name,
       'Associated service': service&.name,
-      Details: details,
+      Fields: field_hash,
     }.reject { |_k, v| v.nil? }
   end
 
@@ -279,5 +279,11 @@ class Case < ApplicationRecord
   def validates_user_assignment
     return if assignee.nil?
     errors.add(:assignee, 'must belong to this site, or be an admin') unless assignee.site == site or assignee.admin?
+  end
+
+  def field_hash
+    fields.map do |f|
+      [f['name'], f['value']]
+    end.to_h.symbolize_keys
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -179,7 +179,6 @@ class Case < ApplicationRecord
 
   def email_properties
     {
-      Requestor: user.name,
       Cluster: cluster.name,
       Category: category&.name,
       'Issue': issue.name,

--- a/app/views/case_mailer/new_case.html.erb
+++ b/app/views/case_mailer/new_case.html.erb
@@ -4,8 +4,17 @@
 
 <blockquote>
   <% @case.email_properties.each do |key, value| %>
-    <strong><%= key %>:</strong> <%= value %><br/>
+    <strong><%= key %>:</strong>
+    <% if value.is_a?(Hash) %>
+      <ul style="list-style-type: none; margin: 0;">
+        <% value.each do |k, v| %>
+          <li><strong><%= k %>:</strong> <%= v %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <%= value %>
+    <% end %>
+    <br/>
   <% end %>
-  <br/>
   <cite><%= @case.created_at.to_formatted_s(:long) %> - <b><%= @case.user.name %></b></cite>
 </blockquote>

--- a/app/views/case_mailer/new_case.html.erb
+++ b/app/views/case_mailer/new_case.html.erb
@@ -8,7 +8,10 @@
     <% if value.is_a?(Hash) %>
       <ul style="list-style-type: none; margin: 0;">
         <% value.each do |k, v| %>
-          <li><strong><%= k %>:</strong> <%= v %></li>
+          <li>
+            <strong><%= k %>:</strong>
+          <%= v.include?("\n") ? simple_format(v) : v %>
+          </li>
         <% end %>
       </ul>
     <% else %>

--- a/app/views/case_mailer/new_case.html.erb
+++ b/app/views/case_mailer/new_case.html.erb
@@ -3,8 +3,8 @@
 <h3><%= @case.ticket_subject %></h3>
 
 <blockquote>
-  <% @case.text_summary.split(/\n/).each do |line| %>
-    <%= line %><br/>
+  <% @case.email_properties.each do |key, value| %>
+    <strong><%= key %>:</strong> <%= value %><br/>
   <% end %>
   <br/>
   <cite><%= @case.created_at.to_formatted_s(:long) %> - <b><%= @case.user.name %></b></cite>

--- a/app/views/case_mailer/new_case.text.erb
+++ b/app/views/case_mailer/new_case.text.erb
@@ -6,7 +6,14 @@ A new support case has been created:
 <%= @case.created_at.to_formatted_s(:long) %> - <%= @case.user.name %>:
 
 <% @case.email_properties.each do |key, value| %>
+  <% if value.is_a?(Hash) %>
+  <%= key %>:
+    <% value.each do |k, v| %>
+      <%= k %>: <%= v %>
+    <% end %>
+  <% else %>
   <%= key %>: <%= value %>
+  <% end %>
 <% end %>
 
 -------------------------------------------------------------------------------

--- a/app/views/case_mailer/new_case.text.erb
+++ b/app/views/case_mailer/new_case.text.erb
@@ -8,8 +8,14 @@ A new support case has been created:
 <% @case.email_properties.each do |key, value| %>
   <% if value.is_a?(Hash) %>
   <%= key %>:
-    <% value.each do |k, v| %>
+    <% value.each do |k, v| -%>
+      <% if v.include?("\n") %>
+      <%= k %>: <% v.split(/\n+/).each do |line| %>
+        <%= line %>
+      <% end %>
+      <% else %>
       <%= k %>: <%= v %>
+      <% end %>
     <% end %>
   <% else %>
   <%= key %>: <%= value %>

--- a/app/views/case_mailer/new_case.text.erb
+++ b/app/views/case_mailer/new_case.text.erb
@@ -5,6 +5,8 @@ A new support case has been created:
 -------------------------------------------------------------------------------
 <%= @case.created_at.to_formatted_s(:long) %> - <%= @case.user.name %>:
 
-<%= @case.text_summary %>
+<% @case.email_properties.each do |key, value| %>
+  <%= key %>: <%= value %>
+<% end %>
 
 -------------------------------------------------------------------------------

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -39,12 +39,6 @@
         <td><%= @case.rt_ticket_id || 'N/A' %></td>
       </tr>
       <tr>
-        <th>Chargeable</th>
-        <td><%= @case.chargeable_symbol %></td>
-        <th>Credit charge</th>
-        <td><%= @case.credit_charge_info %></td>
-      </tr>
-      <tr>
         <th>Fields</th>
         <td colspan="3">
           <div class="table-responsive">

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -81,7 +81,11 @@ RSpec.describe CasesController, type: :controller do
           subject: 'some_subject',
           details: 'Useful info',
           tier_level: 2,
-          fields: [type: 'textarea'],
+          fields: [{
+            type: 'textarea',
+            name: 'some_field',
+            value: 'some_value',
+          }],
         }
       }
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -89,6 +89,7 @@ FactoryBot.define do
     fields [{
       type: 'input',
       name: 'some_field',
+      value: 'some_value',
     }]
 
     factory :level_1_tier do

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -26,14 +26,11 @@ RSpec.describe 'Case mailer', :type => :mailer do
     create(
         :issue,
         name: 'Crashed node',
-        requires_component: requires_component,
-        requires_service: requires_service,
+        requires_component: true,
+        requires_service: true,
         category: category
     )
   end
-
-  let(:requires_component) { true }
-  let(:requires_service) { true }
 
   let(:category) { create(:category, name: 'Hardware issue') }
   let(:cluster) { create(:cluster, site: site, name: 'somecluster') }
@@ -85,28 +82,6 @@ RSpec.describe 'Case mailer', :type => :mailer do
     EOF
 
     expect(mail.body.encoded).to match(expected_body)
-  end
-
-  context 'when no associated component' do
-    let(:requires_component) { false }
-    let(:component) { nil }
-
-    it 'does not include corresponding line in email text' do
-      mail = CaseMailer.new_case(kase)
-      expect(mail.body.encoded).not_to match('Associated component:')
-    end
-
-  end
-
-  context 'when no associated service' do
-    let(:requires_service) { false }
-    let(:service) { nil }
-
-    it 'does not include corresponding line in email text' do
-      mail = CaseMailer.new_case(kase)
-      expect(mail.body.encoded).not_to match('Associated service:')
-    end
-
   end
 
   it 'sends an email on case comment being added' do

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe 'Case mailer', :type => :mailer do
     expect(mail.bcc).to match_array(['tickets@alces-software.com'])
 
     expected_lines = [
-      /Requestor:.* Some User/,
       /Cluster:.* somecluster/,
       /Category:.* Hardware issue/,
       /Issue:.* Crashed node/,

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Case mailer', :type => :mailer do
           Oh no
           my node
           is broken
-    EOF
+        EOF
     )
   }
 
@@ -72,17 +72,17 @@ RSpec.describe 'Case mailer', :type => :mailer do
     expect(mail.cc).to match_array %w(another.user@somecluster.com mailing-list@somecluster.com)
     expect(mail.bcc).to match_array(['tickets@alces-software.com'])
 
-    expected_body = <<EOF
-Requestor: Some User
-Cluster: somecluster
-Category: Hardware issue
-Issue: Crashed node
-Associated component: node01
-Associated service: Some service
-Details: Oh no
- my node
- is broken
-EOF
+    expected_body = <<~EOF.strip_heredoc
+      Requestor: Some User
+      Cluster: somecluster
+      Category: Hardware issue
+      Issue: Crashed node
+      Associated component: node01
+      Associated service: Some service
+      Details: Oh no
+       my node
+       is broken
+    EOF
 
     expect(mail.body.encoded).to match(expected_body)
   end

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -70,22 +70,19 @@ RSpec.describe 'Case mailer', :type => :mailer do
     expect(mail.bcc).to match_array(['tickets@alces-software.com'])
 
     expected_lines = [
-      'Requestor: Some User',
-      'Cluster: somecluster',
-      'Category: Hardware issue',
-      'Issue: Crashed node',
-      'Associated component: node01',
-      'Associated service: Some service',
-      'Details: Oh no',
-       'my node',
-       'is broken',
+      /Requestor:.* Some User/,
+      /Cluster:.* somecluster/,
+      /Category:.* Hardware issue/,
+      /Issue:.* Crashed node/,
+      /Associated component:.* node01/,
+      /Associated service:.* Some service/,
     ]
 
     [:text, :html].each do |format|
       raw_body = mail.send("#{format}_part").body.raw_source
 
       expected_lines.each do |line|
-        expect(raw_body).to include(line)
+        expect(raw_body).to match(line)
       end
     end
   end

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -69,19 +69,25 @@ RSpec.describe 'Case mailer', :type => :mailer do
     expect(mail.cc).to match_array %w(another.user@somecluster.com mailing-list@somecluster.com)
     expect(mail.bcc).to match_array(['tickets@alces-software.com'])
 
-    expected_body = <<~EOF.strip_heredoc
-      Requestor: Some User
-      Cluster: somecluster
-      Category: Hardware issue
-      Issue: Crashed node
-      Associated component: node01
-      Associated service: Some service
-      Details: Oh no
-       my node
-       is broken
-    EOF
+    expected_lines = [
+      'Requestor: Some User',
+      'Cluster: somecluster',
+      'Category: Hardware issue',
+      'Issue: Crashed node',
+      'Associated component: node01',
+      'Associated service: Some service',
+      'Details: Oh no',
+       'my node',
+       'is broken',
+    ]
 
-    expect(mail.body.encoded).to match(expected_body)
+    [:text, :html].each do |format|
+      raw_body = mail.send("#{format}_part").body.raw_source
+
+      expected_lines.each do |line|
+        expect(raw_body).to include(line)
+      end
+    end
   end
 
   it 'sends an email on case comment being added' do

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -48,11 +48,10 @@ RSpec.describe 'Case mailer', :type => :mailer do
         service: service,
         user: requestor,
         subject: 'my_subject',
-        details: <<-EOF.strip_heredoc
-          Oh no
-          my node
-          is broken
-        EOF
+        fields: [
+          {name: 'field1', value: 'value1'},
+          {name: 'field2', value: 'value2', optional: true},
+        ]
     )
   }
 
@@ -70,11 +69,14 @@ RSpec.describe 'Case mailer', :type => :mailer do
     expect(mail.bcc).to match_array(['tickets@alces-software.com'])
 
     expected_lines = [
-      /Cluster:.* somecluster/,
-      /Category:.* Hardware issue/,
-      /Issue:.* Crashed node/,
-      /Associated component:.* node01/,
-      /Associated service:.* Some service/,
+      /Cluster:.* somecluster/m,
+      /Category:.* Hardware issue/m,
+      /Issue:.* Crashed node/m,
+      /Associated component:.* node01/m,
+      /Associated service:.* Some service/m,
+      /Fields:/,
+      /field1:.* value1/m,
+      /field2:.* value2/m,
     ]
 
     [:text, :html].each do |format|

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -307,7 +307,6 @@ RSpec.describe Case, type: :model do
 
     it 'includes all needed Case properties with values' do
       expected_properties = {
-        Requestor: 'Some User',
         Cluster: 'somecluster',
         Category: 'Hardware issue',
         Issue: 'Crashed node',

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Case, type: :model do
     it { is_expected.to eq 'component' }
   end
 
-  describe '#text_summary' do
+  describe '#email_properties' do
     let :site { create(:site) }
 
     let :requestor do
@@ -306,19 +306,21 @@ RSpec.describe Case, type: :model do
     }
 
     it 'includes all needed Case properties with values' do
-      expected_text = <<~EOF.strip_heredoc
-        Requestor: Some User
-        Cluster: somecluster
-        Category: Hardware issue
-        Issue: Crashed node
-        Associated component: node01
-        Associated service: Some service
-        Details: Oh no
-         my node
-         is broken
-      EOF
+      expected_properties = {
+        Requestor: 'Some User',
+        Cluster: 'somecluster',
+        Category: 'Hardware issue',
+        Issue: 'Crashed node',
+        'Associated component': 'node01',
+        'Associated service': 'Some service',
+        Details: <<-EOF.strip_heredoc
+          Oh no
+          my node
+          is broken
+        EOF
+      }
 
-      expect(kase.text_summary).to match(expected_text)
+      expect(kase.email_properties).to eq expected_properties
     end
 
     context 'when no associated component' do
@@ -326,7 +328,7 @@ RSpec.describe Case, type: :model do
       let(:component) { nil }
 
       it 'does not include corresponding line' do
-        expect(kase.text_summary).not_to match('Associated component:')
+        expect(kase.email_properties).not_to include(:'Associated component')
       end
     end
 
@@ -335,7 +337,7 @@ RSpec.describe Case, type: :model do
       let(:service) { nil }
 
       it 'does not include corresponding line' do
-        expect(kase.text_summary).not_to match('Associated service:')
+        expect(kase.email_properties).not_to include(:'Associated service')
       end
     end
   end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -297,11 +297,10 @@ RSpec.describe Case, type: :model do
         service: service,
         user: requestor,
         subject: 'my_subject',
-        details: <<-EOF.strip_heredoc
-          Oh no
-          my node
-          is broken
-        EOF
+        fields: [
+          {name: 'field1', value: 'value1'},
+          {name: 'field2', value: 'value2', optional: true},
+        ]
       )
     }
 
@@ -312,11 +311,10 @@ RSpec.describe Case, type: :model do
         Issue: 'Crashed node',
         'Associated component': 'node01',
         'Associated service': 'Some service',
-        Details: <<-EOF.strip_heredoc
-          Oh no
-          my node
-          is broken
-        EOF
+        Fields: {
+          field1: 'value1',
+          field2: 'value2',
+        }
       }
 
       expect(kase.email_properties).to eq expected_properties

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -297,6 +297,7 @@ RSpec.describe Case, type: :model do
         service: service,
         user: requestor,
         subject: 'my_subject',
+        tier_level: 3,
         fields: [
           {name: 'field1', value: 'value1'},
           {name: 'field2', value: 'value2', optional: true},
@@ -311,6 +312,7 @@ RSpec.describe Case, type: :model do
         Issue: 'Crashed node',
         'Associated component': 'node01',
         'Associated service': 'Some service',
+        Tier: '3 (Consultancy)',
         Fields: {
           field1: 'value1',
           field2: 'value2',


### PR DESCRIPTION
This PR updates the new Case emails so they include the new Tier fields, appropriately formatted for the medium (text vs HTML); this replaces showing the Case details, which are no longer set for new Cases and will eventually be removed. @jamesremuscat you may want to look at this as this touches stuff you've been working on :slightly_smiling_face:.

A few related changes were also made along with this:

- making it possible to preview the new Case emails for different Cases in the email preview pages, by adding a `case_id` parameter to the URL;

- tweaking the other fields shown in the emails (showing the Tier level and accompanying description, and removing the requestor which is now already shown);

- removing the charging-related fields from the Case page, as these have become obsolete/out-of-date with the latest changes we've been making.

Trello: https://trello.com/c/bxctf7j2/246-update-new-case-emails-to-show-tier-fields-1-2-day.