### PR TITLE
Maintenance window request UI enhancements

### DIFF
--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -74,6 +74,7 @@ class MaintenanceWindowsController < ApplicationController
 
   def default_maintenance_window_params
     {
+      case_id: params[:case_id],
       cluster_id: params[:cluster_id],
       component_id: params[:component_id],
       service_id: params[:service_id],

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -27,8 +27,8 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def request_maintenance_path
-    assoc_class = model.associated_model.class.name.downcase
-    h.send("new_#{assoc_class}_maintenance_window_path", model.associated_model.id, case_id: model.id)
+    assoc_class = model.associated_model.underscored_model_name
+    h.send("new_#{assoc_class}_maintenance_window_path", model.associated_model, case_id: model.id)
   end
 
   def tier_description

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -26,6 +26,11 @@ class CaseDecorator < ApplicationDecorator
     h.boolean_symbol(chargeable)
   end
 
+  def request_maintenance_path
+    assoc_class = model.associated_model.class.name.downcase
+    h.send("new_#{assoc_class}_maintenance_window_path", model.associated_model.id, case_id: model.id)
+  end
+
   def tier_description
     h.tier_description(tier_level)
   end

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -17,7 +17,16 @@
       </tr>
       <tr>
         <th>Association</th>
-        <td><%= @case.association_info %></td>
+        <td>
+          <%= @case.association_info %>
+          <% if current_user.admin? && @case.open? %>
+            <%= link_to 'Request maintenance',
+                        @case.request_maintenance_path,
+                        class: 'btn btn-secondary ml-2 btn-sm',
+                        role: 'button'
+            %>
+          <% end %>
+        </td>
         <th>State</th>
         <td id="case-state-controls">
           <%= @case.user_facing_state %>

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -18,23 +18,28 @@
     <%= f.hidden_field :component_id %>
     <%= f.hidden_field :service_id %>
 
-    <h4>
-      Requesting maintenance for <%= maintenance_window.associated_model.decorate.links %>
-      <% if maintenance_window.associated_model.is_a? Cluster %>
-      (whole cluster)
-      <% end %>
-    </h4>
+    <% if action.request? %>
 
-    <% if maintenance_window.associated_model.is_a? Cluster %>
-      <p class="p-3 bg-warning">
-        <i class="fa fa-warning"></i>
-        Not what you want? Try selecting a
-        <%= link_to 'component', cluster_components_path %>
-        or a
-        <%= link_to 'service', cluster_services_path %>
-        from this cluster.
-      </p>
+      <h4>
+        Requesting maintenance for <%= maintenance_window.associated_model.decorate.links %>
+        <% if maintenance_window.associated_model.is_a? Cluster %>
+        (whole cluster)
+        <% end %>
+      </h4>
+
+      <% if maintenance_window.associated_model.is_a? Cluster %>
+        <p class="p-3 alert alert-warning">
+          <i class="fa fa-warning"></i>
+          Not what you want? Try selecting a
+          <%= link_to 'component', cluster_components_path, class: 'alert-link' %>
+          or a
+          <%= link_to 'service', cluster_services_path, class: 'alert-link' %>
+          from this cluster.
+        </p>
+      <% end %>
+
     <% end %>
+
     <div class="form-group">
       <%= f.label :case_id, case_label, 'data-test': 'case-select-label' %>
       <%= f.collection_select(

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -24,6 +24,17 @@
       (whole cluster)
       <% end %>
     </h4>
+
+    <% if maintenance_window.associated_model.is_a? Cluster %>
+      <p class="p-3 bg-warning">
+        <i class="fa fa-warning"></i>
+        Not what you want? Try selecting a
+        <%= link_to 'component', cluster_components_path %>
+        or a
+        <%= link_to 'service', cluster_services_path %>
+        from this cluster.
+      </p>
+    <% end %>
     <div class="form-group">
       <%= f.label :case_id, case_label, 'data-test': 'case-select-label' %>
       <%= f.collection_select(

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -18,6 +18,7 @@
     <%= f.hidden_field :component_id %>
     <%= f.hidden_field :service_id %>
 
+    <h4>Requesting maintenance for <%= maintenance_window.associated_model.decorate.links %></h4>
     <div class="form-group">
       <%= f.label :case_id, case_label, 'data-test': 'case-select-label' %>
       <%= f.collection_select(

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -18,7 +18,12 @@
     <%= f.hidden_field :component_id %>
     <%= f.hidden_field :service_id %>
 
-    <h4>Requesting maintenance for <%= maintenance_window.associated_model.decorate.links %></h4>
+    <h4>
+      Requesting maintenance for <%= maintenance_window.associated_model.decorate.links %>
+      <% if maintenance_window.associated_model.is_a? Cluster %>
+      (whole cluster)
+      <% end %>
+    </h4>
     <div class="form-group">
       <%= f.label :case_id, case_label, 'data-test': 'case-select-label' %>
       <%= f.collection_select(

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe 'Case page' do
   describe 'maintenance window request' do
 
     RSpec.shared_examples 'does not show maintenance button' do
-      it 'doesn\'t' do # Why does RSpec force you to be quite so verbose? :(
+      it 'doesn\'t show maintenance button' do
         visit case_path(subject, as: user)
         expect do
           find('a', text: 'Request maintenance')
@@ -422,7 +422,7 @@ RSpec.describe 'Case page' do
 
         context 'as a contact' do
           let(:user) { contact }
-          it_behaves_like 'does not show maintenance button'
+          include_examples 'does not show maintenance button'
         end
       end
     end
@@ -435,7 +435,7 @@ RSpec.describe 'Case page' do
 
         let(:user) { admin }
 
-        it_behaves_like 'does not show maintenance button'
+        include_examples 'does not show maintenance button'
       end
     end
   end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -395,4 +395,48 @@ RSpec.describe 'Case page' do
       it_behaves_like 'for inapplicable cases'
     end
   end
+
+  describe 'maintenance window request' do
+
+    RSpec.shared_examples 'does not show maintenance button' do
+      it 'doesn\'t' do # Why does RSpec force you to be quite so verbose? :(
+        visit case_path(subject, as: user)
+        expect do
+          find('a', text: 'Request maintenance')
+        end.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+
+    context 'for an open case' do
+      subject { open_case }
+
+      context 'as an admin' do
+        let(:user) { admin }
+
+        it 'shows button' do
+          visit case_path(subject, as: user)
+
+          request_link = find('a', text: 'Request maintenance')
+          expect(request_link[:href]).to eq new_cluster_maintenance_window_path(cluster, case_id: open_case.id)
+        end
+
+        context 'as a contact' do
+          let(:user) { contact }
+          it_behaves_like 'does not show maintenance button'
+        end
+      end
+    end
+
+    %w(resolved closed).each do |state|
+      context "for a #{state} case" do
+        subject do
+          send("#{state}_case")
+        end
+
+        let(:user) { admin }
+
+        it_behaves_like 'does not show maintenance button'
+      end
+    end
+  end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -158,6 +158,10 @@ RSpec.feature "Maintenance windows", type: :feature do
       include_examples 'maintenance form error handling', 'request'
       include_examples 'maintenance form initially valid'
 
+      it 'displays the component for which maintenance is being requested' do
+        expect(find('h4').text).to eq "Requesting maintenance for #{component.name} (#{cluster.name})"
+      end
+
       it 'uses correct default values' do
         a_distant_friday = Time.zone.local(2025, 3, 7, 0, 0)
         following_monday_at_9 = a_distant_friday.advance(days: 3, hours: 9)

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -330,6 +330,22 @@ RSpec.feature "Maintenance windows", type: :feature do
 
       expect(page).not_to have_button(extend_button_text)
     end
+
+    context 'when maintenance is for the entire cluster' do
+      subject do
+        create(
+            :requested_maintenance_window,
+            cluster: cluster,
+            case: support_case
+        )
+      end
+
+      it 'shows the entire-cluster-warning message' do
+        visit new_cluster_maintenance_window_path(id: subject.id, cluster_id: cluster.id, as: user)
+
+        expect(find('p.alert-warning').text).to match 'Not what you want? Try selecting a component or a service from this cluster.'
+      end
+    end
   end
 
   context 'when user is contact' do
@@ -444,6 +460,24 @@ RSpec.feature "Maintenance windows", type: :feature do
       visit cluster_maintenance_windows_path(cluster, as: user)
 
       expect(page).not_to have_button(extend_button_text)
+    end
+
+    context 'when maintenance is for the entire cluster' do
+      subject do
+        create(
+            :requested_maintenance_window,
+            cluster: cluster,
+            case: support_case
+        )
+      end
+
+      it 'does not show the entire-cluster-warning message' do
+        visit confirm_cluster_maintenance_window_path(id: subject.id, cluster_id: cluster.id, as: user)
+
+        expect do
+          find('p.alert-warning')
+        end.to raise_error(Capybara::ElementNotFound)
+      end
     end
   end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -332,16 +332,8 @@ RSpec.feature "Maintenance windows", type: :feature do
     end
 
     context 'when maintenance is for the entire cluster' do
-      subject do
-        create(
-            :requested_maintenance_window,
-            cluster: cluster,
-            case: support_case
-        )
-      end
-
       it 'shows the entire-cluster-warning message' do
-        visit new_cluster_maintenance_window_path(id: subject.id, cluster_id: cluster.id, as: user)
+        visit new_cluster_maintenance_window_path(cluster_id: cluster.id, as: user)
 
         expect(find('p.alert-warning').text).to match 'Not what you want? Try selecting a component or a service from this cluster.'
       end


### PR DESCRIPTION
This PR makes some low-hanging-fruit changes to requesting maintenance windows (MWs) (relating to #233).

- Cases now have a button linking directly to a MW request form for the component/service/cluster associated with that case, and with the appropriate case pre-selected.
- The MW form now tells you what you're about to request maintenance for
- The MW form has a big orange warning if you try and request maintenance for an entire cluster, and suggests that you might want a service or component instead

Trello: https://trello.com/c/XIf3w3zB/290-make-maintenance-request-process-more-intuitive