### PR TITLE
Get Dokku config values without trailing whitespace

### DIFF
--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -121,7 +121,7 @@ class Deployment
 
   def dokku_config_get(env_var, app:)
     command = dokku_command("config:get #{app} #{env_var}")
-    `#{command}`
+    `#{command}`.strip
   end
 
   def dokku_stop(app)


### PR DESCRIPTION
Fix needed when doing the latest staging deploy; don't know why this wasn't previously an issue but this appears to fix it.