### PR TITLE
"Archived case" page cleanup

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -65,9 +65,9 @@ class CasesController < ApplicationController
     end
   end
 
-  def archive
-    change_action "Support case %s archived." do |kase|
-      kase.archive!(current_user)
+  def close
+    change_action "Support case %s closed." do |kase|
+      kase.close!(current_user)
     end
   end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -3,14 +3,14 @@ class CasesController < ApplicationController
 
   decorates_assigned :site
 
-  def index(archive: false)
+  def index(show_resolved: false)
     @site = current_site
-    @archive = archive
+    @show_resolved = show_resolved
     current_site.cases.map(&:update_ticket_status!) if current_user.admin?
   end
 
   def archives
-    index(archive: true)
+    index(show_resolved: true)
     render :index
   end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -9,7 +9,7 @@ class CasesController < ApplicationController
     current_site.cases.map(&:update_ticket_status!) if current_user.admin?
   end
 
-  def archives
+  def resolved
     index(show_resolved: true)
     render :index
   end

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -13,7 +13,7 @@ module TabsHelper
         id: :cases, path: scope.scope_cases_path,
         dropdown: [
           { text: 'Current', path: scope.scope_cases_path },
-          { text: 'Archive', path: scope.archives_scope_cases_path }
+          { text: 'Resolved', path: scope.resolved_scope_cases_path }
         ]
       }
     end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -39,10 +39,10 @@ class Case < ApplicationRecord
 
     state :open  # Open case, still work to do
     state :resolved  # Has been resolved but not yet accounted for commercially
-    state :archived  # Has been accounted for commercially, nothing more to do
+    state :closed  # Has been accounted for commercially, nothing more to do
 
     event(:resolve) { transition open: :resolved }  # Resolved cases cannot be reopened
-    event(:archive) { transition resolved: :archived }
+    event(:close) { transition resolved: :closed }
 
   end
 

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -11,14 +11,14 @@
                 }
     %>
   <% elsif @case.state == 'resolved' %>
-    <%= link_to 'Archive this case',
-                archive_case_path(@case.id),
+    <%= link_to 'Close this case',
+                close_case_path(@case.id),
                 class: 'btn btn-secondary ml-2 btn-sm',
                 method: :post,
                 role: 'button',
-                title: 'Archive this support case if it has been appropriately processed as part of credit reporting',
+                title: 'Close this support case if it has been appropriately processed as part of credit reporting',
                 data: {
-                    confirm: 'Are you sure you want to archive this support case?'
+                    confirm: 'Are you sure you want to close this support case?'
                 }
     %>
   <% end %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,6 +1,6 @@
-<% manage_cases_page = current_user.admin? && @archive %>
+<% manage_cases_page = current_user.admin? && @show_resolved %>
 <%= content_for :subtitle do
-  "#{@archive ? 'All' : 'Open'} Cases"
+  "#{@show_resolved ? 'Resolved' : 'Open'} Cases"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
   <ul class='nav nav-tabs nav-justified' >
@@ -28,10 +28,10 @@ end %>
       <tbody>
         <% @scope.cases.order(created_at: :desc).decorate.each do |c| %>
       <%
-        # If @archive, show only non-open cases; if not @archive, show only open cases.
+        # If @show_resolved, show only non-open cases; if not @show_resolved, show only open cases.
         # Hence logic simplifies to the below (!=)
       %>
-          <% if @archive != c.open?  %>
+          <% if @show_resolved != c.open?  %>
             <% if c.hidden? && !manage_cases_page %>
               <tr
                 class="archived-case-row"

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -27,7 +27,11 @@ end %>
 
       <tbody>
         <% @scope.cases.order(created_at: :desc).decorate.each do |c| %>
-          <% if @archive || c.open? %>
+      <%
+        # If @archive, show only non-open cases; if not @archive, show only open cases.
+        # Hence logic simplifies to the below (!=)
+      %>
+          <% if @archive != c.open?  %>
             <% if c.hidden? && !manage_cases_page %>
               <tr
                 class="archived-case-row"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,7 @@ Rails.application.routes.draw do
     resources :cases, only: [] do
       member do
         post :resolve  # Only admins may resolve a case
-        post :archive  # Only admins may archive a case
+        post :close  # Only admins may close a case
         post :assign  # Only admins may (re)assign a case
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,11 +53,11 @@ Rails.application.routes.draw do
     end
   end
 
-  archive_cases = Proc.new do |**params, &block|
+  resolved_cases = Proc.new do |**params, &block|
     params[:only] = Array.wrap(params[:only]).concat [:new, :index]
     resources :cases, **params do
       collection do
-        get :archives
+        get :resolved
       end
       block.call if block
     end
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
 
     root 'sites#index'
     resources :sites, only: [:show, :index] do
-      archive_cases.call(only: :show)
+      resolved_cases.call(only: :show)
     end
 
     resources :cases, only: [] do
@@ -124,12 +124,12 @@ Rails.application.routes.draw do
     root 'sites#show'
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 
-    archive_cases.call(only: [:show, :create]) do
+    resolved_cases.call(only: [:show, :create]) do
       resources :case_comments, only: :create
     end
 
     resources :clusters, only: :show do
-      archive_cases.call
+      resolved_cases.call
       resources :services, only: :index
       resources :maintenance_windows, path: :maintenance, only: :index
       resources :components, only: :index
@@ -138,7 +138,7 @@ Rails.application.routes.draw do
     end
 
     resources :components, only: :show do
-      archive_cases.call
+      resolved_cases.call
       resources :component_expansions,
                 path: component_expansions_alias,
                 only: :index
@@ -154,7 +154,7 @@ Rails.application.routes.draw do
     end
 
     resources :services, only: :show do
-      archive_cases.call
+      resolved_cases.call
       confirm_maintenance_form.call
     end
 

--- a/db/data_migrations/20180501133322_rename_archived_to_closed.rb
+++ b/db/data_migrations/20180501133322_rename_archived_to_closed.rb
@@ -1,0 +1,9 @@
+class RenameArchivedToClosed < ActiveRecord::DataMigration
+  def up
+    Case.where(state: 'archived').each do |kase|
+      # NB By setting `state` directly we avoid generating any CaseStateTransitions
+      kase.state = 'closed'
+      kase.save!
+    end
+  end
+end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -168,8 +168,8 @@ RSpec.describe CasesController, type: :controller do
       create(:resolved_case)
     }
 
-    let (:archived_case) {
-      create(:archived_case)
+    let (:closed_case) {
+      create(:closed_case)
     }
 
     let(:admin) { create(:admin) }
@@ -181,19 +181,19 @@ RSpec.describe CasesController, type: :controller do
       expect(flash[:success]).to eq "Support case ##{open_case.id} resolved."
     end
 
-    it 'archives a resolved case' do
-      post :archive, params: { id: resolved_case.id }
-      expect(flash[:success]).to eq "Support case ##{resolved_case.id} archived."
+    it 'closes a resolved case' do
+      post :close, params: { id: resolved_case.id }
+      expect(flash[:success]).to eq "Support case ##{resolved_case.id} closed."
     end
 
-    it 'does not resolve an archived case' do
-      post :resolve, params: { id: archived_case.id }
+    it 'does not resolve a closed case' do
+      post :resolve, params: { id: closed_case.id }
       expect(flash[:error]).to eq 'Error updating support case: state cannot transition via "resolve"'
     end
 
-    it 'does not archive an open case' do
-      post :archive, params: { id: open_case.id }
-      expect(flash[:error]).to eq 'Error updating support case: state cannot transition via "archive"'
+    it 'does not close an open case' do
+      post :close, params: { id: open_case.id }
+      expect(flash[:error]).to eq 'Error updating support case: state cannot transition via "close"'
     end
   end
 end

--- a/spec/factories/case.rb
+++ b/spec/factories/case.rb
@@ -16,8 +16,8 @@ FactoryBot.define do
       state 'resolved'
     end
 
-    factory :archived_case do
-      state 'archived'
+    factory :closed_case do
+      state 'closed'
     end
 
     # Every Case requires a Cluster, so this is just the same as the standard

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe 'Cases table', type: :feature do
     end
 
     context 'when visit archive cases page' do
-      it 'renders table of all Cases' do
+      it 'renders table of all resolved or closed Cases' do
         visit archives_cases_path(as: user)
 
         cases = all('tr').map(&:text)
-        expect(cases).to have_text('Open case')
+        expect(cases).not_to have_text('Open case')
         expect(cases).to have_text('Resolved case')
         expect(cases).to have_text('Closed case')
 
@@ -57,7 +57,7 @@ RSpec.describe 'Cases table', type: :feature do
         expect(headings).to include('Contact support')
 
         links = all('a').map { |a| a[:href] }
-        expect(links).to include(open_case.mailto_url)
+        expect(links).not_to include(open_case.mailto_url)
 
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe 'Cases table', type: :feature do
     end
 
     context 'when visit archive cases page' do
-      it 'renders table of all Cases, without Contact-specific buttons/info' do
+      it 'renders table of all resolved and closed Cases, without Contact-specific buttons/info' do
         visit archives_site_cases_path(site, as: user)
 
         headings = all('th').map(&:text)

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Cases table', type: :feature do
 
     context 'when visit archive cases page' do
       it 'renders table of all resolved or closed Cases' do
-        visit archives_cases_path(as: user)
+        visit resolved_cases_path(as: user)
 
         cases = all('tr').map(&:text)
         expect(cases).not_to have_text('Open case')
@@ -76,7 +76,7 @@ RSpec.describe 'Cases table', type: :feature do
 
     context 'when visit archive cases page' do
       it 'renders table of all resolved and closed Cases, without Contact-specific buttons/info' do
-        visit archives_site_cases_path(site, as: user)
+        visit resolved_site_cases_path(site, as: user)
 
         headings = all('th').map(&:text)
         expect(headings).not_to include('Contact support')

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe 'Cases table', type: :feature do
     create(:resolved_case, cluster: cluster, subject: 'Resolved case', completed_at: 1.days.ago, rt_ticket_id: nil)
   end
 
-  let! :archived_case do
-    create(:archived_case, cluster: cluster, subject: 'Archived case', completed_at: 2.days.ago)
+  let! :closed_case do
+    create(:closed_case, cluster: cluster, subject: 'Closed case', completed_at: 2.days.ago)
   end
 
   RSpec.shared_examples 'open cases table rendered' do
@@ -25,7 +25,7 @@ RSpec.describe 'Cases table', type: :feature do
       cases = all('tr').map(&:text)
       expect(cases).to have_text('Open case')
       expect(cases).not_to have_text('Resolved case')
-      expect(cases).not_to have_text('Archived case')
+      expect(cases).not_to have_text('Closed case')
 
       headings = all('th').map(&:text)
       expect(headings).to include('Contact support')
@@ -51,7 +51,7 @@ RSpec.describe 'Cases table', type: :feature do
         cases = all('tr').map(&:text)
         expect(cases).to have_text('Open case')
         expect(cases).to have_text('Resolved case')
-        expect(cases).to have_text('Archived case')
+        expect(cases).to have_text('Closed case')
 
         headings = all('th').map(&:text)
         expect(headings).to include('Contact support')
@@ -114,8 +114,8 @@ RSpec.describe 'Case page' do
     create(:resolved_case, cluster: cluster, subject: 'Resolved case')
   end
 
-  let :archived_case do
-    create(:archived_case, cluster: cluster, subject: 'Archived case', completed_at: 2.days.ago)
+  let :closed_case do
+    create(:closed_case, cluster: cluster, subject: 'Closed case', completed_at: 2.days.ago)
   end
 
   let (:mw) { create(:maintenance_window, case: open_case) }
@@ -166,7 +166,7 @@ RSpec.describe 'Case page' do
       visit case_path(resolved_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
 
-      visit case_path(archived_case, as: contact)
+      visit case_path(closed_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
     end
 
@@ -181,7 +181,7 @@ RSpec.describe 'Case page' do
       visit case_path(resolved_case, as: admin)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
 
-      visit case_path(archived_case, as: admin)
+      visit case_path(closed_case, as: admin)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
     end
   end
@@ -194,7 +194,7 @@ RSpec.describe 'Case page' do
       visit case_path(resolved_case, as: contact)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
 
-      visit case_path(archived_case, as: contact)
+      visit case_path(closed_case, as: contact)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
     end
 
@@ -204,9 +204,9 @@ RSpec.describe 'Case page' do
       expect(find('#case-state-controls').find('a').text).to eq 'Resolve this case'
 
       visit case_path(resolved_case, as: admin)
-      expect(find('#case-state-controls').find('a').text).to eq 'Archive this case'
+      expect(find('#case-state-controls').find('a').text).to eq 'Close this case'
 
-      visit case_path(archived_case, as: admin)
+      visit case_path(closed_case, as: admin)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
     end
   end

--- a/spec/features/log_spec.rb
+++ b/spec/features/log_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature Log, type: :feature do
       expect(submit_log.cases).to contain_exactly(*log_cases)
     end
 
-    %w(resolved archived).each do |state|
+    %w(resolved closed).each do |state|
       it "cannot select #{state} Case for subject to associate" do
         case_attributes = {
             cluster: cluster,

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -231,7 +231,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         expect(invalid_feedback).to have_text('Must be greater than 0')
       end
 
-      %w(resolved archived).each do |state|
+      %w(resolved closed).each do |state|
         it "cannot select #{state} Case for Cluster to associate" do
           my_case = create(
             :case,

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Case, type: :model do
     it 'returns all open Cases' do
       create(:case, subject: 'one', state: 'open')
       create(:case, subject: 'two', state: 'resolved')
-      create(:case, subject: 'three', state: 'archived')
+      create(:case, subject: 'three', state: 'closed')
       create(:case, subject: 'four', state: 'open')
 
       active_cases = Case.active


### PR DESCRIPTION
This PR makes some changes to the (formerly) "Archived cases" page:

- Page is renamed to "Resolved cases", routed from `.../resolved`
- Final Case state is renamed from `archived` to `closed`
- "Resolved cases" page no longer shows open cases, only `resolved` and `closed` ones

Note that I've included a new data migration to convert all cases with `archived` state to `closed`, although I'm not sure that it will apply to anything at the moment!

This closes #206.