### PR TITLE
Change default `from` email address to `center@alces-flight.com`.

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,7 +5,7 @@ class ApplicationMailer < ActionMailer::Base
   include Roadie::Rails::Automatic
   extend Alces::Mailer::Resender
 
-  default from: 'support@alces-flight.com'
+  default from: 'center@alces-flight.com'
   layout 'mailer'
   helper 'mailer'
 end


### PR DESCRIPTION
As title. Requested by @mjtko.