### PR TITLE
Add flag to opt-in to using apt-get install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ install:
   - bin/setup
 addons:
   postgresql: "9.6"
+apt:
+  update: true


### PR DESCRIPTION
As of today we need to opt-in to using apt-get install as Travis has changed the build script to not run apt-get update by default. This may change in the future but this is their fix for the time being.