### PR TITLE
Update data model for tier 1 tools

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -27,6 +27,7 @@ class Case < ApplicationRecord
   has_many :maintenance_windows
   has_and_belongs_to_many :log
   has_many :case_comments
+  has_one :change_motd_request, required: false
 
   has_many :case_state_transitions
   alias_attribute :transitions, :case_state_transitions

--- a/app/models/change_motd_request.rb
+++ b/app/models/change_motd_request.rb
@@ -1,0 +1,6 @@
+class ChangeMotdRequest < ApplicationRecord
+  validates_presence_of :motd
+  belongs_to :case
+
+  delegate :site, to: :case
+end

--- a/app/models/change_motd_request.rb
+++ b/app/models/change_motd_request.rb
@@ -1,6 +1,7 @@
 class ChangeMotdRequest < ApplicationRecord
-  validates_presence_of :motd
+  validates_presence_of :motd, :state
   belongs_to :case
+  has_many :change_motd_request_state_transitions
 
   delegate :site, to: :case
 end

--- a/app/models/change_motd_request.rb
+++ b/app/models/change_motd_request.rb
@@ -1,7 +1,26 @@
 class ChangeMotdRequest < ApplicationRecord
   validates_presence_of :motd, :state
   belongs_to :case
+
   has_many :change_motd_request_state_transitions
+  alias_attribute :transitions, :change_motd_request_state_transitions
 
   delegate :site, to: :case
+
+  state_machine initial: :unapplied do
+    audit_trail context: [:user], initial: false
+
+    state :unapplied
+    state :applied
+
+    event :apply { transition any => :applied }
+  end
+
+  # Picked up by state_machines-audit_trail due to `context` setting above, and
+  # used to automatically set user who instigated the transition in created
+  # ChangeMotdRequestStateTransition.  Refer to
+  # https://github.com/state-machines/state_machines-audit_trail#example-5---store-advanced-method-results.
+  def user(transition)
+    transition.args&.first
+  end
 end

--- a/app/models/change_motd_request_state_transition.rb
+++ b/app/models/change_motd_request_state_transition.rb
@@ -3,4 +3,13 @@ class ChangeMotdRequestStateTransition < ApplicationRecord
   belongs_to :user
 
   delegate :site, to: :change_motd_request
+
+  validates_presence_of :user
+  validate :validate_user_is_admin
+
+  private
+
+  def validate_user_is_admin
+    errors.add(:user, 'must be an admin') unless user&.admin?
+  end
 end

--- a/app/models/change_motd_request_state_transition.rb
+++ b/app/models/change_motd_request_state_transition.rb
@@ -1,0 +1,6 @@
+class ChangeMotdRequestStateTransition < ApplicationRecord
+  belongs_to :change_motd_request
+  belongs_to :user
+
+  delegate :site, to: :change_motd_request
+end

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -22,6 +22,7 @@ class Cluster < ApplicationRecord
   validates :canonical_name, presence: true
   validate :validate_all_components_advice, if: :advice?
   validates :shortcode, presence: true, uniqueness: true
+  validates_presence_of :motd
 
   before_validation CanonicalNameCreator.new, on: :create
 

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -22,7 +22,7 @@ class Cluster < ApplicationRecord
   validates :canonical_name, presence: true
   validate :validate_all_components_advice, if: :advice?
   validates :shortcode, presence: true, uniqueness: true
-  validates_presence_of :motd
+  # validates_presence_of :motd
 
   before_validation CanonicalNameCreator.new, on: :create
 

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -15,6 +15,10 @@ class Tier < ApplicationRecord
       less_than_or_equal_to: 3,
     }
 
+  validates :tool,
+    absence: {unless: :can_have_tool?},
+    inclusion: {in: ['motd'], if: :tool}
+
   def self.globally_available?
     true
   end
@@ -25,5 +29,11 @@ class Tier < ApplicationRecord
       level: level,
       fields: fields,
     }
+  end
+
+  private
+
+  def can_have_tool?
+    level == 1
   end
 end

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -1,8 +1,6 @@
 class Tier < ApplicationRecord
   belongs_to :issue
 
-  validates_presence_of :fields
-
   validates :level,
     presence: true,
     uniqueness: {
@@ -15,8 +13,15 @@ class Tier < ApplicationRecord
       less_than_or_equal_to: 3,
     }
 
+  validates :fields,
+    presence: {unless: :tool},
+    absence: {if: :tool}
+
   validates :tool,
-    absence: {unless: :can_have_tool?},
+    absence: {
+      unless: :can_have_tool?,
+      message: 'must be a level 1 Tier without fields to associate tool'
+    },
     inclusion: {in: ['motd'], if: :tool}
 
   def self.globally_available?
@@ -34,6 +39,6 @@ class Tier < ApplicationRecord
   private
 
   def can_have_tool?
-    level == 1
+    level == 1 && !self.fields
   end
 end

--- a/db/data_migrations/20180509095726_add_placeholder_motds.rb
+++ b/db/data_migrations/20180509095726_add_placeholder_motds.rb
@@ -1,0 +1,7 @@
+class AddPlaceholderMotds < ActiveRecord::DataMigration
+  def up
+    Cluster.update_all(
+      motd: 'Placeholder MOTD - need to set real value before release'
+    )
+  end
+end

--- a/db/data_migrations/20180509115018_add_change_motd_issue.rb
+++ b/db/data_migrations/20180509115018_add_change_motd_issue.rb
@@ -1,0 +1,18 @@
+class AddChangeMotdIssue < ActiveRecord::DataMigration
+  def up
+    end_user_assistance = Category.find_by_name!('End User Assistance')
+    hpc_environment_type = ServiceType.find_by_name!('HPC Environment')
+    issue = end_user_assistance.issues.create!(
+      name: 'Request change of MOTD',
+      # XXX Now junk field which is still required, will be able to be removed
+      # once current staging changes deployed.
+      support_type: 'managed',
+      requires_service: true,
+      service_type: hpc_environment_type,
+    )
+    issue.tiers.create!(
+      level: 1,
+      tool: 'motd',
+    )
+  end
+end

--- a/db/migrate/20180508171035_create_change_motd_requests.rb
+++ b/db/migrate/20180508171035_create_change_motd_requests.rb
@@ -1,0 +1,10 @@
+class CreateChangeMotdRequests < ActiveRecord::Migration[5.1]
+  def change
+    create_table :change_motd_requests do |t|
+      t.timestamps null: false
+
+      t.string :motd, null: false
+      t.references :case, null: false
+    end
+  end
+end

--- a/db/migrate/20180508173313_data_model_changes_for_tier1_tools.rb
+++ b/db/migrate/20180508173313_data_model_changes_for_tier1_tools.rb
@@ -2,5 +2,6 @@ class DataModelChangesForTier1Tools < ActiveRecord::Migration[5.1]
   def change
     add_column :clusters, :motd, :text
     add_column :tiers, :tool, :text
+    change_column_null :tiers, :fields, true
   end
 end

--- a/db/migrate/20180508173313_data_model_changes_for_tier1_tools.rb
+++ b/db/migrate/20180508173313_data_model_changes_for_tier1_tools.rb
@@ -1,0 +1,6 @@
+class DataModelChangesForTier1Tools < ActiveRecord::Migration[5.1]
+  def change
+    add_column :clusters, :motd, :text
+    add_column :tiers, :tool, :text
+  end
+end

--- a/db/migrate/20180509144921_create_change_motd_request_state_transitions.rb
+++ b/db/migrate/20180509144921_create_change_motd_request_state_transitions.rb
@@ -1,0 +1,23 @@
+class CreateChangeMotdRequestStateTransitions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :change_motd_requests, :state, :text, null: false
+
+    create_table :change_motd_request_state_transitions do |t|
+      # Override default name as this goes over index name limit (62
+      # characters).
+      t.references :change_motd_request,
+        foreign_key: true,
+        null: false,
+        index: {name: 'index_cmrst_on_cmr_id'}
+
+      t.string :namespace
+      t.string :event
+      t.string :from
+      t.string :to, null: false
+      t.timestamp :created_at, null: false
+
+      # Custom field not required by state_machines-audit_trail Gem.
+      t.references :user, foreign_key: true, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180502104232) do
+ActiveRecord::Schema.define(version: 20180508171035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,14 @@ ActiveRecord::Schema.define(version: 20180502104232) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "change_motd_requests", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "motd", null: false
+    t.bigint "case_id", null: false
+    t.index ["case_id"], name: "index_change_motd_requests_on_case_id"
   end
 
   create_table "clusters", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180508171035) do
+ActiveRecord::Schema.define(version: 20180508173313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20180508171035) do
     t.string "charging_info"
     t.string "shortcode"
     t.integer "case_index", default: 0, null: false
+    t.text "motd"
     t.index ["shortcode"], name: "index_clusters_on_shortcode", unique: true
     t.index ["site_id"], name: "index_clusters_on_site_id"
   end
@@ -329,6 +330,7 @@ ActiveRecord::Schema.define(version: 20180508171035) do
     t.integer "level", null: false
     t.json "fields", null: false
     t.bigint "issue_id", null: false
+    t.text "tool"
     t.index ["issue_id"], name: "index_tiers_on_issue_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180508173313) do
+ActiveRecord::Schema.define(version: 20180509144921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,11 +135,24 @@ ActiveRecord::Schema.define(version: 20180508173313) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "change_motd_request_state_transitions", force: :cascade do |t|
+    t.bigint "change_motd_request_id", null: false
+    t.string "namespace"
+    t.string "event"
+    t.string "from"
+    t.string "to", null: false
+    t.datetime "created_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["change_motd_request_id"], name: "index_cmrst_on_cmr_id"
+    t.index ["user_id"], name: "index_change_motd_request_state_transitions_on_user_id"
+  end
+
   create_table "change_motd_requests", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "motd", null: false
     t.bigint "case_id", null: false
+    t.text "state", null: false
     t.index ["case_id"], name: "index_change_motd_requests_on_case_id"
   end
 
@@ -366,6 +379,8 @@ ActiveRecord::Schema.define(version: 20180508173313) do
   add_foreign_key "cases", "services"
   add_foreign_key "cases", "users"
   add_foreign_key "cases", "users", column: "assignee_id"
+  add_foreign_key "change_motd_request_state_transitions", "change_motd_requests"
+  add_foreign_key "change_motd_request_state_transitions", "users"
   add_foreign_key "clusters", "sites"
   add_foreign_key "component_groups", "clusters"
   add_foreign_key "component_groups", "component_makes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 20180508173313) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level", null: false
-    t.json "fields", null: false
+    t.json "fields"
     t.bigint "issue_id", null: false
     t.text "tool"
     t.index ["issue_id"], name: "index_tiers_on_issue_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -133,4 +133,9 @@ FactoryBot.define do
     motd 'Some new MOTD'
     association :case # Avoid conflict with case keyword.
   end
+
+  factory :change_motd_request_state_transition do
+    change_motd_request
+    to :applied
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -128,4 +128,9 @@ FactoryBot.define do
     cluster
     association :engineer, factory: :admin
   end
+
+  factory :change_motd_request do
+    motd 'Some new MOTD'
+    association :case # Avoid conflict with case keyword.
+  end
 end

--- a/spec/factories/cluster.rb
+++ b/spec/factories/cluster.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     name 'Hamilton Research Computing Cluster'
     support_type :managed
     shortcode
+    motd 'My MOTD'
 
     factory :managed_cluster do
       support_type :managed

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Case, type: :model do
 
     it { is_expected.to validate_presence_of(:fields) }
     it { is_expected.to validate_presence_of(:tier_level) }
+    it { is_expected.to have_one(:change_motd_request) }
 
     it do
       is_expected.to validate_numericality_of(:tier_level)

--- a/spec/models/change_motd_request_spec.rb
+++ b/spec/models/change_motd_request_spec.rb
@@ -5,4 +5,34 @@ RSpec.describe ChangeMotdRequest, type: :model do
   it { is_expected.to validate_presence_of(:state) }
   it { is_expected.to belong_to(:case) }
   it { is_expected.to have_many(:change_motd_request_state_transitions) }
+
+  describe 'states' do
+    RSpec.shared_examples 'it can be applied' do
+      it 'can be applied' do
+        admin = create(:admin)
+        subject.apply!(admin)
+
+        expect(subject).to be_applied
+        expect(subject.transitions.last.user).to eq admin
+      end
+    end
+
+    it 'is initially in unapplied state' do
+      request = create(:change_motd_request)
+
+      expect(request).to be_unapplied
+    end
+
+    context 'when unapplied' do
+      subject { create(:change_motd_request, state: :unapplied) }
+
+      it_behaves_like 'it can be applied'
+    end
+
+    context 'when applied' do
+      subject { create(:change_motd_request, state: :applied) }
+
+      it_behaves_like 'it can be applied'
+    end
+  end
 end

--- a/spec/models/change_motd_request_spec.rb
+++ b/spec/models/change_motd_request_spec.rb
@@ -2,5 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ChangeMotdRequest, type: :model do
   it { is_expected.to validate_presence_of(:motd) }
+  it { is_expected.to validate_presence_of(:state) }
   it { is_expected.to belong_to(:case) }
+  it { is_expected.to have_many(:change_motd_request_state_transitions) }
 end

--- a/spec/models/change_motd_request_spec.rb
+++ b/spec/models/change_motd_request_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe ChangeMotdRequest, type: :model do
+  it { is_expected.to validate_presence_of(:motd) }
+  it { is_expected.to belong_to(:case) }
+end

--- a/spec/models/change_motd_request_state_transition_spec.rb
+++ b/spec/models/change_motd_request_state_transition_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe ChangeMotdRequestStateTransition, type: :model do
+  it { is_expected.to belong_to(:change_motd_request) }
+  it { is_expected.to belong_to(:user) }
+end

--- a/spec/models/change_motd_request_state_transition_spec.rb
+++ b/spec/models/change_motd_request_state_transition_spec.rb
@@ -3,4 +3,11 @@ require 'rails_helper'
 RSpec.describe ChangeMotdRequestStateTransition, type: :model do
   it { is_expected.to belong_to(:change_motd_request) }
   it { is_expected.to belong_to(:user) }
+
+  describe '#valid?' do
+    subject { build(:change_motd_request_state_transition) }
+
+    it { is_expected.to validate_presence_of(:user) }
+    it_behaves_like 'it must be initiated by an admin'
+  end
 end

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe Cluster, type: :model do
   describe '#valid?' do
     subject { create(:cluster) }
 
-    it { is_expected.to validate_presence_of(:motd) }
+    # XXX Add this back once current staging deployed and so `rake
+    # alces:data:import_and_migrate_production` should succeed with this set
+    # (failing right now due to multiple Cluster data migrations since last
+    # deploy).
+    # it { is_expected.to validate_presence_of(:motd) }
 
     context 'when managed cluster' do
       subject do

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Cluster, type: :model do
   include_examples 'markdown_description'
 
   describe '#valid?' do
+    subject { create(:cluster) }
+
+    it { is_expected.to validate_presence_of(:motd) }
+
     context 'when managed cluster' do
       subject do
         create(:managed_cluster)

--- a/spec/models/tier_spec.rb
+++ b/spec/models/tier_spec.rb
@@ -40,17 +40,40 @@ RSpec.describe Tier, type: :model do
     end
 
     describe 'tool validation' do
-      context 'when level 1 Tier' do
-        subject { create(:tier, level: 1) }
+      context 'when level 1 Tier without fields' do
+        subject { build(:tier, level: 1, fields: nil) }
 
         it { is_expected.not_to validate_absence_of(:tool) }
         it { is_expected.to validate_inclusion_of(:tool).in_array(['motd']) }
+
+        context 'when has tool' do
+          before :each do
+            subject.tool = 'motd'
+          end
+
+          it { is_expected.to validate_absence_of(:fields) }
+        end
+      end
+
+      RSpec.shared_examples 'cannot have tool' do
+        it do
+          is_expected.to validate_absence_of(:tool)
+            .with_message('must be a level 1 Tier without fields to associate tool')
+        end
+      end
+
+      context 'when level 1 Tier with fields' do
+        subject do
+          build(:tier, level: 1, fields: [{type: 'input', name: 'Some field'}])
+        end
+
+        include_examples 'cannot have tool'
       end
 
       context 'when another level Tier' do
-        subject { create(:tier, level: 2) }
+        subject { build(:tier, level: 2) }
 
-        it { is_expected.to validate_absence_of(:tool) }
+        include_examples 'cannot have tool'
       end
     end
   end

--- a/spec/models/tier_spec.rb
+++ b/spec/models/tier_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe Tier, type: :model do
 
       it { is_expected.to be_valid }
     end
+
+    describe 'tool validation' do
+      context 'when level 1 Tier' do
+        subject { create(:tier, level: 1) }
+
+        it { is_expected.not_to validate_absence_of(:tool) }
+        it { is_expected.to validate_inclusion_of(:tool).in_array(['motd']) }
+      end
+
+      context 'when another level Tier' do
+        subject { create(:tier, level: 2) }
+
+        it { is_expected.to validate_absence_of(:tool) }
+      end
+    end
   end
 
   describe '#case_form_json' do


### PR DESCRIPTION
This PR makes various data model updates, and some actual data changes alongside these, to set things up for implementing the Tier 1 tools, in particular the MOTD update tool - see https://trello.com/c/ECGJfu3D/282-update-data-model-for-motd-and-future-tier-1-tools for full details. Going to leave this open but un-merged until I've implemented the next step since the Case form has not yet been updated to decode the new data format.