### PR TITLE
Remove last unnecessary ticket and ticket_id references

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -37,7 +37,7 @@ class CasesController < ApplicationController
   end
 
   def create
-    @case = Case.new(case_params.merge(user: current_user)).decorate
+    @case = Case.new(case_params.merge(user: current_user))
 
     respond_to do |format|
       if @case.save
@@ -104,7 +104,7 @@ class CasesController < ApplicationController
   end
 
   def change_action(success_flash, redirect_path: case_path, &block)
-    @case = Case.find(params[:id]).decorate
+    @case = Case.find(params[:id])
     begin
       block.call(@case)
       @case.save!

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -118,7 +118,7 @@ class ApplicationDecorator < Draper::Decorator
       return
     end
 
-    title = "#{title_base} for ticket #{window.case.rt_ticket_id}"
+    title = "#{title_base} for case #{window.case.display_id}"
 
     h.icon('wrench', inline: true, class: class_names, title: title)
   end

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -17,12 +17,6 @@ class CaseDecorator < ApplicationDecorator
     state == 'resolved' || state == 'archived'
   end
 
-  def display_id
-    # TODO Once https://trello.com/c/dzY3fb5C has been implemented we should
-    # replace `##{object.id}` with that identifier for non-RT tickets.
-    rt_ticket_id ? "RT#{rt_ticket_id}" : "##{object.id}"
-  end
-
   def case_select_details
     [
       "#{display_id} #{subject}",

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -36,10 +36,6 @@ class CaseDecorator < ApplicationDecorator
     associated_model.decorate.links
   end
 
-  def rt_ticket_url
-    "http://helpdesk.alces-software.com/rt/Ticket/Display.html?id=#{rt_ticket_id}"
-  end
-
   def case_link
     h.link_to(display_id, h.case_path(self))
   end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -5,7 +5,7 @@ class CaseMailer < ApplicationMailer
   default bcc: Rails.application.config.email_bcc_address
 
   def new_case(my_case)
-    @case = my_case.decorate
+    @case = my_case
     mail(
       cc: @case.email_recipients.reject { |contact| contact == @case.user.email }, # Exclude the user raising the case
       subject: @case.email_subject
@@ -13,7 +13,7 @@ class CaseMailer < ApplicationMailer
   end
 
   def change_assignee(my_case, new_assignee)
-    @case = my_case.decorate
+    @case = my_case
     @assignee = new_assignee
     mail(
       cc: new_assignee&.email, # Send to new assignee only
@@ -23,7 +23,7 @@ class CaseMailer < ApplicationMailer
 
   def comment(comment)
     @comment = comment
-    @case = @comment.case.decorate
+    @case = @comment.case
     mail(
       cc: @case.email_recipients.reject { |contact| contact == @comment.user.email }, # Exclude the user making the comment
       subject: @case.email_reply_subject,
@@ -31,7 +31,7 @@ class CaseMailer < ApplicationMailer
   end
 
   def maintenance(my_case, text)
-    @case = my_case.decorate
+    @case = my_case
     @text = text
     mail(
       cc: @case.email_recipients,

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -247,11 +247,11 @@ class Case < ApplicationRecord
     user.email
   end
 
-  # We generate a short random token to identify each ticket within email
-  # clients and RT. Without this, similar but distinct tickets can be hard to
-  # distinguish in RT as they will have identical subjects, and many email
-  # clients will also collapse different tickets into the same thread due to
-  # their similar subjects (see
+  # We generate a short random token to identify each Case within email
+  # clients. Without this, similar but distinct Cases can be hard to
+  # distinguish in many email clients as they can have identical subjects, as
+  # many email clients will collapse different tickets into the same thread due
+  # to their similar subjects (see
   # https://github.com/alces-software/alces-flight-center/issues/41#issuecomment-361307971).
   #
   # We generate this token with alternating letters and digits to minimize the

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -162,9 +162,9 @@ class Case < ApplicationRecord
   end
 
   def ticket_subject
-    # NOTE: If the format used here ever changes then this may cause emails
-    # sent using the `mailto` links for existing Cases to not be threaded with
-    # previous emails related to that Case (see
+    # NOTE: If the format used here ever changes then this may cause new emails
+    # sent in relation to an existing Cases to not be threaded with previous
+    # emails related to that Case (see
     # https://github.com/alces-software/alces-flight-center/issues/37#issuecomment-358948462
     # for an explanation). If we want to change this format and avoid this
     # consequence then a solution would be to first add a new field for this

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -157,6 +157,7 @@ class Case < ApplicationRecord
     if rt_ticket_id
       "[helpdesk.alces-software.com ##{rt_ticket_id}]"
     else
+      # TODO Update this with identifier in format `BAR123` once this exists.
       "[Alces Flight Center ##{id}]"
     end
   end
@@ -169,6 +170,8 @@ class Case < ApplicationRecord
     # for an explanation). If we want to change this format and avoid this
     # consequence then a solution would be to first add a new field for this
     # whole string, and save and use the existing format for existing Cases.
+    # TODO should we update this to include identifier in format `BAR123` once
+    # this exists?
     "#{cluster.name}: #{subject} [#{token}]"
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -198,6 +198,12 @@ class Case < ApplicationRecord
     super(new_assignee)
   end
 
+  def display_id
+    # TODO Once https://trello.com/c/dzY3fb5C has been implemented we should
+    # replace `##{object.id}` with that identifier for non-RT tickets.
+    rt_ticket_id ? "RT#{rt_ticket_id}" : "##{id}"
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -24,7 +24,7 @@ class Log < ApplicationRecord
   def cases_belong_to_cluster
     cases.each do |kase|
       unless kase.cluster == cluster
-        msg = "ticket ##{kase.rt_ticket_id} is for a different cluster"
+        msg = "case #{kase.display_id} is for a different cluster"
         errors.add(:cases, msg)
       end
     end

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -33,8 +33,8 @@
       <tr>
         <th>Tier</th>
         <td><%= @case.tier_description %>
-        <th>RT Ticket ID</th>
-        <td><%= @case.rt_ticket_id || 'N/A' %></td>
+        <th>Unique identifier</th>
+        <td><%= @case.display_id %></td>
       </tr>
       <tr>
         <th>Fields</th>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -46,7 +46,7 @@
           </div>
         <% end %>
         <div class='form-group'>
-          <%= f.label :case_ids, 'Related Ticket(s)' %>
+          <%= f.label :case_ids, 'Related Case(s)' %>
           <%= f.collection_select :case_ids,
                                   @cases.active.decorate,
                                   :id,

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -54,41 +54,41 @@ RSpec.describe ApplicationDecorator do
 
       it 'includes correct icon when has requested maintenance window' do
         window = create(:requested_maintenance_window, component: component)
-        ticket_id = window.case.rt_ticket_id
+        display_id = window.case.display_id
 
         expect(subject).to include(
           h.icon(
             'wrench',
             inline: true,
             class: 'faded-icon',
-            title: "Maintenance has been requested for #{component.name} for ticket #{ticket_id}"
+            title: "Maintenance has been requested for #{component.name} for case #{display_id}"
           )
         )
       end
 
       it 'includes correct icon when has confirmed maintenance window' do
         window = create(:confirmed_maintenance_window, component: component)
-        ticket_id = window.case.rt_ticket_id
+        display_id = window.case.display_id
 
         expect(subject).to include(
           h.icon(
             'wrench',
             inline: true,
             class: 'faded-icon',
-            title: "Maintenance is scheduled for #{component.name} for ticket #{ticket_id}"
+            title: "Maintenance is scheduled for #{component.name} for case #{display_id}"
           )
         )
       end
 
       it 'includes correct icon when has in progress maintenance window' do
         window = create(:maintenance_window, state: :started, component: component)
-        ticket_id = window.case.rt_ticket_id
+        display_id = window.case.display_id
 
         expect(subject).to include(
           h.icon(
             'wrench',
             inline: true,
-            title: "#{component.name} currently under maintenance for ticket #{ticket_id}"
+            title: "#{component.name} currently under maintenance for case #{display_id}"
           )
         )
       end

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -134,18 +134,4 @@ RSpec.describe CaseDecorator do
       end.to raise_error(RuntimeError, "Unhandled tier_level: 4")
     end
   end
-
-  describe '#display_id' do
-    it "gives RT ticket ID with 'RT' prefix when RT ticket ID associated" do
-      kase = create(:case, rt_ticket_id: 12345).decorate
-
-      expect(kase.display_id).to eq('RT12345')
-    end
-
-    it "gives object ID with '#' prefix when no RT ticket ID associated" do
-      kase = create(:case, id: 123).decorate
-
-      expect(kase.display_id).to eq('#123')
-    end
-  end
 end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Cases table', type: :feature do
   end
 
   let! :resolved_case do
-    create(:resolved_case, cluster: cluster, subject: 'Resolved case', completed_at: 1.days.ago, rt_ticket_id: nil)
+    create(:resolved_case, cluster: cluster, subject: 'Resolved case', completed_at: 1.days.ago)
   end
 
   let! :closed_case do

--- a/spec/features/log_spec.rb
+++ b/spec/features/log_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature Log, type: :feature do
       expect(log.cases).to be_blank
     end
 
-    it 'can associate multiple tickets/cases with a log' do
+    it 'can associate multiple cases with a log' do
       fill_details_input
       log_cases = [subject.cases.first, subject.cases.last].each do |kase|
         select kase.decorate.case_select_details, from: case_select_id

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -106,13 +106,13 @@ RSpec.describe Case, type: :model do
       subject.save!
     end
 
-    it 'saves generated ticket token' do
+    it 'saves generated token' do
       subject.save!
-      created_ticket_token = subject.token
-      expect(created_ticket_token).to match(random_token_regex)
+      generated_token = subject.token
+      expect(generated_token).to match(random_token_regex)
       subject.reload
 
-      expect(subject.token).to eq(created_ticket_token)
+      expect(subject.token).to eq(generated_token)
     end
   end
 

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -352,4 +352,18 @@ RSpec.describe Case, type: :model do
       expect(kase).not_to be_consultancy
     end
   end
+
+  describe '#display_id' do
+    it "gives RT ticket ID with 'RT' prefix when RT ticket ID associated" do
+      kase = create(:case, rt_ticket_id: 12345)
+
+      expect(kase.display_id).to eq('RT12345')
+    end
+
+    it "gives object ID with '#' prefix when no RT ticket ID associated" do
+      kase = create(:case, id: 123)
+
+      expect(kase.display_id).to eq('#123')
+    end
+  end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -287,7 +287,6 @@ RSpec.describe Case, type: :model do
     let(:kase) {
       create(
         :case,
-        rt_ticket_id: 1138,
         created_at: Time.now,
         cluster: cluster,
         issue: issue,

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Log, type: :model do
       subject.cases << bad_case
       subject.reload
 
-      expect_single_error subject, "#{bad_case.rt_ticket_id}"
+      expect_single_error subject, "#{bad_case.display_id}"
     end
   end
 


### PR DESCRIPTION
As just discussed IRL these are the changes to be more consistent and correct with how we refer to cases. Essentially this makes it so:

- we always refer to Cases when we mean Flight Center Cases, rather than tickets, and only refer to tickets when we actually mean an RT ticket;

- we use the `display_id` method wherever we previously showed the RT ticket ID (except where we need to keep our previous behaviour for a reason, such as in emails to avoid breaking threading with previous emails);

- `display_id` has been moved to `Case` since it fits better there now;

- the comments in https://github.com/alces-software/alces-flight-center/commit/5402a790f415a474ceb63ca568b0fd539b1240ab may be relevant to you @jamesremuscat for your current work on https://trello.com/c/dzY3fb5C/252-new-case-ids-ready-for-use-after-replacing-rt, as we may want to update these places then (also see https://github.com/alces-software/alces-flight-center/blob/5402a790f415a474ceb63ca568b0fd539b1240ab/app/models/case.rb#L205-L206, which may need updating or become obsolete depending on how we implement things).