### PR TITLE
Improve site dashboard UI/UX

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,6 +41,12 @@
       margin-right: 0.5rem;
     }
   }
+
+  &.title-card {
+    margin-top: 0;
+    margin-bottom: 0;
+    text-align: center;
+  }
 }
 
 .navbar-text {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,6 +46,7 @@
     margin-top: 0;
     margin-bottom: 0;
     text-align: center;
+    border-radius: 0;
   }
 }
 

--- a/app/assets/stylesheets/sites.scss
+++ b/app/assets/stylesheets/sites.scss
@@ -9,8 +9,12 @@
     justify-items: center;
 
     h4 {
-      line-height: 1.5em;
-      margin: 0;
+      margin: 0.75rem 0;
+    }
+
+    & > span {
+      line-height: 3rem;
+      text-align: right;
     }
   }
 }

--- a/app/assets/stylesheets/sites.scss
+++ b/app/assets/stylesheets/sites.scss
@@ -1,3 +1,16 @@
 // Place all the styles related to the sites controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.cluster-list {
+  .list-group-item {
+    display: flex;
+    justify-content: space-between;
+    justify-items: center;
+
+    h4 {
+      line-height: 1.5em;
+      margin: 0;
+    }
+  }
+}

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -3,7 +3,7 @@ class SiteDecorator < ApplicationDecorator
   decorates_association :clusters
 
   def tabs
-    [tabs_builder.overview, tabs_builder.cases]
+    [tabs_builder.overview, all_cases_tab]
   end
 
   private
@@ -16,5 +16,11 @@ class SiteDecorator < ApplicationDecorator
   # The site model is not required when a contact is logged in
   def arguments_for_scope_path(*a)
     h.current_user.contact? ? a : super
+  end
+
+  def all_cases_tab
+    tabs_builder.cases.tap do |tab|
+      tab[:text] = 'All site cases'
+    end
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,5 @@
+class UserDecorator < ApplicationDecorator
+  def info
+    "#{model.name} (<a href=\"mailto:#{model.email}\">#{model.email}</a>)".html_safe
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -30,14 +30,6 @@ class Site < ApplicationRecord
     users.where(primary_contact: false).order(:id)
   end
 
-  def secondary_contacts_info
-    secondary_contacts.map(&:info).join(', ')
-  end
-
-  def additional_contacts_info
-    additional_contacts.map(&:email).join(', ')
-  end
-
   def managed_clusters
     clusters.select(&:managed?)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,10 +36,6 @@ class User < ApplicationRecord
     contact? && !primary_contact?
   end
 
-  def info
-    "#{name} <#{email}>"
-  end
-
   def self.globally_available?
     true
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,37 +28,23 @@
     <div class='page-content'>
 
       <% if @title %>
-        <div class="jumbotron">
-          <div class="container-fluid">
-            <div class="row">
-              <div class="col"></div>
-              <div class="col-8">
-                <h1 class="display-4"><%= @title %></h1>
-                <p class="lead"><%= yield :subtitle %></p>
-              </div>
-              <div class="col"></div>
-            </div>
+          <div class="card title-card">
+            <div class="card-body">
+            <h1><%= @title %></h1>
+            <p class="lead" style="font-size: 18px;">
+              <%= yield :subtitle %>
+            </p>
           </div>
         </div>
       <% end %>
 
-      <div class="container-fluid page-container">
+      <div class="container page-container">
         <%= render 'partials/flash_alert', flash_key: :alert, alert_class: 'alert-danger' %>
         <%= render 'partials/flash_alert', flash_key: :error, alert_class: 'alert-danger' %>
         <%= render 'partials/flash_alert', flash_key: :success, alert_class: 'alert-success' %>
         <%= render 'partials/flash_alert', flash_key: :notice, alert_class: 'alert-info' %>
 
-        <% if signed_in? %>
-          <div class="row">
-            <div class="col"></div>
-            <div class="col-8">
-              <%= yield %>
-            </div>
-            <div class="col"></div>
-          </div>
-        <% else %>
-          <%= yield %>
-        <% end %>
+        <%= yield %>
       </div>
 
     </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,8 +9,7 @@
 </div>
 
 <div class="row">
-  <div class="col"></div>
-  <div class="col-4">
+  <div class="col-md-6 col-sm-12">
     <h4>What is Flight Center?</h4>
     <p>
       Designed to help you to make the most of your HPC resources, Alces Flight
@@ -25,7 +24,7 @@
       Crew.
     </p>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-6 col-sm-12">
     <div id='clearance' class='card sign-in'>
       <div class='card-header'>
         <ul class='nav'>
@@ -41,5 +40,4 @@
     </div>
 
   </div>
-  <div class="col"></div>
 </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,33 +1,49 @@
 <% content_for :subtitle { 'Overview' } %>
 
 <%= render 'partials/tabs', activate: :overview do %>
-  <ul class="list-group list-group-flush">
-    <li class="list-group-item">
-      <%= site.rendered_description.html_safe %>
-    </li>
-    <li class="list-group-item">
-      Primary site contact: <%= site.primary_contact&.info || raw('<em>Unset</em>') %>
-    </li>
-    <li class="list-group-item">
-      Secondary site <%= 'contact'.pluralize(site.secondary_contacts.length) %>:
-      <%= site.secondary_contacts.present? ? site.secondary_contacts_info : raw('<em>None</em>') %>
-    </li>
-    <% if site.additional_contacts_info.present? %>
-      <li class="list-group-item">
-        Additional site contacts: <%= site.additional_contacts_info %>
-      </li>
-    <% end %>
-  </ul>
-  <% site.clusters.each do |cluster| %>
-    <%= link_to "#{cluster.name}: Manage this cluster",
-                cluster_path(cluster),
-                type: "button",
-                class: [
-                  'list-group-item',
-                  'list-group-item-action',
-                  'text-center',
-                  'text-primary'
-                ]
-    %>
+  <div class="card-body row">
+    <div class="col-6 card-text">
+      <h3><%= site.name %></h3>
+      <p><%= site.rendered_description.html_safe %></p>
+
+      <h4>Primary site contact</h4>
+      <ul><li><%= site.primary_contact&.decorate&.info || raw('<em>Unset</em>') %></li></ul>
+
+      <h4>Secondary site <%= 'contact'.pluralize(site.secondary_contacts.length) %></h4>
+      <% if site.secondary_contacts.present? %>
+        <ul>
+          <% site.secondary_contacts.map(&:decorate).each do |contact| %>
+            <li><%= contact.info %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <em>None</em>
+      <% end %>
+
+      <% if site.additional_contacts.present? %>
+
+        <h4>Additional site contacts</h4>
+        <ul>
+          <% site.additional_contacts.each do |contact| %>
+            <li><a href="mailto:<%= contact.email %>"><%= contact.email %></a></li>
+          <% end %>
+        </ul>
+      <% end %>
+  </div>
+  <div class="col">
+    <h3>Clusters</h3>
+    <% site.clusters.each do |cluster| %>
+      <%= link_to "#{cluster.name}: Manage this cluster",
+                  cluster_path(cluster),
+                  type: "button",
+                  class: [
+                    'list-group-item',
+                    'list-group-item-action',
+                    'text-center',
+                    'text-primary'
+                  ]
+      %>
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -30,20 +30,41 @@
         </ul>
       <% end %>
   </div>
-  <div class="col">
-    <h3>Clusters</h3>
-    <% site.clusters.each do |cluster| %>
-      <%= link_to "#{cluster.name}: Manage this cluster",
-                  cluster_path(cluster),
-                  type: "button",
-                  class: [
-                    'list-group-item',
-                    'list-group-item-action',
-                    'text-center',
-                    'text-primary'
-                  ]
-      %>
+    <div class="col">
+      <h3>Clusters</h3>
+      <div class="list-group cluster-list">
+        <% site.clusters.each do |cluster| %>
+          <div class="list-group-item">
+            <h4><%= cluster.name %></h4>
+            <span>
+              <%= link_to "Manage this cluster",
+                          cluster_path(cluster),
+                          type: "button",
+                          class: [
+                            'btn',
+                            'btn-primary'
+                          ]
+              %>
+              <%= link_to "View cases",
+                          cluster_cases_path(cluster),
+                          type: "button",
+                          class: [
+                            'btn',
+                            'btn-primary'
+                          ]
+              %>
+              <%= link_to "Create case",
+                          new_cluster_case_path(cluster),
+                          type: "button",
+                          class: [
+                            'btn',
+                            'btn-danger'
+                          ]
+              %>
+            </span>
+          </div>
+        <% end %>
       </div>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe UserDecorator do
+  describe '#info' do
+    subject do
+      build(
+        :admin,
+        name: 'Lord Adminus',
+        email: 'adminus@example.com'
+      ).decorate
+    end
+
+    it 'renders name, and email as HTML link' do
+      expect(subject.info).to eq 'Lord Adminus (<a href="mailto:adminus@example.com">adminus@example.com</a>)'
+    end
+
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -47,18 +47,6 @@ RSpec.describe Site, type: :model do
     )
   end
 
-  describe '#secondary_contacts_info' do
-    subject { site.secondary_contacts_info }
-
-    it { is_expected.to eq "#{secondary_contact.info}, #{another_secondary_contact.info}" }
-  end
-
-  describe '#additional_contacts_info' do
-    subject { site.additional_contacts_info }
-
-    it { is_expected.to eq "#{additional_contact_1.email}, #{additional_contact_2.email}" }
-  end
-
   describe '#all_contacts' do
     subject { site.all_contacts }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,16 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe '#info' do
-    let :user do
-      create(:user, name: 'Some User', email: 'some.user@example.com')
-    end
-
-    subject { user.info }
-
-    it { is_expected.to eq 'Some User <some.user@example.com>' }
-  end
-
   describe '#secondary_contact?' do
     context 'when User is primary contact' do
       subject { create(:primary_contact).secondary_contact? }


### PR DESCRIPTION
This PR makes some changes to the site dashboard to improve the user experience.

Primarily, it makes more prominent links to each cluster's management dashboard and cases, taking the focus away from the (now renamed) "all site cases" page that was formerly the most obvious.

Site contacts are now listed with clickable email addresses rather than unclickable ones.

I've also taken the opportunity to kill off the Jumbotron page header, replacing it with something a little more compact so that content has a chance of making it "above the fold"; and made some tweaks to the base page layout to reduce the number of empty columns we were rendering.

Trello: https://trello.com/c/bvriA3hT/289-make-site-dashboard-ui-more-intuitive