### PR TITLE
Fix navbar drill-down and tabs on Case page (fixes #188)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,6 +66,19 @@ class ApplicationController < ActionController::Base
              when /^\/services/
                id = scope_id_param(:service_id)
                @service = @cluster_part = Service.find(id)
+             when /^\/cases/
+               begin
+                 id = scope_id_param(:case_id)
+                 Case.find(id).associated_model
+               rescue ActiveRecord::RecordNotFound
+                 # There are various routes which begin `/cases/` but are not
+                 # the route for a particular Case; if we can't find the Case
+                 # we must either be in one of these, or we are trying to find
+                 # a Case which actually doesn't exist. Either way assign the
+                 # Site scope rather than blow up, then carry on and let
+                 # specific controller we are in handle this as normal.
+                 assign_site_scope
+               end
              else
                assign_site_scope
              end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,13 +67,17 @@ class ApplicationController < ActionController::Base
                id = scope_id_param(:service_id)
                @service = @cluster_part = Service.find(id)
              else
-               @site = if request.path =~ /^\/sites/
-                         id = scope_id_param(:site_id)
-                         Site.find(id)
-                       elsif current_user.contact?
-                         current_user.site
-                       end
+               assign_site_scope
              end
+  end
+
+  def assign_site_scope
+    @site = if request.path =~ /^\/sites/
+              id = scope_id_param(:site_id)
+              Site.find(id)
+            elsif current_user.contact?
+              current_user.site
+            end
   end
 
   def assign_title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,46 +27,7 @@ module ApplicationHelper
   end
 
   def scope_nav_link_procs
-    return @scope_nav_link_procs if @scope_nav_link_procs
-    @scope_nav_link_procs ||= []
-
-    if current_user&.admin?
-      @scope_nav_link_procs << nav_link_proc(text: 'All Sites',
-                                      path: root_path,
-                                      nav_icon: 'fa-globe')
-    end
-
-    if @scope
-      site_obj = model_from_scope :site
-      path_for_site = if current_user.admin?
-                        site_obj
-                      else
-                        root_path
-                      end
-      @scope_nav_link_procs << nav_link_proc(model: site_obj,
-                                      path: path_for_site,
-                                      nav_icon: 'fa-institution')
-
-      cluster_obj = model_from_scope :cluster
-      if cluster_obj
-        @scope_nav_link_procs << nav_link_proc(model: cluster_obj,
-                                        nav_icon: 'fa-server')
-      end
-
-      component_group_obj = model_from_scope :component_group
-      if component_group_obj
-        @scope_nav_link_procs << nav_link_proc(model: component_group_obj,
-                                        nav_icon: 'fa-cubes')
-      end
-
-      cluster_part = model_from_scope(:service) || model_from_scope(:component)
-      if cluster_part
-        @scope_nav_link_procs << nav_link_proc(model: cluster_part,
-                                        nav_icon: 'fa-cube')
-      end
-    end
-
-    @scope_nav_link_procs
+    @scope_nav_link_procs ||= ScopeNavLinksBuilder.new(scope: @scope).build
   end
 
   def icon_span(text, icon = '')
@@ -96,21 +57,5 @@ module ApplicationHelper
     }.to_json
 
     "data-single-part=#{single_part_json}"
-  end
-
-  def model_from_scope(type)
-    if @scope.respond_to? type
-      @scope.public_send type
-    elsif @scope.is_a?(type.to_s.classify.constantize)
-      @scope
-    else
-      nil
-    end
-  end
-
-  def nav_link_proc(**inputs_to_partial)
-    Proc.new do |**additional_inputs|
-      render 'partials/nav_link', **additional_inputs, **inputs_to_partial
-    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,24 +26,46 @@ module ApplicationHelper
     )
   end
 
-  def model_from_scope(type)
-    if @scope.respond_to? type
-      @scope.public_send type
-    elsif @scope.is_a?(type.to_s.classify.constantize)
-      @scope
-    else
-      nil
-    end
-  end
+  def scope_nav_link_procs
+    return @scope_nav_link_procs if @scope_nav_link_procs
+    @scope_nav_link_procs ||= []
 
-  def add_nav_link_proc(**inputs_to_partial)
-    nav_link_procs << Proc.new do |**additional_inputs|
-      render 'partials/nav_link', **additional_inputs, **inputs_to_partial
+    if current_user&.admin?
+      @scope_nav_link_procs << nav_link_proc(text: 'All Sites',
+                                      path: root_path,
+                                      nav_icon: 'fa-globe')
     end
-  end
 
-  def nav_link_procs
-    @nav_link_procs ||= []
+    if @scope
+      site_obj = model_from_scope :site
+      path_for_site = if current_user.admin?
+                        site_obj
+                      else
+                        root_path
+                      end
+      @scope_nav_link_procs << nav_link_proc(model: site_obj,
+                                      path: path_for_site,
+                                      nav_icon: 'fa-institution')
+
+      cluster_obj = model_from_scope :cluster
+      if cluster_obj
+        @scope_nav_link_procs << nav_link_proc(model: cluster_obj,
+                                        nav_icon: 'fa-server')
+      end
+
+      component_group_obj = model_from_scope :component_group
+      if component_group_obj
+        @scope_nav_link_procs << nav_link_proc(model: component_group_obj,
+                                        nav_icon: 'fa-cubes')
+      end
+
+      if @cluster_part
+        @scope_nav_link_procs << nav_link_proc(model: @cluster_part,
+                                        nav_icon: 'fa-cube')
+      end
+    end
+
+    @scope_nav_link_procs
   end
 
   def icon_span(text, icon = '')
@@ -73,5 +95,21 @@ module ApplicationHelper
     }.to_json
 
     "data-single-part=#{single_part_json}"
+  end
+
+  def model_from_scope(type)
+    if @scope.respond_to? type
+      @scope.public_send type
+    elsif @scope.is_a?(type.to_s.classify.constantize)
+      @scope
+    else
+      nil
+    end
+  end
+
+  def nav_link_proc(**inputs_to_partial)
+    Proc.new do |**additional_inputs|
+      render 'partials/nav_link', **additional_inputs, **inputs_to_partial
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,8 +59,9 @@ module ApplicationHelper
                                         nav_icon: 'fa-cubes')
       end
 
-      if @cluster_part
-        @scope_nav_link_procs << nav_link_proc(model: @cluster_part,
+      cluster_part = model_from_scope(:service) || model_from_scope(:component)
+      if cluster_part
+        @scope_nav_link_procs << nav_link_proc(model: cluster_part,
                                         nav_icon: 'fa-cube')
       end
     end

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -1,0 +1,70 @@
+
+class ScopeNavLinksBuilder
+  include Draper::ViewHelpers
+
+  def initialize(scope:)
+    @scope = scope
+  end
+
+  def build
+    scope_nav_link_procs = []
+
+    if h.current_user&.admin?
+      scope_nav_link_procs << nav_link_proc(text: 'All Sites',
+                                            path: h.root_path,
+                                            nav_icon: 'fa-globe')
+    end
+
+    if scope
+      site_obj = model_from_scope :site
+      path_for_site = if h.current_user.admin?
+                        site_obj
+                      else
+                        h.root_path
+                      end
+      scope_nav_link_procs << nav_link_proc(model: site_obj,
+                                            path: path_for_site,
+                                            nav_icon: 'fa-institution')
+
+      cluster_obj = model_from_scope :cluster
+      if cluster_obj
+        scope_nav_link_procs << nav_link_proc(model: cluster_obj,
+                                              nav_icon: 'fa-server')
+      end
+
+      component_group_obj = model_from_scope :component_group
+      if component_group_obj
+        scope_nav_link_procs << nav_link_proc(model: component_group_obj,
+                                              nav_icon: 'fa-cubes')
+      end
+
+      cluster_part = model_from_scope(:service) || model_from_scope(:component)
+      if cluster_part
+        scope_nav_link_procs << nav_link_proc(model: cluster_part,
+                                              nav_icon: 'fa-cube')
+      end
+    end
+
+    scope_nav_link_procs
+  end
+
+  private
+
+  attr_reader :scope
+
+  def model_from_scope(type)
+    if scope.respond_to? type
+      scope.public_send type
+    elsif scope.is_a?(type.to_s.classify.constantize)
+      scope
+    else
+      nil
+    end
+  end
+
+  def nav_link_proc(**inputs_to_partial)
+    Proc.new do |**additional_inputs|
+      h.render 'partials/nav_link', **additional_inputs, **inputs_to_partial
+    end
+  end
+end

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,8 +1,6 @@
-<% content_for :subtitle { 'Support Case' } %>
-<div class='card'>
-  <%= render 'partials/card_header_nav',
-    title: "#{@case.display_id} - #{@case.subject}"
-  %>
+<% content_for :subtitle { "Support Case #{@case.display_id}: #{@case.subject}" } %>
+
+<%= render 'partials/tabs', activate: :cases do %>
   <div class='table-responsive'>
     <table class="table case-table">
       <tr style="width: 100%;">
@@ -68,4 +66,4 @@
       </tr>
     </table>
   </div>
-</div>
+<% end %>

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -13,42 +13,8 @@
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
-      <% if current_user&.admin?
-        add_nav_link_proc text: 'All Sites',
-                          path: root_path,
-                          nav_icon: 'fa-globe'
-      end
-
-      if @scope
-        site_obj = model_from_scope :site
-        path_for_site = if current_user.admin?
-                          site_obj
-                        else
-                          root_path
-                        end
-        add_nav_link_proc model: site_obj,
-                          path: path_for_site,
-                          nav_icon: 'fa-institution'
-
-        cluster_obj = model_from_scope :cluster
-        if cluster_obj
-          add_nav_link_proc model: cluster_obj,
-                            nav_icon: 'fa-server'
-        end
-
-        component_group_obj = model_from_scope :component_group
-        if component_group_obj
-          add_nav_link_proc model: component_group_obj,
-                            nav_icon: 'fa-cubes'
-        end
-
-        if @cluster_part
-          add_nav_link_proc model: @cluster_part,
-                            nav_icon: 'fa-cube'
-        end
-      end %>
-      <% nav_link_procs.each do |nav_proc| %>
-        <% active = (nav_proc == nav_link_procs.last) %>
+      <% scope_nav_link_procs.each do |nav_proc| %>
+        <% active = (nav_proc == scope_nav_link_procs.last) %>
         <%= nav_proc.call active: active %>
       <% end %>
     </ul>

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -106,6 +106,24 @@ RSpec.feature 'Navigation Bar', type: :feature do
       before :each { visit_subject :service_path }
       it_behaves_like 'a cluster navigation bar'
     end
+
+    context 'when visiting a case' do
+      subject do
+        create(:case_requiring_component, component: associated_model)
+      end
+      let :associated_model { create(:component, cluster: cluster) }
+
+      let :expected_cluster_links do
+        [
+          cluster_path(associated_model.cluster),
+          component_group_path(associated_model.component_group),
+          component_path(associated_model),
+        ]
+      end
+
+      before :each { visit_subject :case_path }
+      it_behaves_like 'a cluster navigation bar'
+    end
   end
 
   context 'with an admin logged in' do


### PR DESCRIPTION
This PR:

- makes the drill-down menu be shown when on an individual Case page;

- also makes the tabs for the corresponding dashboard (i.e. for the last entry in the drill-down) be shown when on this page, for consistency and to give the user routes to related actions;

- refactors generating this drill-down to make this a bit simpler to change in future.

Also related: https://trello.com/c/bj7KZixd/256-show-all-correct-links-in-header-of-case-page.