### PR TITLE
Give more room to table data

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -89,3 +89,13 @@ body {
     pointer-events: none;
   }
 }
+
+table {
+  .shrink {
+    white-space: nowrap;
+  }
+
+  .expand {
+    width: 99%
+  }
+}

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -49,3 +49,11 @@
 .case-table th {
   text-align: right;
 }
+
+.table th.shrink {
+  white-space: nowrap
+}
+
+.table td.expand {
+  width: 99%
+}

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -49,11 +49,3 @@
 .case-table th {
   text-align: right;
 }
-
-.table th.shrink {
-  white-space: nowrap
-}
-
-.table td.expand {
-  width: 99%
-}

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -43,7 +43,7 @@
             <table class="table table-sm table-striped table-bordered">
               <% @case.fields.each do |field| %>
                 <tr>
-                  <th scope="row">
+                  <th scope="row", style="width: 25%;">
                     <%= field.fetch('name') %>
                   </th>
                   <td>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -43,10 +43,10 @@
             <table class="table table-sm table-striped table-bordered">
               <% @case.fields.each do |field| %>
                 <tr>
-                  <th scope="row", style="width: 25%;">
+                  <th scope="row" class="shrink">
                     <%= field.fetch('name') %>
                   </th>
-                  <td>
+                  <td class="expand">
                     <%= simple_format(field.fetch('value')) %>
                   </td>
                 </tr>


### PR DESCRIPTION
Previously cases with very little added to fields would have the table pushed to the far right of the given space. With these changes the table header now shrinks to the longest field available, giving more space to actual data and improving readability.

_(Trello: https://trello.com/c/5KrWmFS9/279-fields-table-can-show-squashed-up-with-lots-of-space-for-keys-and-not-much-for-values-when-not-much-text-entered-for-values)_