### PR TITLE
Display associated component for a log

### DIFF
--- a/app/decorators/component_decorator.rb
+++ b/app/decorators/component_decorator.rb
@@ -20,4 +20,8 @@ class ComponentDecorator < ClusterPartDecorator
       { id: :expansions, path: h.component_component_expansions_path(self) },
     ]
   end
+
+  def link
+    h.link_to self.name, path
+  end
 end

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -6,6 +6,7 @@
         <th>Date Created</th>
         <th>Engineer</th>
         <th>Details</th>
+        <th>Associated Component</th>
         <th>Related Case(s)</th>
       </thead>
       <% @logs.each do |log| %>
@@ -13,6 +14,9 @@
           <%= timestamp_td(description:  'Logged', timestamp: log.created_at) %>
           <td style="white-space: nowrap;"><%= log.engineer.name %></td>
           <td><%= log.details %></td>
+          <td>
+            <%= log.component&.decorate&.link || raw("<em>None</em>") %>
+          </td>
           <td>
             <% log.cases.map(&:decorate).each do |kase| %>
               <%= kase.case_link %>

--- a/spec/features/log_spec.rb
+++ b/spec/features/log_spec.rb
@@ -107,6 +107,7 @@ RSpec.feature Log, type: :feature do
     it 'can create a log without a component' do
       fill_details_input
       expect(submit_log.component).to be_nil
+      expect(page).to have_text 'None'
     end
 
     it 'can create a log with a component' do
@@ -114,6 +115,7 @@ RSpec.feature Log, type: :feature do
       component = subject.components.last
       select component.name, from: component_select_id
       expect(submit_log.component).to eq(component)
+      expect(page).to have_link(component.name, href: component_path(component))
     end
   end
 


### PR DESCRIPTION
A new column has been added to the log page to display a link to the `Associated Component` of a log where one exists. If there is no component assigned to a log then it will simply display '_None_'

This PR fixes #185.