### PR TITLE
Display logs tab on the component dashboard

### DIFF
--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -14,7 +14,7 @@ class ClusterDecorator < ApplicationDecorator
   def tabs
     [
       tabs_builder.overview,
-      { id: :logs, path: h.cluster_logs_path(self) },
+      tabs_builder.logs,
       tabs_builder.cases,
       {
         id: :maintenance,

--- a/app/decorators/component_decorator.rb
+++ b/app/decorators/component_decorator.rb
@@ -15,6 +15,7 @@ class ComponentDecorator < ClusterPartDecorator
   def tabs
     [
       tabs_builder.overview,
+      tabs_builder.logs,
       tabs_builder.asset_record,
       tabs_builder.cases,
       { id: :expansions, path: h.component_component_expansions_path(self) },

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -22,6 +22,10 @@ module TabsHelper
       { id: :asset_record, path: scope.scope_asset_record_path }
     end
 
+    def logs
+      { id: :logs, path: scope.scope_logs_path }
+    end
+
     private
 
     attr_reader :scope


### PR DESCRIPTION
Much like on the `Cluster` dashboard there is now a `Logs` tab on the `Component` dashboard. This allows you to view all logs for that component from within its dashboard.

This is based off #228 