### PR TITLE
Support help text for Tier fields

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -98,7 +98,7 @@ class CasesController < ApplicationController
       :service_id,
       :subject,
       :tier_level,
-      fields: [:type, :name, :value, :optional],
+      fields: [:type, :name, :value, :optional, :help],
     )
   end
 

--- a/app/javascript/packs/Tier/Field.elm
+++ b/app/javascript/packs/Tier/Field.elm
@@ -31,6 +31,7 @@ type alias TextInputData =
     -- | RequiredTextInput TextInput
     -- | OptionalTextInput TextInput
     , optional : Bool
+    , help : Maybe String
     }
 
 
@@ -82,13 +83,14 @@ textInputDecoder type_ =
                 |> D.map (Maybe.withDefault False)
     in
     D.map TextInput <|
-        D.map5 TextInputData
+        D.map6 TextInputData
             (D.succeed type_)
             (D.field "name" D.string)
             initialValueDecoder
             -- Every field is initially untouched.
             (D.succeed Untouched)
             optionalDecoder
+            (D.maybe (D.field "help" D.string))
 
 
 encoder : Field -> Maybe E.Value
@@ -103,6 +105,7 @@ encoder field =
                     [ ( "type", textFieldTypeToString data.type_ |> E.string )
                     , ( "name", E.string data.name )
                     , ( "value", E.string data.value )
+                    , ( "help", Maybe.map E.string data.help |> Maybe.withDefault E.null )
                     , ( "optional", E.bool data.optional )
                     ]
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -21,6 +21,7 @@ import Tier exposing (Tier)
 import Tier.DisplayWrapper
 import Tier.Field
 import Tier.Level as Level exposing (Level)
+import Types
 import Validation
 import View.Charging as Charging
 import View.Fields as Fields
@@ -229,7 +230,8 @@ subjectField state =
         selectedIssue =
             State.selectedIssue state
     in
-    Fields.inputField Field.Subject
+    Fields.textField Types.Input
+        Field.Subject
         selectedIssue
         Issue.subject
         ChangeSubject

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -229,14 +229,16 @@ subjectField state =
     let
         selectedIssue =
             State.selectedIssue state
+
+        textFieldConfig =
+            { fieldType = Types.Input
+            , field = Field.Subject
+            , toContent = Issue.subject
+            , inputMsg = ChangeSubject
+            , optional = False
+            }
     in
-    Fields.textField Types.Input
-        Field.Subject
-        selectedIssue
-        Issue.subject
-        ChangeSubject
-        False
-        state
+    Fields.textField textFieldConfig state selectedIssue
 
 
 dynamicTierFields : State -> Html Msg
@@ -259,13 +261,16 @@ renderTierField state ( index, field ) =
             Markdown.toHtml [] content
 
         Tier.Field.TextInput fieldData ->
-            Fields.textField fieldData.type_
-                (Field.TierField fieldData)
-                fieldData
-                .value
-                (ChangeTierField index)
-                fieldData.optional
-                state
+            let
+                textFieldConfig =
+                    { fieldType = fieldData.type_
+                    , field = Field.TierField fieldData
+                    , toContent = .value
+                    , inputMsg = ChangeTierField index
+                    , optional = fieldData.optional
+                    }
+            in
+            Fields.textField textFieldConfig state fieldData
 
 
 submitButton : State -> Html Msg

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -236,6 +236,7 @@ subjectField state =
             , toContent = Issue.subject
             , inputMsg = ChangeSubject
             , optional = False
+            , help = Nothing
             }
     in
     Fields.textField textFieldConfig state selectedIssue
@@ -268,6 +269,7 @@ renderTierField state ( index, field ) =
                     , toContent = .value
                     , inputMsg = ChangeTierField index
                     , optional = fieldData.optional
+                    , help = fieldData.help
                     }
             in
             Fields.textField textFieldConfig state fieldData

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -1,7 +1,6 @@
 module View.Fields
     exposing
-        ( inputField
-        , selectField
+        ( selectField
         , textField
         )
 
@@ -51,18 +50,6 @@ selectField field items toId toOptionLabel isDisabled changeMsg state =
         options
         False
         state
-
-
-inputField :
-    Field
-    -> a
-    -> (a -> String)
-    -> (String -> msg)
-    -> Bool
-    -> State
-    -> Html msg
-inputField =
-    textField Types.Input
 
 
 textField :

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -18,6 +18,7 @@ import State exposing (State)
 import String.Extra
 import Types
 import Validation exposing (Error, ErrorMessage(..))
+import View.Utils
 
 
 selectField :
@@ -129,7 +130,7 @@ formField field item htmlFn additionalAttributes children optional help state =
 
         requiredBadge =
             if optional then
-                text ""
+                View.Utils.nothing
             else
                 Badge.badgeLight [ Spacing.ml1 ] [ text "Required" ]
 
@@ -153,7 +154,7 @@ formField field item htmlFn additionalAttributes children optional help state =
                         [ text helpText ]
 
                 Nothing ->
-                    text ""
+                    View.Utils.nothing
 
         helpIdentifier =
             identifier ++ "-help"

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -12,6 +12,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
 import Json.Decode as D
 import Maybe.Extra
+import Msg exposing (Msg)
 import SelectList exposing (Position(..), SelectList)
 import State exposing (State)
 import String.Extra
@@ -52,22 +53,23 @@ selectField field items toId toOptionLabel isDisabled changeMsg state =
         state
 
 
-textField :
-    Types.TextField
-    -> Field
-    -> a
-    -> (a -> String)
-    -> (String -> msg)
-    -> Bool
-    -> State
-    -> Html msg
-textField textFieldType field item toContent inputMsg optional state =
+type alias TextFieldConfig a =
+    { fieldType : Types.TextField
+    , field : Field
+    , toContent : a -> String
+    , inputMsg : String -> Msg
+    , optional : Bool
+    }
+
+
+textField : TextFieldConfig a -> State -> a -> Html Msg
+textField config state item =
     let
         content =
-            toContent item
+            config.toContent item
 
         ( element, additionalAttributes ) =
-            case textFieldType of
+            case config.fieldType of
                 Types.Input ->
                     ( input, [] )
 
@@ -75,17 +77,17 @@ textField textFieldType field item toContent inputMsg optional state =
                     ( textarea, [ rows 10 ] )
 
         attributes =
-            [ onInput inputMsg
+            [ onInput config.inputMsg
             , value content
             ]
                 ++ additionalAttributes
     in
-    formField field
+    formField config.field
         item
         element
         attributes
         []
-        optional
+        config.optional
         state
 
 

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -50,6 +50,7 @@ selectField field items toId toOptionLabel isDisabled changeMsg state =
         [ Html.Events.on "change" (D.map changeMsg Html.Events.targetValue) ]
         options
         False
+        Nothing
         state
 
 
@@ -59,6 +60,7 @@ type alias TextFieldConfig a =
     , toContent : a -> String
     , inputMsg : String -> Msg
     , optional : Bool
+    , help : Maybe String
     }
 
 
@@ -88,6 +90,7 @@ textField config state item =
         attributes
         []
         config.optional
+        config.help
         state
 
 
@@ -102,9 +105,10 @@ formField :
     -> List (Attribute msg)
     -> List (Html msg)
     -> Bool
+    -> Maybe String
     -> State
     -> Html msg
-formField field item htmlFn additionalAttributes children optional state =
+formField field item htmlFn additionalAttributes children optional help state =
     let
         fieldName =
             case field of
@@ -134,11 +138,25 @@ formField field item htmlFn additionalAttributes children optional state =
                 [ id identifier
                 , class (formControlClasses field errors)
                 , disabled fieldIsUnavailable
+                , attribute "aria-describedBy" helpIdentifier
                 ]
                 additionalAttributes
 
         formElement =
             htmlFn attributes children
+
+        helpElement =
+            case help of
+                Just helpText ->
+                    small
+                        [ id helpIdentifier, class "form-text text-muted" ]
+                        [ text helpText ]
+
+                Nothing ->
+                    text ""
+
+        helpIdentifier =
+            identifier ++ "-help"
 
         errors =
             Validation.validateField field state
@@ -149,6 +167,7 @@ formField field item htmlFn additionalAttributes children optional state =
             [ text fieldName ]
         , requiredBadge
         , formElement
+        , helpElement
         , validationFeedback errors
         ]
 

--- a/app/javascript/packs/View/Utils.elm
+++ b/app/javascript/packs/View/Utils.elm
@@ -15,3 +15,8 @@ supportEmailLink =
         , target "_blank"
         ]
         [ text email ]
+
+
+nothing : Html msg
+nothing =
+    text ""

--- a/db/data_migrations/20180504104059_add_some_example_help_to_fields.rb
+++ b/db/data_migrations/20180504104059_add_some_example_help_to_fields.rb
@@ -1,0 +1,10 @@
+class AddSomeExampleHelpToFields < ActiveRecord::DataMigration
+  def up
+    gridware_issue = Issue.find_by_name!('From available Alces Gridware')
+    tier_2 = gridware_issue.tiers.find_by_level!(2)
+    tier_2.fields[1].merge!(help: 'E.g. python3')
+    tier_2.fields[2].merge!(help: 'E.g. v3.6.4')
+    tier_2.fields[3].merge!(help: 'E.g. /home/you/myscript.py')
+    tier_2.save!
+  end
+end


### PR DESCRIPTION
This PR allows specifying `help` text within the Tier fields JSON, and having this then be displayed in the Case form alongside the field. This is done by refactoring and then adding this functionality, in such a way that it should be slightly easier to add similar additional fields with special handling to the Tier fields JSON next time.

This closes #211 and completes https://trello.com/c/2RkPP0zI/270-add-ability-to-add-hints-for-inputs-in-tiers-in-case-form.