### PR TITLE
Admin case management page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,11 +86,18 @@ class ApplicationController < ActionController::Base
 
   def assign_site_scope
     if current_user.contact?
+      # For a Site contact, the Site in scope is always the Site they belong
+      # to.
       @site = current_user.site
     elsif request.path =~ /^\/sites/
+      # For an admin viewing the pages for a particular Site, that is the Site
+      # in scope.
       id = scope_id_param(:site_id)
       @site = Site.find(id)
     else
+      # If we reach this point we must be an admin viewing the top-level pages
+      # which show cross-site information, so assign the AllSites scope which
+      # handles this in a similar way to any of the other scopes.
       AllSites.new
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,19 +85,23 @@ class ApplicationController < ActionController::Base
   end
 
   def assign_site_scope
-    @site = if request.path =~ /^\/sites/
-              id = scope_id_param(:site_id)
-              Site.find(id)
-            elsif current_user.contact?
-              current_user.site
-            end
+    if current_user.contact?
+      @site = current_user.site
+    else
+      if request.path =~ /^\/sites/
+        id = scope_id_param(:site_id)
+        @site = Site.find(id)
+      else
+        AllSites.new
+      end
+    end
   end
 
   def assign_title
     if @scope
       @title = <<~EOF.squish
         #{@scope.readable_model_name.split.map(&:capitalize).join(' ')}
-        Dashboard: #{@scope.name}
+        Dashboard#{@scope.respond_to?(:name) ? ": #{@scope.name}" : ''}
       EOF
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,13 +87,11 @@ class ApplicationController < ActionController::Base
   def assign_site_scope
     if current_user.contact?
       @site = current_user.site
+    elsif request.path =~ /^\/sites/
+      id = scope_id_param(:site_id)
+      @site = Site.find(id)
     else
-      if request.path =~ /^\/sites/
-        id = scope_id_param(:site_id)
-        @site = Site.find(id)
-      else
-        AllSites.new
-      end
+      AllSites.new
     end
   end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -4,7 +4,6 @@ class CasesController < ApplicationController
   decorates_assigned :site
 
   def index(show_resolved: false)
-    @site = current_site
     @show_resolved = show_resolved
   end
 

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,6 +1,5 @@
 class SitesController < ApplicationController
   def index
-    @title = 'Alces Admin Sites Dashboard'
     @sites = Site.all
   end
 end

--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -1,0 +1,3 @@
+class AllSitesDecorator < ApplicationDecorator
+  delegate_all
+end

--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -3,9 +3,9 @@ class AllSitesDecorator < ApplicationDecorator
 
   def tabs
     [
-      #{ id: :overview, path: h.cases_path },
+      { id: :all_sites, path: h.root_path },
       {
-        id: :cases, path: h.cases_path,
+        id: :cases, text: 'All Cases', path: h.cases_path,
         dropdown: [
           { text: 'Current', path: h.cases_path },
           { text: 'Resolved', path: h.resolved_cases_path }

--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -1,3 +1,16 @@
 class AllSitesDecorator < ApplicationDecorator
   delegate_all
+
+  def tabs
+    [
+      #{ id: :overview, path: h.cases_path },
+      {
+        id: :cases, path: h.cases_path,
+        dropdown: [
+          { text: 'Current', path: h.cases_path },
+          { text: 'Resolved', path: h.resolved_cases_path }
+        ]
+      }
+    ]
+  end
 end

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -15,7 +15,7 @@ class ScopeNavLinksBuilder
                                             nav_icon: 'fa-globe')
     end
 
-    if scope
+    if scope && !scope.is_a?(AllSites)
       site_obj = model_from_scope :site
       path_for_site = if h.current_user.admin?
                         site_obj

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -7,51 +7,60 @@ class ScopeNavLinksBuilder
   end
 
   def build
-    return [] unless scope
-    scope_nav_link_procs = []
-
-    if h.current_user&.admin?
-      scope_nav_link_procs << nav_link_proc(text: 'All Sites',
-                                            path: h.root_path,
-                                            nav_icon: 'fa-globe')
-    end
-
-    site_obj = model_from_scope :site
-    path_for_site = if h.current_user.admin?
-                      site_obj
-                    else
-                      h.root_path
-                    end
-    if site_obj
-      scope_nav_link_procs << nav_link_proc(model: site_obj,
-                                            path: path_for_site,
-                                            nav_icon: 'fa-institution')
-    end
-
-    cluster_obj = model_from_scope :cluster
-    if cluster_obj
-      scope_nav_link_procs << nav_link_proc(model: cluster_obj,
-                                            nav_icon: 'fa-server')
-    end
-
-    component_group_obj = model_from_scope :component_group
-    if component_group_obj
-      scope_nav_link_procs << nav_link_proc(model: component_group_obj,
-                                            nav_icon: 'fa-cubes')
-    end
-
-    cluster_part = model_from_scope(:service) || model_from_scope(:component)
-    if cluster_part
-      scope_nav_link_procs << nav_link_proc(model: cluster_part,
-                                            nav_icon: 'fa-cube')
-    end
-
-    scope_nav_link_procs
+    [
+      all_sites_link,
+      site_link,
+      cluster_link,
+      component_group_link,
+      cluster_part_link,
+    ].compact
   end
 
   private
 
   attr_reader :scope
+
+  def all_sites_link
+    if h.current_user&.admin?
+      nav_link_proc(text: 'All Sites',
+                    path: h.root_path,
+                    nav_icon: 'fa-globe')
+    end
+  end
+
+  def site_link
+    site_obj = model_from_scope :site
+    return nil unless site_obj
+    path_for_site = if h.current_user.admin?
+                      site_obj
+                    else
+                      h.root_path
+                    end
+    nav_link_proc(model: site_obj,
+                  path: path_for_site,
+                  nav_icon: 'fa-institution')
+  end
+
+  def cluster_link
+    cluster_obj = model_from_scope :cluster
+    return nil unless cluster_obj
+    nav_link_proc(model: cluster_obj,
+                  nav_icon: 'fa-server')
+  end
+
+  def component_group_link
+    component_group_obj = model_from_scope :component_group
+    return nil unless component_group_obj
+    nav_link_proc(model: component_group_obj,
+                  nav_icon: 'fa-cubes')
+  end
+
+  def cluster_part_link
+    cluster_part = model_from_scope(:service) || model_from_scope(:component)
+    return nil unless cluster_part
+    nav_link_proc(model: cluster_part,
+                  nav_icon: 'fa-cube')
+  end
 
   def model_from_scope(type)
     if scope.respond_to? type

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -7,6 +7,7 @@ class ScopeNavLinksBuilder
   end
 
   def build
+    return [] unless scope
     scope_nav_link_procs = []
 
     if h.current_user&.admin?
@@ -15,34 +16,34 @@ class ScopeNavLinksBuilder
                                             nav_icon: 'fa-globe')
     end
 
-    if scope && !scope.is_a?(AllSites)
-      site_obj = model_from_scope :site
-      path_for_site = if h.current_user.admin?
-                        site_obj
-                      else
-                        h.root_path
-                      end
+    site_obj = model_from_scope :site
+    path_for_site = if h.current_user.admin?
+                      site_obj
+                    else
+                      h.root_path
+                    end
+    if site_obj
       scope_nav_link_procs << nav_link_proc(model: site_obj,
                                             path: path_for_site,
                                             nav_icon: 'fa-institution')
+    end
 
-      cluster_obj = model_from_scope :cluster
-      if cluster_obj
-        scope_nav_link_procs << nav_link_proc(model: cluster_obj,
-                                              nav_icon: 'fa-server')
-      end
+    cluster_obj = model_from_scope :cluster
+    if cluster_obj
+      scope_nav_link_procs << nav_link_proc(model: cluster_obj,
+                                            nav_icon: 'fa-server')
+    end
 
-      component_group_obj = model_from_scope :component_group
-      if component_group_obj
-        scope_nav_link_procs << nav_link_proc(model: component_group_obj,
-                                              nav_icon: 'fa-cubes')
-      end
+    component_group_obj = model_from_scope :component_group
+    if component_group_obj
+      scope_nav_link_procs << nav_link_proc(model: component_group_obj,
+                                            nav_icon: 'fa-cubes')
+    end
 
-      cluster_part = model_from_scope(:service) || model_from_scope(:component)
-      if cluster_part
-        scope_nav_link_procs << nav_link_proc(model: cluster_part,
-                                              nav_icon: 'fa-cube')
-      end
+    cluster_part = model_from_scope(:service) || model_from_scope(:component)
+    if cluster_part
+      scope_nav_link_procs << nav_link_proc(model: cluster_part,
+                                            nav_icon: 'fa-cube')
     end
 
     scope_nav_link_procs

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -29,29 +29,29 @@ class ScopeNavLinksBuilder
   end
 
   def site_link
-    site_obj = model_from_scope :site
-    return nil unless site_obj
+    site = model_from_scope :site
+    return nil unless site
     path_for_site = if h.current_user.admin?
-                      site_obj
+                      site
                     else
                       h.root_path
                     end
-    nav_link_proc(model: site_obj,
+    nav_link_proc(model: site,
                   path: path_for_site,
                   nav_icon: 'fa-institution')
   end
 
   def cluster_link
-    cluster_obj = model_from_scope :cluster
-    return nil unless cluster_obj
-    nav_link_proc(model: cluster_obj,
+    cluster = model_from_scope :cluster
+    return nil unless cluster
+    nav_link_proc(model: cluster,
                   nav_icon: 'fa-server')
   end
 
   def component_group_link
-    component_group_obj = model_from_scope :component_group
-    return nil unless component_group_obj
-    nav_link_proc(model: component_group_obj,
+    component_group = model_from_scope :component_group
+    return nil unless component_group
+    nav_link_proc(model: component_group,
                   nav_icon: 'fa-cubes')
   end
 

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -42,24 +42,28 @@ class ScopeNavLinksBuilder
   end
 
   def cluster_link
-    cluster = model_from_scope :cluster
-    return nil unless cluster
-    nav_link_proc(model: cluster,
-                  nav_icon: 'fa-server')
+    link_for_model(:cluster, nav_icon: 'fa-server')
   end
 
   def component_group_link
-    component_group = model_from_scope :component_group
-    return nil unless component_group
-    nav_link_proc(model: component_group,
-                  nav_icon: 'fa-cubes')
+    link_for_model(:component_group, nav_icon: 'fa-cubes')
   end
 
   def cluster_part_link
-    cluster_part = model_from_scope(:service) || model_from_scope(:component)
-    return nil unless cluster_part
-    nav_link_proc(model: cluster_part,
-                  nav_icon: 'fa-cube')
+    link_for_model([:service, :component], nav_icon: 'fa-cube')
+  end
+
+  def link_for_model(possible_types, nav_icon:)
+    model = first_model_from_scope(possible_types)
+    return nil unless model
+    nav_link_proc(model: model, nav_icon: nav_icon)
+  end
+
+  def first_model_from_scope(possible_types)
+    Array.wrap(possible_types)
+      .lazy
+      .map { |type| model_from_scope(type) }
+      .find(&:itself)
   end
 
   def model_from_scope(type)

--- a/app/models/all_sites.rb
+++ b/app/models/all_sites.rb
@@ -1,0 +1,14 @@
+class AllSites
+  include Draper::Decoratable
+  def cases
+    Case.all
+  end
+
+  def readable_model_name
+    'All Sites'
+  end
+
+  def ==(other_object)
+    other_object.is_a?(AllSites)
+  end
+end

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -1,15 +1,5 @@
 <% content_for :subtitle { 'All Sites' } %>
-<div class='card'>
-  <div class='card-header'>
-    <ul class="nav">
-      <li class="nav-item">
-        <span class="navbar-brand">
-          All Sites
-        </span>
-      </li>
-    </ul>
-  </div>
-
+<%= render 'partials/tabs', activate: :all_sites do %>
   <ul class="list-group list-group-flush">
     <% @sites.each do |site| %>
       <li class="list-group-item">
@@ -19,4 +9,4 @@
       </li>
     <% end %>
   </ul>
-</div>
+<% end %>

--- a/spec/decorators/all_sites_decorator_spec.rb
+++ b/spec/decorators/all_sites_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe AllSitesDecorator do
+end

--- a/spec/decorators/all_sites_decorator_spec.rb
+++ b/spec/decorators/all_sites_decorator_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe AllSitesDecorator do
-end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     include_examples 'cluster and part variable assignment'
 
     describe "get '/'" do
-      subject { nil }
+      subject { AllSites.new }
       before :each do
         get root_path(as: user)
       end


### PR DESCRIPTION
The admin dashboard now contains tabs to switch between viewing `All sites` and `All cases`. The former displays what admins currently see on the dashboard. Whereas the latter will display **all** open cases, with the option to view all resolved/closed cases via the dropdown.

Once #247 has been merged then this page should also filter by cases assigned to the current user.

[Trello Card](https://trello.com/c/4V06Dvme/269-add-case-management-pages-for-admins)