### PR TITLE
Remove ticket status update for admins (fixes #197)

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -6,7 +6,6 @@ class CasesController < ApplicationController
   def index(show_resolved: false)
     @site = current_site
     @show_resolved = show_resolved
-    current_site.cases.map(&:update_ticket_status!) if current_user.admin?
   end
 
   def resolved


### PR DESCRIPTION
Doing this when an admin visits a `/cases` or `/cases/resolved` page,
especially given our increasing number of non-resolved Cases, was
causing a massive slow down in this request, due to us needing to make a
large number of sequential requests to our tiny RT server.

We could try to improve how we do this, but since we plan to remove all
integration with RT entirely soon, and don't need to keep this part for
the transition, let's just remove it now.