### PR TITLE
Fix new case form in non-site-wide uses

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,7 +14,7 @@ module ApplicationHelper
   end
 
   def new_case_form(clusters:, single_part: nil)
-    clusters_json = json_map(clusters.decorate, :case_form_json)
+    clusters_json = json_map(clusters.map(&:decorate), :case_form_json)
     raw(
       <<~EOF
         <div


### PR DESCRIPTION
In three of the four ways that `clusters` can be set, it's set to an array (a singleton, as it happens). Only in the fourth case is it set to an `ActiveRecord::Associations::CollectionProxy` with a `decorate` method, and that was the only case in which the new case form was working (when accessed from a site dashboard).

This commit fixes the form to work for the other code paths by assuming `clusters` is an array, and calling `decorate` on each of its members directly.

Fixes #254.