### PR TITLE
Prioritise cases assigned to the current user

### DIFF
--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -45,3 +45,8 @@
 .case-table th {
   text-align: right;
 }
+
+.current-user {
+  background-color: #ecf0f1;
+}
+

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -46,11 +46,6 @@
   text-align: right;
 }
 
-.current-user {
+.assigned-cases {
   background-color: rgba(39,148,216,0.1);
-  #background-color: #ecf0f1;
-}
-
-.current-user td:nth-child(6) {
-  font-weight: bold;
 }

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -47,6 +47,10 @@
 }
 
 .current-user {
-  background-color: #ecf0f1;
+  background-color: rgba(39,148,216,0.1);
+  #background-color: #ecf0f1;
 }
 
+.current-user td:nth-child(6) {
+  font-weight: bold;
+}

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -2,8 +2,8 @@ class LogsController < ApplicationController
   def index
     @new_log = Log.new
     @scope = @component || @cluster
-    @logs = @scope.logs.order(created_at: :desc)
-    @cases = @scope.cases.order(created_at: :desc)
+    @logs = @scope.logs
+    @cases = @scope.cases
     @components = @scope.components if @scope.is_a? Cluster
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -112,6 +112,9 @@ class Case < ApplicationRecord
 
   scope :active, -> { where(state: 'open') }
 
+  scope :assigned_to, ->(user) { where(assignee: user) }
+  scope :not_assigned_to, ->(user) { where.not(assignee: user).or(where(assignee: nil)) }
+
   def to_param
     self.display_id.parameterize.upcase
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -1,6 +1,8 @@
 class Case < ApplicationRecord
   include AdminConfig::Case
 
+  default_scope { order(created_at: :desc) }
+
   # @deprecated - to be removed in next release
   COMPLETED_RT_TICKET_STATUSES = [
     'resolved',

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,5 +1,7 @@
 
 class Log < ApplicationRecord
+  default_scope { order(created_at: :desc) }
+
   belongs_to :cluster
   belongs_to :component, optional: true
   has_one :site, through: :cluster

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -1,4 +1,5 @@
 class MaintenanceWindow < ApplicationRecord
+  default_scope { order(created_at: :desc) }
   belongs_to :case
   belongs_to :cluster, required: false
   belongs_to :component, required: false

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,4 +1,3 @@
-<% manage_cases_page = current_user.admin? && @show_resolved %>
 <%= content_for :subtitle do
   "#{@show_resolved ? 'Resolved' : 'Open'} Cases"
 end %>
@@ -20,36 +19,15 @@ end %>
         </tr>
       </thead>
 
+      <tbody class="current-user">
+        <% @scope.cases.assigned_to(current_user).order(created_at: :desc).decorate.each do |c| %>
+          <%= render 'partials/case_table_row', kase: c, show_resolved: @show_resolved %>
+        <% end %>
+      </tbody>
+
       <tbody>
-        <% @scope.cases.order(created_at: :desc).decorate.each do |c| %>
-      <%
-        # If @show_resolved, show only non-open cases; if not @show_resolved, show only open cases.
-        # Hence logic simplifies to the below (!=)
-      %>
-          <% if @show_resolved != c.open?  %>
-            <% if (c.resolved? || c.closed?) && !manage_cases_page %>
-              <tr
-                class="closed-case-row"
-                title="This support case has been resolved; you should open a new support case if you wish to contact Alces Flight Support"
-              >
-            <% else %>
-              <tr>
-            <% end %>
-              <td><%= link_to c.display_id, case_path(c) %></td>
-              <%= timestamp_td(
-                description:  'Support case created',
-                timestamp: c.created_at
-              ) %>
-              <td><%= c.user_facing_state %></td>
-              <td style="white-space: nowrap;"><%= c.user.name %></td>
-              <td><%= link_to c.subject, case_path(c) %></td>
-              <td><%= c.assignee&.name || 'Nobody' %></td>
-              <td><%= c.association_info %></td>
-              <% if @show_resolved %>
-                <td><%= c.credit_charge %></td>
-              <% end %>
-            </tr>
-          <% end %>
+        <% @scope.cases.not_assigned_to(current_user).order(created_at: :desc).decorate.each do |c| %>
+          <%= render 'partials/case_table_row', kase: c, show_resolved: @show_resolved %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -19,14 +19,14 @@ end %>
         </tr>
       </thead>
 
-      <tbody class="current-user">
-        <% @scope.cases.assigned_to(current_user).order(created_at: :desc).decorate.each do |c| %>
+      <tbody class="assigned-cases">
+        <% @scope.cases.assigned_to(current_user).decorate.each do |c| %>
           <%= render 'partials/case_table_row', kase: c, show_resolved: @show_resolved %>
         <% end %>
       </tbody>
 
       <tbody>
-        <% @scope.cases.not_assigned_to(current_user).order(created_at: :desc).decorate.each do |c| %>
+        <% @scope.cases.not_assigned_to(current_user).decorate.each do |c| %>
           <%= render 'partials/case_table_row', kase: c, show_resolved: @show_resolved %>
         <% end %>
       </tbody>

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -22,7 +22,7 @@
       <%= f.label :case_id, case_label, 'data-test': 'case-select-label' %>
       <%= f.collection_select(
         :case_id,
-        maintenance_window.associated_cluster.cases.active.order(created_at: :desc).decorate,
+        maintenance_window.associated_cluster.cases.active.decorate,
         :id,
         :case_select_details,
         {},

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,18 +1,13 @@
-<% manage_cases_page = current_user.admin? && @show_resolved %>
+<% manage_cases_page = current_user.admin? && show_resolved %>
 <%
   # If @show_resolved, show only non-open cases; if not @show_resolved, show only open cases.
   # Hence logic simplifies to the below (!=)
 %>
-<% if @show_resolved != kase.open?  %>
-  <% if kase.hidden? && !manage_cases_page %>
+<% if show_resolved != kase.open?  %>
+  <% if (kase.resolved? || kase.closed?) && !manage_cases_page %>
     <tr
-      class="archived-case-row"
-      title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
-    >
-  <% elsif manage_cases_page && kase.requires_credit_charge? %>
-    <tr
-      class="credit-charge-required-case-row"
-      title="This support case is chargeable and has been completed, and needs some credits associated with it."
+      class="closed-case-row"
+      title="This support case has been resolved; you should open a new support case if you wish to contact Alces Flight Support"
     >
   <% else %>
     <tr>
@@ -27,20 +22,8 @@
     <td><%= link_to kase.subject, case_path(kase) %></td>
     <td><%= kase.assignee&.name || 'Nobody' %></td>
     <td><%= kase.association_info %></td>
-    <% if manage_cases_page %>
-      <td><%= kase.chargeable_symbol %></td>
+    <% if show_resolved %>
+      <td><%= kase.credit_charge %></td>
     <% end %>
-    <td>
-      <% if kase.credit_charge_allowed? && manage_cases_page %>
-        <% credit_charge = kase.credit_charge || CreditCharge.new(case: kase) %>
-        <%= form_for credit_charge, class: 'form-inline' do |f| %>
-          <%= f.hidden_field :case_id %>
-          <%= f.number_field :amount, class: 'form-control', required: true %>
-          <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
-        <% end %>
-      <% else %>
-        <%= kase.credit_charge_info %>
-      <% end %>
-    </td>
   </tr>
 <% end %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,0 +1,46 @@
+<% manage_cases_page = current_user.admin? && @show_resolved %>
+<%
+  # If @show_resolved, show only non-open cases; if not @show_resolved, show only open cases.
+  # Hence logic simplifies to the below (!=)
+%>
+<% if @show_resolved != kase.open?  %>
+  <% if kase.hidden? && !manage_cases_page %>
+    <tr
+      class="archived-case-row"
+      title="This support case has been archived; you should open a new support case if you wish to contact Alces Flight Support"
+    >
+  <% elsif manage_cases_page && kase.requires_credit_charge? %>
+    <tr
+      class="credit-charge-required-case-row"
+      title="This support case is chargeable and has been completed, and needs some credits associated with it."
+    >
+  <% else %>
+    <tr>
+  <% end %>
+    <td><%= link_to kase.display_id, case_path(kase) %></td>
+    <%= timestamp_td(
+      description:  'Support case created',
+      timestamp: kase.created_at
+    ) %>
+    <td><%= kase.user_facing_state %></td>
+    <td style="white-space: nowrap;"><%= kase.user.name %></td>
+    <td><%= link_to kase.subject, case_path(kase) %></td>
+    <td><%= kase.assignee&.name || 'Nobody' %></td>
+    <td><%= kase.association_info %></td>
+    <% if manage_cases_page %>
+      <td><%= kase.chargeable_symbol %></td>
+    <% end %>
+    <td>
+      <% if kase.credit_charge_allowed? && manage_cases_page %>
+        <% credit_charge = kase.credit_charge || CreditCharge.new(case: kase) %>
+        <%= form_for credit_charge, class: 'form-inline' do |f| %>
+          <%= f.hidden_field :case_id %>
+          <%= f.number_field :amount, class: 'form-control', required: true %>
+          <%= f.submit '+', class: 'btn btn-success', style: 'width: 100%' %>
+        <% end %>
+      <% else %>
+        <%= kase.credit_charge_info %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -20,7 +20,7 @@
     <td><%= kase.user_facing_state %></td>
     <td style="white-space: nowrap;"><%= kase.user.name %></td>
     <td><%= link_to kase.subject, case_path(kase) %></td>
-    <td><%= kase.assignee&.name || 'Nobody' %></td>
+    <td><%= current_user == kase.assignee ? 'Me' : kase.assignee&.name || 'Nobody' %></td>
     <td><%= kase.association_info %></td>
     <% if show_resolved %>
       <td><%= kase.credit_charge %></td>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -20,7 +20,13 @@
     <td><%= kase.user_facing_state %></td>
     <td style="white-space: nowrap;"><%= kase.user.name %></td>
     <td><%= link_to kase.subject, case_path(kase) %></td>
-    <td><%= current_user == kase.assignee ? 'Me' : kase.assignee&.name || 'Nobody' %></td>
+    <td>
+      <% if current_user == kase.assignee %>
+        <%= raw('<strong>Me</strong>') %>
+      <% else %>
+        <%= kase.assignee&.name || 'Nobody' %>
+      <% end %>
+    </td>
     <td><%= kase.association_info %></td>
     <% if show_resolved %>
       <td><%= kase.credit_charge %></td>

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe 'Cases table', type: :feature do
         expect(cases).to have_text('1138')
       end
     end
+
+    it 'shows cases assigned to current user in separate section' do
+      create(
+        :open_case,
+        cluster: cluster,
+        subject: 'Assigned case',
+        assignee: user
+      )
+
+      visit cases_path(as: user)
+      assigned_cases = find('.current-user').all('tr').map(&:text)
+      expect(assigned_cases).to have_text('Assigned case')
+      expect(assigned_cases).not_to have_text('Open case')
+    end
   end
 
   context 'when user is admin' do

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -61,29 +61,6 @@ RSpec.describe 'Cases table', type: :feature do
       # same for both admins as contacts.
       include_examples 'open cases table rendered'
     end
-
-    context 'when visit archive cases page' do
-      it 'renders table of all resolved and closed Cases, without Contact-specific buttons/info' do
-        visit resolved_site_cases_path(site, as: user)
-
-        headings = all('th').map(&:text)
-        expect(headings).not_to include('Contact support')
-        expect(headings).not_to include('Archive/Restore')
-
-        # Only include links in the table NOT the tab bar
-        links = first('table').all('a')
-
-        mailto_links = links.select { |a| a[:href]&.match?('mailto') }
-        expect(mailto_links).to eq []
-
-        archive_links = links.select { |a| a[:href]&.match?('archive') }
-        expect(archive_links).to eq []
-
-        expect do
-          find('.archived-case-row')
-        end.to raise_error(Capybara::ElementNotFound)
-      end
-    end
   end
 end
 
@@ -245,7 +222,7 @@ RSpec.describe 'Case page' do
       end
     end
   end
-  
+
   describe 'Commenting' do
 
     context 'for open non-consultancy Case' do

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Cases table', type: :feature do
       )
 
       visit cases_path(as: user)
-      assigned_cases = find('.current-user').all('tr').map(&:text)
+      assigned_cases = find('.assigned-cases').all('tr').map(&:text)
       expect(assigned_cases).to have_text('Assigned case')
       expect(assigned_cases).not_to have_text('Open case')
     end


### PR DESCRIPTION
This PR implements prioritisation and highlighting of cases that have been assigned to the current user. Cases are split into two distinct groups of those that are and aren't assigned to the current user. With those that are assigned appearing first and foremost at the top in descending order with a darker background to make them stand out.

_(Trello: https://trello.com/c/rvMjwwcA/287-make-cases-assigned-to-current-user-more-prominent-every-time-we-display-case-tables)_