### PR TITLE
Case escalation

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -81,7 +81,7 @@ class CasesController < ApplicationController
                         "Support case %s assigned to #{new_assignee.name}."
                         : 'Support case %s unassigned.'
 
-    change_action success_flash, redirect_path: case_path do |kase|
+    change_action success_flash do |kase|
       kase.assignee = new_assignee
     end
   end
@@ -121,7 +121,7 @@ class CasesController < ApplicationController
     )
   end
 
-  def change_action(success_flash, redirect_path: case_path, &block)
+  def change_action(success_flash, &block)
     @case = case_from_params
     begin
       block.call(@case)
@@ -130,7 +130,7 @@ class CasesController < ApplicationController
     rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
       flash[:error] = "Error updating support case: #{format_errors(@case)}"
     end
-    redirect_to redirect_path
+    redirect_to case_path(@case)
   end
 
   def case_from_params

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -101,6 +101,12 @@ class CasesController < ApplicationController
     end
   end
 
+  def escalate
+    change_action "Support case %s escalated." do |kase|
+      kase.tier_level = 3
+    end
+  end
+
   private
 
   def case_params

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -24,7 +24,9 @@ module Audited
       text = send("#{field}_text", from, to)
       admin_only = ADMIN_ONLY_CARDS.include?(field)
 
-      render_card(date, user&.name || 'Flight Center', type, text, admin_only)
+      if text
+        render_card(date, user&.name || 'Flight Center', type, text, admin_only)
+      end
     end
 
     def render_card(date, name, type, text, admin_only)
@@ -84,6 +86,8 @@ module Audited
     def tier_level_text(from, to)
       if to == 3 && from < 3
         'Escalated this case to tier 3 (General support).'
+      elsif from.nil?  # Hide initial transitions caused by data migration
+        nil
       else
         raise "Unsupported tier level transition #{from} => #{to}"
       end

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -83,7 +83,7 @@ module Audited
 
     def tier_level_text(from, to)
       if to == 3 && from < 3
-        'Escalated this case to tier 3 (General support)'
+        'Escalated this case to tier 3 (General support).'
       else
         raise "Unsupported tier level transition #{from} => #{to}"
       end

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -85,7 +85,7 @@ module Audited
 
     def tier_level_text(from, to)
       if to == 3 && from < 3
-        'Escalated this case to tier 3 (General support).'
+        "Escalated this case to tier #{h.tier_description(to)}."
       elsif from.nil?  # Hide initial transitions caused by data migration
         nil
       else

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -80,5 +80,17 @@ module Audited
     def credit_charge_type
       'usd'
     end
+
+    def tier_level_text(from, to)
+      if to == 3 && from < 3
+        'Escalated this case to tier 3 (General support)'
+      else
+        raise "Unsupported tier level transition #{from} => #{to}"
+      end
+    end
+
+    def tier_level_type
+      'chevron-circle-up'
+    end
   end
 end

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -1,14 +1,6 @@
 class CaseDecorator < ApplicationDecorator
   delegate_all
 
-  # Note: These should match values used in `Tier.Level.description` in Case
-  # form app.
-  TIER_DESCRIPTIONS = {
-    1 => 'Tool',
-    2 => 'Routine Maintenance',
-    3 => 'General Support',
-  }.freeze
-
   def user_facing_state
     model.state.to_s.titlecase
   end
@@ -35,11 +27,7 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def tier_description
-    unless TIER_DESCRIPTIONS.has_key?(tier_level)
-      raise "Unhandled tier_level: #{tier_level}"
-    end
-    description = TIER_DESCRIPTIONS[tier_level]
-    "#{tier_level} (#{description})"
+    h.tier_description(tier_level)
   end
 
   def commenting_disabled?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,6 +50,21 @@ module ApplicationHelper
       EOF
     )
   end
+  # Note: These should match values used in `Tier.Level.description` in Case
+  # form app.
+  TIER_DESCRIPTIONS = {
+      1 => 'Tool',
+      2 => 'Routine Maintenance',
+      3 => 'General Support',
+  }.freeze
+
+  def tier_description(tier_level)
+    unless TIER_DESCRIPTIONS.has_key?(tier_level)
+      raise "Unhandled tier_level: #{tier_level}"
+    end
+    description = TIER_DESCRIPTIONS[tier_level]
+    "#{tier_level} (#{description})"
+  end
 
   private
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,4 +9,5 @@ class ApplicationMailer < ActionMailer::Base
   default from: 'Alces Flight Center <center@alces-flight.com>'
   layout 'mailer'
   helper 'mailer'
+  helper 'application'
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -244,15 +244,14 @@ class Case < ApplicationRecord
     super(new_assignee)
   end
 
-<<<<<<< HEAD
   def time_worked=(new_time)
     @time_worked_changed = (new_time != time_worked)
     super(new_time)
-=======
+  end
+
   def tier_level=(new_level)
     @tier_level_changed = (new_level != tier_level)
     super(new_level)
->>>>>>> Don't allow resolved or closed cases to be escalated.
   end
 
   private

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -73,6 +73,7 @@ class Case < ApplicationRecord
       greater_than_or_equal_to: 1,
       less_than_or_equal_to: 3,
     }
+  validate :validate_tier_level_changes
 
   validates :time_worked, numericality: {
       greater_than_or_equal_to: 0,
@@ -243,9 +244,15 @@ class Case < ApplicationRecord
     super(new_assignee)
   end
 
+<<<<<<< HEAD
   def time_worked=(new_time)
     @time_worked_changed = (new_time != time_worked)
     super(new_time)
+=======
+  def tier_level=(new_level)
+    @tier_level_changed = (new_level != tier_level)
+    super(new_level)
+>>>>>>> Don't allow resolved or closed cases to be escalated.
   end
 
   private
@@ -348,6 +355,11 @@ class Case < ApplicationRecord
   def time_worked_not_changed_unless_allowed
     error_condition = !time_entry_allowed? && @time_worked_changed
     errors.add(:time_worked, "must not be changed when case is #{state}") unless !error_condition
+  end
+
+  def validate_tier_level_changes
+    error_condition = @tier_level_changed && persisted? && !open?
+    errors.add(:tier_level, "cannot be changed when a case is #{state}") if error_condition
   end
 
   def field_hash

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -254,6 +254,17 @@ class Case < ApplicationRecord
     super(new_level)
   end
 
+  def save!
+    # Particularly in tests, rather than in normal controller operation, we might keep this object
+    # around after saving and do more things to it.
+    # So that the validation on these setters works properly, we need to reset the "changed" state
+    # of them all before continuing.
+    super
+    @assignee_changed = false
+    @time_worked_changed = false
+    @tier_level_changed = false
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -49,7 +49,7 @@ class Case < ApplicationRecord
 
   end
 
-  audited only: [:assignee_id, :time_worked, :credit_charge], on: [ :update ]
+  audited only: [:assignee_id, :time_worked, :credit_charge, :tier_level], on: [ :update ]
 
   # XXX Remove if: display_id when we can do so
   validates :display_id, uniqueness: true, if: :display_id

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -1,0 +1,12 @@
+<% if @case.open? && !@case.consultancy? %>
+  <%= link_to 'Escalate',
+              resolve_case_path(@case.id),
+              class: 'btn btn-warning ml-2 btn-sm',
+              method: :post,
+              role: 'button',
+              data: {
+                  confirm: 'Are you sure you want to escalate this support case?
+Escalating will mean that this case is potentially chargeable, and may incur a charge of support credits.'
+              }
+  %>
+<% end %>

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -17,7 +17,7 @@
         <div class="modal-footer">
           <button class="btn btn-outline-primary" data-dismiss="modal">Cancel</button>
           <%= link_to 'Escalate',
-                      resolve_case_path(@case.id),
+                      escalate_case_path(@case.id),
                       class: 'btn btn-outline-warning',
                       method: :post,
                       role: 'button'

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -19,6 +19,7 @@
           <%= link_to 'Escalate',
                       escalate_case_path(@case.id),
                       class: 'btn btn-outline-warning',
+                      id: 'confirm-escalate-button',
                       method: :post,
                       role: 'button'
           %>

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -1,12 +1,30 @@
 <% if @case.open? && !@case.consultancy? %>
-  <%= link_to 'Escalate',
-              resolve_case_path(@case.id),
-              class: 'btn btn-warning ml-2 btn-sm',
-              method: :post,
-              role: 'button',
-              data: {
-                  confirm: 'Are you sure you want to escalate this support case?
-Escalating will mean that this case is potentially chargeable, and may incur a charge of support credits.'
-              }
-  %>
+  <button type="button" class="btn btn-warning btn-sm ml-2" data-toggle="modal" data-target="#escalateModal">
+    Escalate
+  </button>
+  <div class="modal fade" id="escalateModal" tabindex="-1" role="dialog" aria-labelledby="escalateModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="escalateModalLabel">Escalating this support case may incur charges</h5>
+          <button class="close" data-dismiss="modal">×</button>
+        </div>
+        <div class="modal-body">
+          <p>Escalating a support case means that the case becomes potentially
+            chargeable, and may incur a charge of support credits.</p>
+          <p>Do you wish to continue?</p>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-outline-primary" data-dismiss="modal">Cancel</button>
+          <%= link_to 'Escalate',
+                      resolve_case_path(@case.id),
+                      class: 'btn btn-outline-warning',
+                      method: :post,
+                      role: 'button'
+          %>
+        </div>
+      </div>
+    </div>
+  </div>
+
 <% end %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -39,7 +39,10 @@
       </tr>
       <tr>
         <th>Tier</th>
-        <td><%= @case.tier_description %></td>
+        <td>
+          <%= @case.tier_description %>
+          <%= render 'cases/escalation_controls' %>
+        </td>
         <th>Unique identifier</th>
         <td><%= @case.display_id %></td>
       </tr>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -39,7 +39,7 @@
       </tr>
       <tr>
         <th>Tier</th>
-        <td><%= @case.tier_description %>
+        <td><%= @case.tier_description %></td>
         <th>Unique identifier</th>
         <td><%= @case.display_id %></td>
       </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,9 @@ Rails.application.routes.draw do
 
     resolved_cases.call(only: [:show, :create]) do
       resources :case_comments, only: :create
+      member do
+        post :escalate
+      end
     end
 
     resources :clusters, only: :show do

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -216,4 +216,41 @@ RSpec.describe CasesController, type: :controller do
       expect(flash[:success]).to eq "Updated 'time worked' for support case #{some_case.display_id}."
     end
   end
+
+  describe 'case escalation' do
+    let (:open_case) {
+      create(:open_case, cluster: first_cluster, tier_level: 2)
+    }
+
+    let (:resolved_case) {
+      create(:resolved_case, cluster: first_cluster, tier_level: 2)
+    }
+
+    let (:closed_case) {
+      create(:closed_case, cluster: first_cluster, tier_level: 2)
+    }
+
+    let(:admin) { create(:admin) }
+
+    RSpec.shared_examples 'case escalation behaviour' do
+      it 'escalates an open case' do
+        post :escalate, params: { id: open_case.id }
+        expect(flash[:success]).to eq "Support case #{open_case.display_id} escalated."
+
+        open_case.reload
+
+        expect(open_case.tier_level).to eq 3
+      end
+    end
+
+    context 'as an admin' do
+      before(:each) { sign_in_as(admin) }
+      it_behaves_like 'case escalation behaviour'
+    end
+
+    context 'as a contact' do
+      before(:each) { sign_in_as(user) }
+      it_behaves_like 'case escalation behaviour'
+    end
+  end
 end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe CasesController, type: :controller do
     end
   end
 
-  describe 'case escalation' do
+  describe 'POST #escalate' do
     let (:open_case) {
       create(:open_case, cluster: first_cluster, tier_level: 2)
     }
@@ -240,6 +240,17 @@ RSpec.describe CasesController, type: :controller do
         open_case.reload
 
         expect(open_case.tier_level).to eq 3
+      end
+
+      %w(resolved closed).each do |state|
+        it "does not escalate a #{state} case" do
+          kase = send("#{state}_case")
+          post :escalate, params: { id: kase.id }
+
+          expect(flash[:error]).to eq "Error updating support case: tier_level cannot be changed when a case is #{state}"
+          kase.reload
+          expect(open_case.tier_level).to eq 2
+        end
       end
     end
 

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Case page' do
           'Assigned this case to A Scientist.'
       )
       expect(event_cards[0].find('.card-body').text).to eq(
-          'Escalated this case to tier 3 (General support).'
+          'Escalated this case to tier 3 (General Support).'
       )
     end
 


### PR DESCRIPTION
This PR adds the ability for users - both contacts and admins - to escalate an open case up to tier 3.

When viewing an open tier 2 case, there is now a button next to the "Tier" value marked "Escalate". Clicking this button will open a modal almost identical to the one used in the new-case form warning that: 

> Escalating a support case means that the case becomes potentially chargeable, and may incur a charge of support credits.

If the user proceeds, then the case is set to tier 3 and an entry logged in the case history feed.

This is a one-time, irreversible action - once done a case cannot be de-escalated (though whether or not a case actually incurs a credit charge is a separate, if related, concern). It is not possible to escalate resolved or closed tickets.

Trello: https://trello.com/c/vrSKJGx0/268-add-escalation-of-cases