### PR TITLE
Display table headers on a single line

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,11 +97,11 @@ body {
   }
 }
 
-table {
-  .shrink {
-    white-space: nowrap;
-  }
+.nowrap {
+  white-space: nowrap;
+}
 
+table {
   .expand {
     width: 99%
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,7 +51,7 @@ module ApplicationHelper
       <<~EOF.strip_heredoc
         <td
           title="#{description} on #{timestamp.to_formatted_s(:long)}"
-          style="white-space: nowrap;"
+          class="nowrap"
         >
           #{timestamp.to_formatted_s(:short)}
         </td>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -5,7 +5,7 @@ end %>
   <div class='table-responsive'>
     <table class="table">
       <thead>
-        <tr>
+        <tr class="shrink">
           <th>ID</th>
           <th>Date</th>
           <th>State</th>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -5,7 +5,7 @@ end %>
   <div class='table-responsive'>
     <table class="table">
       <thead>
-        <tr class="shrink">
+        <tr class="nowrap">
           <th>ID</th>
           <th>Date</th>
           <th>State</th>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -54,7 +54,7 @@
               <table class="table table-sm table-striped table-bordered">
                 <% @case.fields.each do |field| %>
                   <tr>
-                    <th scope="row" class="shrink">
+                    <th scope="row" class="nowrap">
                       <%= field.fetch('name') %>
                     </th>
                     <td class="expand">

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -12,7 +12,7 @@
       <% @logs.each do |log| %>
         <tr>
           <%= timestamp_td(description:  'Logged', timestamp: log.created_at) %>
-          <td style="white-space: nowrap;"><%= log.engineer.name %></td>
+          <td class="nowrap"><%= log.engineer.name %></td>
           <td><%= log.details %></td>
           <td>
             <%= log.component&.decorate&.link || raw("<em>None</em>") %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -6,7 +6,7 @@
       timestamp: kase.created_at
     ) %>
     <td><%= kase.user_facing_state %></td>
-    <td style="white-space: nowrap;"><%= kase.user.name %></td>
+    <td class="nowrap"><%= kase.user.name %></td>
     <td><%= link_to kase.subject, case_path(kase) %></td>
     <td>
       <% if current_user == kase.assignee %>


### PR DESCRIPTION
This PR forces the table headers on `Case` pages to display on a single line. Previously they would wrap to a new line to display the second word of `Assigned to` and `Credit usage`. This had the effect of pushing the table content down slightly and as the headers are not massively long seemed unnecessary.

[Trello](https://trello.com/c/8aPaLSua/301-display-table-headers-on-a-single-line)