### PR TITLE
Show a more accurate message disabling commenting on non-open cases.

### DIFF
--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -31,6 +31,19 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def commenting_disabled?
-    current_user.contact? && !consultancy?
+    !open? || (current_user.contact? && !consultancy?)
+  end
+
+  def commenting_disabled_text
+    if !open?
+      "Commenting is disabled as this case is #{state}."
+    elsif current_user.contact? && !consultancy?
+      <<~TITLE.squish
+            This is a non-consultancy support case and so additional discussion is
+            not available. If you wish to request additional support please either
+            escalate this case (which may incur a charge), or open a
+            new support case.
+      TITLE
+    end
   end
 end

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -31,7 +31,7 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def commenting_disabled?
-    !open? || (current_user.contact? && !consultancy?)
+    commenting_disabled_text.present?
   end
 
   def commenting_disabled_text

--- a/app/views/case_comments/_form.html.erb
+++ b/app/views/case_comments/_form.html.erb
@@ -1,60 +1,28 @@
+<% if @case.commenting_disabled? %>
 
-<%
-  disabled_message_text = <<~TITLE.squish
-            This is a non-consultancy support case and so additional discussion is
-            not available. If you wish to request additional support please open a
-            new support case.
-  TITLE
-  additional_attributes =
-    if @case.commenting_disabled?
-      {
-        disabled: true,
-        title: disabled_message_text
-      }
-    else
-      {}
-    end
+ <div class="card bg-light">
+   <div class="card-body">
+     <span class="float-left mr-3">
+       <%= icon('info') %>
+     </span>
+     <%= @case.commenting_disabled_text %>
+   </div>
+ </div>
 
-%>
-
-<% if @case.state == 'open' %>
-
-  <% if @case.commenting_disabled? %>
-     <div class="card bg-light">
-       <div class="card-body">
-         <span class="float-left mr-3">
-           <%= icon('info') %>
-         </span>
-         <%= disabled_message_text %>
-       </div>
-     </div>
-  <% end %>
+<% else %>
 
   <%= form_for [@case, @comment] do |f| %>
     <div class="form-group">
       <%= f.text_area :text,
             class: 'form-control',
-            rows: 3,
-            **additional_attributes
+            rows: 3
       %>
     </div>
     <div class="form-group" style="overflow: hidden;">
       <%= f.submit "Add new comment",
-        class: 'btn btn-primary float-right',
-        **additional_attributes
+        class: 'btn btn-primary float-right'
       %>
     </div>
   <% end %>
-
-<% else %>
-
-  <div class="card bg-light">
-     <div class="card-body">
-       <span class="float-left mr-3">
-         <%= icon('info') %>
-       </span>
-       Commenting is disabled as this case is <%= @case.state %>.
-     </div>
-  </div>
 
 <% end %>

--- a/app/views/case_comments/_form.html.erb
+++ b/app/views/case_comments/_form.html.erb
@@ -17,18 +17,19 @@
 
 %>
 
-<% if @case.commenting_disabled? %>
-   <div class="card bg-light">
-     <div class="card-body">
-       <span class="float-left mr-3">
-         <%= icon('info') %>
-       </span>
-       <%= disabled_message_text %>
-     </div>
-   </div>
-<% end %>
-
 <% if @case.state == 'open' %>
+
+  <% if @case.commenting_disabled? %>
+     <div class="card bg-light">
+       <div class="card-body">
+         <span class="float-left mr-3">
+           <%= icon('info') %>
+         </span>
+         <%= disabled_message_text %>
+       </div>
+     </div>
+  <% end %>
+
   <%= form_for [@case, @comment] do |f| %>
     <div class="form-group">
       <%= f.text_area :text,
@@ -44,4 +45,16 @@
       %>
     </div>
   <% end %>
+
+<% else %>
+
+  <div class="card bg-light">
+     <div class="card-body">
+       <span class="float-left mr-3">
+         <%= icon('info') %>
+       </span>
+       Commenting is disabled as this case is <%= @case.state %>.
+     </div>
+  </div>
+
 <% end %>

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -173,11 +173,15 @@ RSpec.describe 'Case page' do
       visit case_path(open_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
 
+      # Observe that case state overrides case tier in terms of why we report commenting
+      # being disabled.
       visit case_path(resolved_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+      expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is resolved.'
 
       visit case_path(closed_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+      expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is closed.'
     end
 
     it 'shows or hides add comment form for admins' do
@@ -197,9 +201,11 @@ RSpec.describe 'Case page' do
 
       visit case_path(resolved_case, as: admin)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+      expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is resolved.'
 
       visit case_path(closed_case, as: admin)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
+      expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is closed.'
     end
   end
 

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -280,6 +280,27 @@ RSpec.describe 'Case page' do
       expect(find('.alert')).to have_text('Empty comments are not permitted')
     end
 
+    %w(resolved closed).each do |state|
+      context "for a #{state} case" do
+        subject { create("#{state}_case".to_sym, cluster: cluster, tier_level: 3) }
+
+        it 'does not allow commenting by site contact' do
+          visit case_path(subject, as: contact)
+          expect do
+            find('textarea')
+          end.to raise_error(Capybara::ElementNotFound)
+        end
+
+        it 'does not allow commenting by admin' do
+          visit case_path(subject, as: admin)
+          expect do
+            find('textarea')
+          end.to raise_error(Capybara::ElementNotFound)
+        end
+
+      end
+    end
+
   end
 
   describe 'time logging' do


### PR DESCRIPTION
Previously, a resolved or closed tier-2 case would erroneously display a "you can't comment because it's tier 2" message to contacts.

Now, a resolved or closed case of any tier displays a "you can't comment because it's resolved" (or closed) message to all users, and only open tier-2 cases display the former message (still only to contacts).

Trello: https://trello.com/c/kEw2MVZ3/294-should-we-still-show-the-additional-discussion-unavailable-box-for-tier-1-2-cases-when-the-case-is-not-open-and-so-additional-di