### PR TITLE
Feature/track time on cases

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -89,7 +89,12 @@ class CasesController < ApplicationController
   end
 
   def set_time
-    redirect_to case_path
+    times = params.require(:time).permit(:hours, :minutes)
+    total_time = (times.require(:hours).to_i * 60) + times.require(:minutes).to_i
+
+    change_action "Updated 'time worked' for support case %s" do |kase|
+      kase.time_worked = total_time
+    end
   end
 
   private

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -88,6 +88,10 @@ class CasesController < ApplicationController
     end
   end
 
+  def set_time
+    redirect_to case_path
+  end
+
   private
 
   def case_params

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -92,7 +92,7 @@ class CasesController < ApplicationController
     times = params.require(:time).permit(:hours, :minutes)
     total_time = (times.require(:hours).to_i * 60) + times.require(:minutes).to_i
 
-    change_action "Updated 'time worked' for support case %s" do |kase|
+    change_action "Updated 'time worked' for support case %s." do |kase|
       kase.time_worked = total_time
     end
   end

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -14,18 +14,26 @@ module Audited
 
     private
 
+    ADMIN_ONLY_CARDS = %w(time_worked)
+
     def change_card(date, user, change)
       field = change[0]
       from, to = *change[1]
 
       type = send("#{field}_type")
       text = send("#{field}_text", from, to)
+      admin_only = ADMIN_ONLY_CARDS.include?(field)
 
-      render_card(date, user&.name || 'Flight Center', type, text)
+      render_card(date, user&.name || 'Flight Center', type, text, admin_only)
     end
 
-    def render_card(date, name, type, text)
-      h.render 'cases/event', date: date, name: name, type: type, text: text
+    def render_card(date, name, type, text, admin_only)
+      h.render 'cases/event',
+               admin_only: admin_only,
+               date: date,
+               name: name,
+               text: text,
+               type: type
     end
 
     def assignee_id_text(from, to)

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -43,5 +43,22 @@ module Audited
     def assignee_id_type
       'user'
     end
+
+    def time_worked_text(from, to)
+      "Changed time worked from #{format_minutes(from)} to #{format_minutes(to)}."
+    end
+
+    def time_worked_type
+      'hourglass-half'
+    end
+
+    def format_minutes(mins)
+      hours, minutes = mins.divmod(60)
+      if hours > 0
+        "#{hours}h #{minutes}m"
+      else
+        "#{minutes}m"
+      end
+    end
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -77,7 +77,7 @@ class Case < ApplicationRecord
       only_integer: true  # We store time worked as integer minutes.
   }
 
-  validate :time_worked_not_changed_unless_open
+  validate :time_worked_not_changed_unless_allowed
 
   # @deprecated - to be removed in next release
   validates :last_known_ticket_status,
@@ -342,7 +342,7 @@ class Case < ApplicationRecord
     errors.add(:display_id, 'must be present') unless !persisted? or display_id
   end
 
-  def time_worked_not_changed_unless_open
+  def time_worked_not_changed_unless_allowed
     error_condition = !time_entry_allowed? && @time_worked_changed
     errors.add(:time_worked, "must not be changed when case is #{state}") unless !error_condition
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -47,7 +47,7 @@ class Case < ApplicationRecord
 
   end
 
-  audited only: :assignee_id, on: [ :update ]
+  audited only: [:assignee_id, :time_worked], on: [ :update ]
 
   # XXX Remove if: display_id when we can do so
   validates :display_id, uniqueness: true, if: :display_id

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -72,6 +72,11 @@ class Case < ApplicationRecord
       less_than_or_equal_to: 3,
     }
 
+  validates :time_worked, numericality: {
+      greater_than_or_equal_to: 0,
+      only_integer: true  # We store time worked as integer minutes.
+  }
+
   # @deprecated - to be removed in next release
   validates :last_known_ticket_status,
     inclusion: {in: RT_TICKET_STATUSES}

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -141,6 +141,10 @@ class Case < ApplicationRecord
     ticket_completed? && chargeable
   end
 
+  def time_entry_allowed?
+    open?
+  end
+
   def associated_model
     component || service || cluster
   end

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -1,9 +1,11 @@
-<div class="card event-card">
-  <div class="card-header d-inline-flex justify-content-between align-items-center">
-    <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
-    <%= icon(type) %>
+<% if !local_assigns.fetch(:admin_only, false) || current_user.admin? %>
+  <div class="card event-card">
+    <div class="card-header d-inline-flex justify-content-between align-items-center">
+      <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
+      <%= icon(type) %>
+    </div>
+    <div class="card-body">
+      <%= simple_format(text) %>
+    </div>
   </div>
-  <div class="card-body">
-    <%= simple_format(text) %>
-  </div>
-</div>
+<% end %>

--- a/app/views/cases/_time_worked.html.erb
+++ b/app/views/cases/_time_worked.html.erb
@@ -1,0 +1,23 @@
+<% if current_user.admin?
+  hours = @case.time_worked % 60
+  minutes = @case.time_worked - (60 * hours)
+%>
+<tr>
+  <th>Time worked</th>
+  <td colspan="3">
+    <%= form_tag({ controller: 'cases', action: 'set_time' }, method: :post, class: 'form-inline') do %>
+      <div class="form-group">
+        <label>
+          <%= number_field :time, :hours, class: 'form-control mr-1', min: 0, value: hours %>
+          hours
+        </label>
+        <label class="ml-1">
+          <%= number_field :time, :minutes, class: 'form-control mr-1', min: 0, max: 59, value: minutes %>
+          minutes
+        </label>
+      </div>
+      <%= submit_tag 'Change time worked', class: 'form-control btn-primary ml-2' %>
+    <% end %>
+  </td>
+</tr>
+<% end %>

--- a/app/views/cases/_time_worked.html.erb
+++ b/app/views/cases/_time_worked.html.erb
@@ -1,6 +1,5 @@
 <% if current_user.admin?
-  hours = @case.time_worked % 60
-  minutes = @case.time_worked - (60 * hours)
+  hours, minutes = @case.time_worked.divmod(60)
 %>
 <tr>
   <th>Time worked</th>

--- a/app/views/cases/_time_worked.html.erb
+++ b/app/views/cases/_time_worked.html.erb
@@ -11,15 +11,31 @@
         ) do %>
       <div class="form-group">
         <label>
-          <%= number_field :time, :hours, class: 'form-control mr-1', min: 0, value: hours %>
+          <%= number_field :time,
+                           :hours,
+                           class: 'form-control mr-1',
+                           disabled: !@case.time_entry_allowed?,
+                           min: 0,
+                           value: hours
+          %>
           hours
         </label>
         <label class="ml-1">
-          <%= number_field :time, :minutes, class: 'form-control mr-1', min: 0, max: 59, value: minutes %>
+          <%= number_field :time,
+                           :minutes,
+                           class: 'form-control mr-1',
+                           disabled: !@case.time_entry_allowed?,
+                           min: 0,
+                           max: 59,
+                           value: minutes
+          %>
           minutes
         </label>
       </div>
-      <%= submit_tag 'Change time worked', class: 'form-control btn-primary ml-2' %>
+      <%= submit_tag 'Change time worked',
+                     class: 'form-control btn-primary ml-2',
+                     disabled: !@case.time_entry_allowed?
+      %>
     <% end %>
   </td>
 </tr>

--- a/app/views/cases/_time_worked.html.erb
+++ b/app/views/cases/_time_worked.html.erb
@@ -4,7 +4,11 @@
 <tr>
   <th>Time worked</th>
   <td colspan="3">
-    <%= form_tag({ controller: 'cases', action: 'set_time' }, method: :post, class: 'form-inline') do %>
+    <%= form_tag({ controller: 'cases', action: 'set_time' },
+                 method: :post,
+                 class: 'form-inline',
+                 id: 'case-time-form'
+        ) do %>
       <div class="form-group">
         <label>
           <%= number_field :time, :hours, class: 'form-control mr-1', min: 0, value: hours %>

--- a/app/views/cases/_time_worked.html.erb
+++ b/app/views/cases/_time_worked.html.erb
@@ -38,7 +38,7 @@
                        disabled: !@case.time_entry_allowed?
         %>
       <% else %>
-        <i class='ml-4'>Case is resolved - time cannot be changed</i>
+        <i class='ml-4'>Case is <%= @case.user_facing_state.downcase %> - time cannot be changed</i>
       <% end %>
     <% end %>
   </td>

--- a/app/views/cases/_time_worked.html.erb
+++ b/app/views/cases/_time_worked.html.erb
@@ -32,10 +32,14 @@
           minutes
         </label>
       </div>
-      <%= submit_tag 'Change time worked',
-                     class: 'form-control btn-primary ml-2',
-                     disabled: !@case.time_entry_allowed?
-      %>
+      <% if @case.time_entry_allowed? %>
+        <%= submit_tag 'Change time worked',
+                       class: 'form-control btn-primary ml-2',
+                       disabled: !@case.time_entry_allowed?
+        %>
+      <% else %>
+        <i class='ml-4'>Case is resolved - time cannot be changed</i>
+      <% end %>
     <% end %>
   </td>
 </tr>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -55,6 +55,7 @@
           </div>
         </td>
       </tr>
+      <%= render 'cases/time_worked' %>
       <tr>
         <th>Case history</th>
         <td colspan="3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
         post :resolve  # Only admins may resolve a case
         post :close  # Only admins may close a case
         post :assign  # Only admins may (re)assign a case
+        post :set_time
       end
     end
 

--- a/db/migrate/20180504103655_add_time_worked_to_cases.rb
+++ b/db/migrate/20180504103655_add_time_worked_to_cases.rb
@@ -1,5 +1,5 @@
 class AddTimeWorkedToCases < ActiveRecord::Migration[5.1]
   def change
-    add_column :cases, :time_worked, :integer, default: 0
+    add_column :cases, :time_worked, :integer, default: 0, null: false
   end
 end

--- a/db/migrate/20180504103655_add_time_worked_to_cases.rb
+++ b/db/migrate/20180504103655_add_time_worked_to_cases.rb
@@ -1,0 +1,5 @@
+class AddTimeWorkedToCases < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cases, :time_worked, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -113,7 +113,7 @@ ActiveRecord::Schema.define(version: 20180509144921) do
     t.text "state", default: "open", null: false
     t.bigint "assignee_id"
     t.string "display_id"
-    t.integer "time_worked", default: 0
+    t.integer "time_worked", default: 0, null: false
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20180509144921) do
     t.text "state", default: "open", null: false
     t.bigint "assignee_id"
     t.string "display_id"
+    t.integer "time_worked", default: 0
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -196,4 +196,19 @@ RSpec.describe CasesController, type: :controller do
       expect(flash[:error]).to eq 'Error updating support case: state cannot transition via "close"'
     end
   end
+
+  describe 'case time management' do
+
+    let(:some_case) { create(:open_case, time_worked: 0)}
+    let(:admin) { create(:admin) }
+
+    before(:each) { sign_in_as(admin) }
+
+    it 'converts from hours and minutes to minutes on a case' do
+      post :set_time, params: { id: some_case.id, time: { hours: 3, minutes: 21 }}
+      some_case.reload
+      expect(some_case.time_worked).to eq (3 * 60) + 21
+      expect(flash[:success]).to eq "Updated 'time worked' for support case #{some_case.display_id}."
+    end
+  end
 end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -145,6 +145,20 @@ RSpec.describe 'Case page' do
           'Assigned this case to A Scientist.'
       )
     end
+
+    it 'does not show time-worked events to contacts' do
+      open_case.time_worked = 1138
+      open_case.save
+
+      visit case_path(open_case, as: contact)
+
+      open_case.reload
+
+      expect(open_case.audits.count).to eq 1  # It's there...
+      expect do
+        find('.event-card')
+      end.to raise_error(Capybara::ElementNotFound) # ...but we don't show it
+    end
   end
 
   describe 'comments form' do

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -265,4 +265,21 @@ RSpec.describe 'Case page' do
     end
 
   end
+
+  describe 'Time logging' do
+
+    let (:time_form_id) { '#case-time-form' }
+
+    subject do
+      create(:open_case, time_worked: (2 * 60) + 17)
+    end
+
+    it 'correctly displays existing time in hours and minutes' do
+      visit case_path(subject, as: admin)
+
+      form = find(time_form_id)
+      expect(form.find_field('time[hours]').value).to eq "2"
+      expect(form.find_field('time[minutes]').value).to eq "17"
+    end
+  end
 end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe 'Case page' do
     let (:time_form_id) { '#case-time-form' }
 
     subject do
-      create(:open_case, time_worked: (2 * 60) + 17)
+      create(:open_case, cluster: cluster, time_worked: (2 * 60) + 17)
     end
 
     it 'correctly displays existing time in hours and minutes' do
@@ -280,6 +280,23 @@ RSpec.describe 'Case page' do
       form = find(time_form_id)
       expect(form.find_field('time[hours]').value).to eq "2"
       expect(form.find_field('time[minutes]').value).to eq "17"
+    end
+
+    it 'allows admins to set time worked' do
+      visit case_path(subject, as: admin)
+
+      fill_in 'time[hours]', with: '3'
+      fill_in 'time[minutes]', with: '42'
+      click_button 'Change time worked'
+
+      subject.reload
+
+      expect(subject.time_worked).to eq (3 * 60) + 42
+    end
+
+    it 'doesn\'t show time worked to contacts' do
+      visit case_path(subject, as: contact)
+      expect { find(time_form_id) }.to raise_error(Capybara::ElementNotFound)
     end
   end
 end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -123,18 +123,24 @@ RSpec.describe 'Case page' do
 
       # Generate an assignee-change audit entry
       open_case.assignee = admin
+      # ...and a time-worked one
+      open_case.time_worked = 123
       open_case.save
+
 
       visit case_path(open_case, as: admin)
 
       event_cards = all('.event-card')
-      expect(event_cards.size).to eq(4)
+      expect(event_cards.size).to eq(5)
 
-      expect(event_cards[3].find('.card-body').text).to eq('First')
-      expect(event_cards[2].find('.card-body').text).to eq('Second')
-      expect(event_cards[1].find('.card-body').text).to match(
+      expect(event_cards[4].find('.card-body').text).to eq('First')
+      expect(event_cards[3].find('.card-body').text).to eq('Second')
+      expect(event_cards[2].find('.card-body').text).to match(
         /Maintenance requested for .* from .* until .* by A Scientist; to proceed this maintenance must be confirmed on the cluster dashboard/
       )
+
+      expect(event_cards[1].find('.card-body').text).to eq 'Changed time worked from 0m to 2h 3m.'
+
       expect(event_cards[0].find('.card-body').text).to eq(
           'Assigned this case to A Scientist.'
       )

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -320,8 +320,8 @@ RSpec.describe 'Case page' do
 
         expect(find_field('time[hours]', disabled: true)).to be_disabled
         expect(find_field('time[minutes]', disabled: true)).to be_disabled
-        expect(find(time_form_id)).to \
-          have_button(time_form_submit_button, disabled: true)
+        expect(find(time_form_id)).not_to \
+          have_button(time_form_submit_button, disabled: :any)
       end
     end
   end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -382,4 +382,28 @@ RSpec.describe Case, type: :model do
       expect(cluster.case_index).to eq 0
     end
   end
+
+  describe ':time_worked' do
+
+    it 'can be changed when case is open' do
+      kase = create(:open_case, time_worked:42)
+
+      kase.time_worked = 48
+      expect do
+        kase.save!
+      end.not_to raise_error
+    end
+
+    %w(resolved closed).each do |state|
+      it "cannot be changed when case is #{state}" do
+        kase = create(:case, state: state, time_worked:42)
+
+        kase.time_worked = 48
+        expect do
+          kase.save!
+        end.to raise_error(ActiveRecord::RecordInvalid)
+        expect(kase.errors.messages).to match({time_worked: ["must not be changed when case is #{state}"]})
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the ability to track total time worked against a case.

Visible only to admins, each case now displays a "time worked" value in hours and minutes. For open cases, this value can be set (absolutely, not cumulatively - it should always be set to the *total* time worked to date).

Internally, it is stored as integer minutes, converted to a more friendly hours/minutes for display and entry.

Changes to `:time_worked` are stored by the `audited` gem in the same way as assignee changes, and events displayed in a case's history (again, only for admins).

To enforce process, the value of `:time_worked` may not be changed when a case is `resolved` or `closed`.

Trello: https://trello.com/c/aCQmt0eg/266-bonus-add-time-tracking-to-cases-for-admins