### PR TITLE
Generate per-cluster sequential case IDs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,7 +69,11 @@ class ApplicationController < ActionController::Base
              when /^\/cases/
                begin
                  id = scope_id_param(:case_id)
-                 Case.find(id).associated_model
+                 if id
+                  Case.find_from_id(id).associated_model
+                 else
+                   assign_site_scope
+                 end
                rescue ActiveRecord::RecordNotFound
                  # There are various routes which begin `/cases/` but are not
                  # the route for a particular Case; if we can't find the Case

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,11 +69,7 @@ class ApplicationController < ActionController::Base
              when /^\/cases/
                begin
                  id = scope_id_param(:case_id)
-                 if id
-                  Case.find_from_id(id).associated_model
-                 else
-                   assign_site_scope
-                 end
+                 Case.find_from_id!(id).associated_model
                rescue ActiveRecord::RecordNotFound
                  # There are various routes which begin `/cases/` but are not
                  # the route for a particular Case; if we can't find the Case

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -2,7 +2,7 @@ class CaseCommentsController < ApplicationController
   before_action :require_login
 
   def create
-    my_case = Case.find_from_id(params.require(:case_id))
+    my_case = Case.find_from_id!(params.require(:case_id))
 
     new_comment = my_case.case_comments.create(
         user: current_user,

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -2,8 +2,7 @@ class CaseCommentsController < ApplicationController
   before_action :require_login
 
   def create
-    case_id = params.require(:case_id)
-    my_case = Case.find(case_id)
+    my_case = Case.find_from_id(params.require(:case_id))
 
     new_comment = my_case.case_comments.create(
         user: current_user,
@@ -18,10 +17,10 @@ class CaseCommentsController < ApplicationController
       flash[:error] = "Your comment was not added. #{new_comment.errors.full_messages.join('; ').strip}"
     end
 
-    redirect_to case_path(case_id)
+    redirect_to case_path(my_case)
 
   rescue ActionController::ParameterMissing
     flash[:error] = 'Empty comments are not permitted.'
-    redirect_to case_path(case_id)
+    redirect_to case_path(my_case)
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -15,7 +15,7 @@ class CasesController < ApplicationController
   end
 
   def show
-    @case = Case.find(params[:id]).decorate
+    @case = case_from_params
     @comment = @case.case_comments.new
   end
 
@@ -104,7 +104,7 @@ class CasesController < ApplicationController
   end
 
   def change_action(success_flash, redirect_path: case_path, &block)
-    @case = Case.find(params[:id])
+    @case = case_from_params
     begin
       block.call(@case)
       @case.save!
@@ -113,5 +113,9 @@ class CasesController < ApplicationController
       flash[:error] = "Error updating support case: #{format_errors(@case)}"
     end
     redirect_to redirect_path
+  end
+
+  def case_from_params
+    Case.find_from_id(params.require(:id)).decorate
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -116,6 +116,6 @@ class CasesController < ApplicationController
   end
 
   def case_from_params
-    Case.find_from_id(params.require(:id)).decorate
+    Case.find_from_id!(params.require(:id)).decorate
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -172,8 +172,7 @@ class Case < ApplicationRecord
     if rt_ticket_id
       "[helpdesk.alces-software.com ##{rt_ticket_id}]"
     else
-      # TODO Update this with identifier in format `BAR123` once this exists.
-      "[Alces Flight Center ##{id}]"
+      "[Alces Flight Center #{display_id}]"
     end
   end
 
@@ -185,9 +184,16 @@ class Case < ApplicationRecord
     # for an explanation). If we want to change this format and avoid this
     # consequence then a solution would be to first add a new field for this
     # whole string, and save and use the existing format for existing Cases.
-    # TODO should we update this to include identifier in format `BAR123` once
-    # this exists?
-    "#{cluster.name}: #{subject} [#{token}]"
+    #
+    # FSR using the conditional in `#email_identifier` rather than repeating it
+    # here causes Rails to Base64-encode the plain text part of the email, which
+    # causes some of our tests to fail...
+    if rt_ticket_id
+      "#{cluster.name}: #{subject} [#{token}]"
+    else
+      # With 'new' display IDs we have a cluster hint, so don't include it twice.
+      "#{subject} [#{token}]"
+    end
   end
 
   def email_properties

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -101,11 +101,11 @@ class Case < ApplicationRecord
     self.display_id.parameterize.upcase
   end
 
-  def self.find_from_id(id)
+  def self.find_from_id!(id)
     if /^[0-9]+$/.match(id)  # It's just a numeric ID
       Case.find(id).decorate
     else # It has non-digits in - let's assume it's a display ID
-      Case.find_by_display_id(id.upcase)
+      Case.find_by_display_id!(id&.upcase)
     end
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -204,12 +204,6 @@ class Case < ApplicationRecord
     super(new_assignee)
   end
 
-  def display_id
-    # TODO Once https://trello.com/c/dzY3fb5C has been implemented we should
-    # replace `##{object.id}` with that identifier for non-RT tickets.
-    rt_ticket_id ? "RT#{rt_ticket_id}" : "##{id}"
-  end
-
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -48,6 +48,8 @@ class Case < ApplicationRecord
 
   audited only: :assignee_id, on: [ :update ]
 
+  validates :display_id, uniqueness: true
+  validate :has_display_id_when_saved
   validates :token, presence: true
   validates :subject, presence: true
   validates :rt_ticket_id, uniqueness: true, if: :rt_ticket_id
@@ -84,6 +86,7 @@ class Case < ApplicationRecord
 
   before_validation :assign_default_subject_if_unset
 
+  after_create :set_display_id
   after_create :send_new_case_email
   after_update :maybe_send_new_assignee_email
 
@@ -284,6 +287,25 @@ class Case < ApplicationRecord
   def validates_user_assignment
     return if assignee.nil?
     errors.add(:assignee, 'must belong to this site, or be an admin') unless assignee.site == site or assignee.admin?
+  end
+
+  def set_display_id
+    return if self.display_id
+    # Note: this method is called AFTER create, to ensure that the case is valid
+    # before we increment the cluster's `case_index` field. Otherwise display IDs
+    # could end up non-sequential.
+
+    if self.rt_ticket_id
+      self.display_id = "RT#{rt_ticket_id}"
+    else
+      self.display_id = "#{cluster.shortcode}#{cluster.next_case_index}"
+    end
+    save!
+  end
+
+  def has_display_id_when_saved
+    # We want to be able to save the case initially without a display id
+    errors.add(:display_id, 'must be present') unless !persisted? or display_id
   end
 
   def field_hash

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -92,6 +92,18 @@ class Case < ApplicationRecord
 
   scope :active, -> { where(state: 'open') }
 
+  def to_param
+    self.display_id.parameterize.upcase
+  end
+
+  def self.find_from_id(id)
+    if /^[0-9]+$/.match(id)  # It's just a numeric ID
+      Case.find(id).decorate
+    else # It has non-digits in - let's assume it's a display ID
+      Case.find_by_display_id(id.upcase)
+    end
+  end
+
   # @deprecated - to be removed in next release
   def self.request_tracker
     # Note: `rt_interface_class` is a string which we `constantize`, rather

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -48,8 +48,13 @@ class Case < ApplicationRecord
 
   audited only: :assignee_id, on: [ :update ]
 
-  validates :display_id, uniqueness: true
-  validate :has_display_id_when_saved
+  # XXX Remove if: display_id when we can do so
+  validates :display_id, uniqueness: true, if: :display_id
+
+  # XXX We want to enable this validation when we've migrated production over -
+  # otherwise historical migrations will fail :(
+  #validate :has_display_id_when_saved
+
   validates :token, presence: true
   validates :subject, presence: true
   validates :rt_ticket_id, uniqueness: true, if: :rt_ticket_id

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -21,6 +21,7 @@ class Cluster < ApplicationRecord
   validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true
   validates :canonical_name, presence: true
   validate :validate_all_components_advice, if: :advice?
+  validates :shortcode, presence: true, uniqueness: true
 
   before_validation CanonicalNameCreator.new, on: :create
 

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -95,6 +95,14 @@ class Cluster < ApplicationRecord
       .reverse
   end
 
+  def next_case_index
+    with_lock do  # Prevent concurrent reads of this record
+      self.case_index = case_index + 1
+      save!
+      case_index
+    end
+  end
+
   private
 
   def validate_all_components_advice

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -44,7 +44,7 @@ end %>
             <% else %>
               <tr>
             <% end %>
-              <td><%= c.display_id %></td>
+              <td><%= link_to c.display_id, case_path(c) %></td>
               <%= timestamp_td(
                 description:  'Support case created',
                 timestamp: c.created_at

--- a/db/data_migrations/20180502100018_set_cluster_shortcodes.rb
+++ b/db/data_migrations/20180502100018_set_cluster_shortcodes.rb
@@ -1,0 +1,40 @@
+class SetClusterShortcodes < ActiveRecord::DataMigration
+  def up
+    Cluster.all.each do |cluster|
+
+      shortcode = dedupe(base_shortcode(cluster.name)) do |code|
+        !Cluster.where(shortcode: code).exists?
+      end
+
+      cluster.shortcode = shortcode
+      cluster.save!
+    end
+  end
+
+    private
+
+  def base_shortcode(cluster_name)
+    if cluster_name == 'Demo Cluster'
+      'DEMO'
+    else
+      cluster_name[0, 3].upcase
+    end
+  end
+
+  def dedupe(base, &test)
+    if test.call(base)
+      base
+    else
+      attempt_count = 0
+
+      while attempt_count < 26
+        attempt = "#{base}#{(attempt_count + 'A'.ord).chr}"
+        if test.call(attempt)
+          return attempt
+        end
+      end
+
+      raise 'I can\'t handle how many duplicate cluster shortcodes there might be. Please migrate manually.'
+    end
+  end
+end

--- a/db/data_migrations/20180502110608_set_case_display_ids.rb
+++ b/db/data_migrations/20180502110608_set_case_display_ids.rb
@@ -2,6 +2,7 @@ class SetCaseDisplayIds < ActiveRecord::DataMigration
   def up
     Case.all.each do |kase|
       kase.send :set_display_id
+      kase.save!
     end
   end
 end

--- a/db/data_migrations/20180502110608_set_case_display_ids.rb
+++ b/db/data_migrations/20180502110608_set_case_display_ids.rb
@@ -1,0 +1,7 @@
+class SetCaseDisplayIds < ActiveRecord::DataMigration
+  def up
+    Case.all.each do |kase|
+      kase.send :set_display_id
+    end
+  end
+end

--- a/db/migrate/20180502093509_add_shortcode_and_case_index_to_cluster.rb
+++ b/db/migrate/20180502093509_add_shortcode_and_case_index_to_cluster.rb
@@ -1,0 +1,10 @@
+class AddShortcodeAndCaseIndexToCluster < ActiveRecord::Migration[5.1]
+  def change
+    add_column :clusters, :shortcode, :string  # We want this to be null: false
+    # but can't do so until the data migration has been run. We can't set a
+    # default because we want it to be unique.
+    add_column :clusters, :case_index, :integer, default: 0, null: false
+
+    add_index :clusters, :shortcode, unique: true
+  end
+end

--- a/db/migrate/20180502104232_add_display_id_to_cases.rb
+++ b/db/migrate/20180502104232_add_display_id_to_cases.rb
@@ -1,0 +1,8 @@
+class AddDisplayIdToCases < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cases, :display_id, :string # We'd like this to be null: false but
+    # can't until the field has been populated for existing cases.
+
+    add_index :cases, :display_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425134112) do
+ActiveRecord::Schema.define(version: 20180502093509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,9 @@ ActiveRecord::Schema.define(version: 20180425134112) do
     t.datetime "updated_at", null: false
     t.string "canonical_name", null: false
     t.string "charging_info"
+    t.string "shortcode"
+    t.integer "case_index", default: 0, null: false
+    t.index ["shortcode"], name: "index_clusters_on_shortcode", unique: true
     t.index ["site_id"], name: "index_clusters_on_site_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180502093509) do
+ActiveRecord::Schema.define(version: 20180502104232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,9 +112,11 @@ ActiveRecord::Schema.define(version: 20180502093509) do
     t.json "fields"
     t.text "state", default: "open", null: false
     t.bigint "assignee_id"
+    t.string "display_id"
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"
+    t.index ["display_id"], name: "index_cases_on_display_id", unique: true
     t.index ["issue_id"], name: "index_cases_on_issue_id"
     t.index ["rt_ticket_id"], name: "index_cases_on_rt_ticket_id", unique: true
     t.index ["service_id"], name: "index_cases_on_service_id"

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -178,12 +178,12 @@ RSpec.describe CasesController, type: :controller do
 
     it 'resolves an open case' do
       post :resolve, params: { id: open_case.id }
-      expect(flash[:success]).to eq "Support case ##{open_case.id} resolved."
+      expect(flash[:success]).to eq "Support case #{open_case.display_id} resolved."
     end
 
     it 'closes a resolved case' do
       post :close, params: { id: resolved_case.id }
-      expect(flash[:success]).to eq "Support case ##{resolved_case.id} closed."
+      expect(flash[:success]).to eq "Support case #{resolved_case.display_id} closed."
     end
 
     it 'does not resolve a closed case' do

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -101,8 +101,7 @@ RSpec.describe CaseDecorator do
 
   describe '#case_link' do
     it 'returns link to Case page with display_id as text' do
-      kase = create(:case)
-      kase.rt_ticket_id = 12345
+      kase = create(:case, rt_ticket_id: 12345)
 
       link = kase.decorate.tap do
         Draper::ViewContext.clear!

--- a/spec/factories/cluster.rb
+++ b/spec/factories/cluster.rb
@@ -1,9 +1,15 @@
 
 FactoryBot.define do
+  sequence :shortcode do |n|
+    # Shortcodes must be unique and we create many clusters in tests
+    "#{n}TEST"
+  end
+
   factory :cluster do
     site
     name 'Hamilton Research Computing Cluster'
     support_type :managed
+    shortcode
 
     factory :managed_cluster do
       support_type :managed

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -359,10 +359,10 @@ RSpec.describe Case, type: :model do
       expect(kase.display_id).to eq('RT12345')
     end
 
-    it "gives object ID with '#' prefix when no RT ticket ID associated" do
-      kase = create(:case, id: 123)
+    it "gives cluster-specific unique ID when no RT ticket ID associated" do
+      kase = create(:case)
 
-      expect(kase.display_id).to eq('#123')
+      expect(kase.display_id).to eq("#{kase.cluster.shortcode}1")
     end
   end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -363,6 +363,22 @@ RSpec.describe Case, type: :model do
       kase = create(:case)
 
       expect(kase.display_id).to eq("#{kase.cluster.shortcode}1")
+      expect(kase.cluster.case_index).to eq 1
+    end
+
+    it 'doesn\'t use up a case_index when case is invalid' do
+
+      cluster = create(:cluster)
+
+      expect(cluster.case_index).to eq 0
+
+      bad_case = build(:case, cluster: cluster, tier_level: 99)
+
+      expect do
+        bad_case.save!
+      end.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect(cluster.case_index).to eq 0
     end
   end
 end

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -280,4 +280,17 @@ RSpec.describe Cluster, type: :model do
       expect(resulting_window_ids).to eq([2, 1])
     end
   end
+
+  describe '#next_case_index' do
+    subject { create(:cluster) }
+
+    it 'gives a sequence of case indices starting with 1' do
+      results = []
+      results << subject.next_case_index
+      results << subject.next_case_index
+      results << subject.next_case_index
+
+      expect(results).to eq [1, 2, 3]
+    end
+  end
 end


### PR DESCRIPTION
This PR changes the way we publicly refer to `Case`s by introducing a per-cluster sequential "display ID", prefixed with a new "shortcode" allocated to each cluster.

The `#display_id` method on `Case` is therefore replaced by simply accessing the value of this stored field.

New-style display IDs are of the form `BAR123` - this being the 123rd case raised for the `BAR` cluster (which, in production, would be the shortcode allocated to Barkla).

Old cases with RT ticket IDs use a display ID of the form `RT12345`, as previously.

Display IDs are allocated immediately before the initial save of a `Case` (specifically, using the `before_create` callback). It is from `Cluster` that the numeric part of the display ID is obtained, and we use a database row-level lock on the cluster to ensure concurrently created cases comply correctly with the uniqueness constraint. 

Since the new display IDs include a cluster hint, we no longer include the cluster name explicitly in email subject lines.

We also support accessing cases via their display IDs in the URL. This works case-insensitively so that `/cases/bar1` and `/cases/BAR1` both go to the same place. Accessing cases by their database ID still works, so old links will continue to function, but we no longer display those links anywhere. Code should use `Case#find_from_id` rather than `Case.find` to take advantage of this omni-findyness.

There are two data migrations included in this PR:

- One to allocate a shortcode to all clusters. This uses the first three characters in the cluster name, upper-cased; except for "Demo Cluster" which uses `DEMO`. There's some attempt at deduplication which almost certainly won't be needed, except possibly in development if you have old data lying around (I did).

- One to assign display IDs to cases. For cases with an RT ticket ID, a display ID of the form `RTxxxx` is created. For cases without (and there won't be any in live) the cluster's `case_index` is used for numbering.

I've also taken the liberty of making the ID column in the cases table a clickable link as per https://trello.com/c/yv5pDErI/261-cases-ticket-id-needs-to-be-on-the-left-and-make-it-a-link.

Trello: https://trello.com/c/dzY3fb5C/252-new-case-ids-ready-for-use-after-replacing-rt