### PR TITLE
MOTD tool submission

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -118,6 +118,7 @@ class CasesController < ApplicationController
       :subject,
       :tier_level,
       fields: [:type, :name, :value, :optional, :help],
+      tool_fields: {}
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  # Note: These should match values used in `Tier.Level.description` in Case
+  # form app.
+  TIER_DESCRIPTIONS = {
+      1 => 'Tool',
+      2 => 'Routine Maintenance',
+      3 => 'General Support',
+  }.freeze
+
   def icon(name, interactive: false, inline: false, **args)
     classes = [
       (inline ? 'inline-icon' : 'fa-2x'),
@@ -50,13 +58,6 @@ module ApplicationHelper
       EOF
     )
   end
-  # Note: These should match values used in `Tier.Level.description` in Case
-  # form app.
-  TIER_DESCRIPTIONS = {
-      1 => 'Tool',
-      2 => 'Routine Maintenance',
-      3 => 'General Support',
-  }.freeze
 
   def tier_description(tier_level)
     unless TIER_DESCRIPTIONS.has_key?(tier_level)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,6 +66,10 @@ module ApplicationHelper
     "#{tier_level} (#{description})"
   end
 
+  def simple_format_if_needed(text)
+    text.include?("\n") ? simple_format(text) : text
+  end
+
   private
 
   # Map function with given name over enumerable collection of objects, then

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -195,7 +195,7 @@ encoder state =
                 , ( "service_id", serviceIdValue )
                 , ( "subject", Issue.subject issue |> E.string )
                 , ( "tier_level", Tier.Level.asInt tier.level |> E.int )
-                , ( "fields", Tier.fieldsEncoder tier )
+                , Tier.encodeContentPair tier
                 ]
           )
         ]

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -4,9 +4,9 @@ module Tier
         , Id(..)
         , Tier
         , decoder
+        , encodeContentPair
         , extractId
         , fields
-        , fieldsEncoder
         , isChargeable
         , setFieldValue
         )
@@ -114,20 +114,22 @@ motdTool clusterMotd =
     MotdTool fields
 
 
-fieldsEncoder : Tier -> E.Value
-fieldsEncoder tier =
+encodeContentPair : Tier -> ( String, E.Value )
+encodeContentPair tier =
     case tier.content of
         Fields fields ->
-            E.array
+            ( "fields"
+            , E.array
                 (Dict.values fields
                     |> List.map Field.encoder
                     |> Maybe.Extra.values
                     |> Array.fromList
                 )
+            )
 
         MotdTool _ ->
             -- XXX Do something useful
-            E.null
+            ( "tool_fields", E.null )
 
 
 extractId : Tier -> Int

--- a/app/javascript/packs/Tier.elm
+++ b/app/javascript/packs/Tier.elm
@@ -127,9 +127,24 @@ encodeContentPair tier =
                 )
             )
 
-        MotdTool _ ->
-            -- XXX Do something useful
-            ( "tool_fields", E.null )
+        MotdTool fields ->
+            let
+                motdFieldValue =
+                    Dict.values fields
+                        |> List.head
+                        |> Maybe.map Field.data
+                        |> Maybe.Extra.join
+                        |> Maybe.map (.value >> E.string)
+                        -- Should never happen, but this should cause an
+                        -- obvious error if it ever somehow does.
+                        |> Maybe.withDefault E.null
+            in
+            ( "tool_fields"
+            , E.object
+                [ ( "type", E.string "motd" )
+                , ( "motd", motdFieldValue )
+                ]
+            )
 
 
 extractId : Tier -> Int

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -14,7 +14,6 @@ import Html.Events exposing (onClick)
 import Msg exposing (..)
 import State exposing (State)
 import Tier
-import View.Utils
 
 
 chargeableAlert : State -> Maybe (Html Msg)

--- a/app/mailer_previews/case_mailer_preview.rb
+++ b/app/mailer_previews/case_mailer_preview.rb
@@ -23,6 +23,6 @@ class CaseMailerPreview < ApplicationMailerPreview
   private
 
   def get_case
-    @case_id ? Case.find(@case_id) : Case.last
+    @case_id ? Case.find_from_id!(@case_id) : Case.last
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -29,7 +29,7 @@ class Case < ApplicationRecord
   has_many :maintenance_windows
   has_and_belongs_to_many :log
   has_many :case_comments
-  has_one :change_motd_request, required: false
+  has_one :change_motd_request, required: false, autosave: true
 
   has_many :case_state_transitions
   alias_attribute :transitions, :case_state_transitions

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -269,6 +269,12 @@ class Case < ApplicationRecord
     @tier_level_changed = false
   end
 
+  def tool_fields=(tool_hash)
+    tool_hash = tool_hash.deep_symbolize_keys
+    tool_type = tool_hash.fetch(:type).to_sym
+    handle_tool(tool_type, fields: tool_hash)
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and
@@ -381,5 +387,16 @@ class Case < ApplicationRecord
       f = f.with_indifferent_access
       [f.fetch(:name), f.fetch(:value)]
     end.to_h.symbolize_keys
+  end
+
+  def handle_tool(type, fields:)
+    case type
+    when :motd
+      self.build_change_motd_request(
+        fields.slice(:motd)
+      )
+    else
+      raise "Unknown type: '#{type}'"
+    end
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -61,7 +61,11 @@ class Case < ApplicationRecord
   validates :token, presence: true
   validates :subject, presence: true
   validates :rt_ticket_id, uniqueness: true, if: :rt_ticket_id
-  validates :fields, presence: true
+
+  validates :fields,
+    presence: {unless: :change_motd_request},
+    absence: {if: :change_motd_request}
+  validates_absence_of :change_motd_request, if: :fields
 
   validates :tier_level,
     presence: true,

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -231,6 +231,7 @@ class Case < ApplicationRecord
       'Associated service': service&.name,
       Tier: decorate.tier_description,
       Fields: field_hash,
+      'Requested MOTD': change_motd_request&.motd
     }.reject { |_k, v| v.nil? }
   end
 
@@ -383,6 +384,7 @@ class Case < ApplicationRecord
   end
 
   def field_hash
+    return nil unless fields
     fields.map do |f|
       f = f.with_indifferent_access
       [f.fetch(:name), f.fetch(:value)]

--- a/app/views/case_mailer/new_case.html.erb
+++ b/app/views/case_mailer/new_case.html.erb
@@ -10,7 +10,7 @@
         <% value.each do |k, v| %>
           <li>
             <strong><%= k %>:</strong>
-          <%= v.include?("\n") ? simple_format(v) : v %>
+          <%= simple_format_if_needed(v) %>
           </li>
         <% end %>
       </ul>

--- a/app/views/case_mailer/new_case.html.erb
+++ b/app/views/case_mailer/new_case.html.erb
@@ -15,7 +15,7 @@
         <% end %>
       </ul>
     <% else %>
-      <%= value %>
+      <%= simple_format_if_needed(value) %>
     <% end %>
     <br/>
   <% end %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -47,23 +47,28 @@
         <td><%= @case.display_id %></td>
       </tr>
       <tr>
-        <th>Fields</th>
-        <td colspan="3">
-          <div class="table-responsive">
-            <table class="table table-sm table-striped table-bordered">
-              <% @case.fields.each do |field| %>
-                <tr>
-                  <th scope="row" class="shrink">
-                    <%= field.fetch('name') %>
-                  </th>
-                  <td class="expand">
-                    <%= simple_format(field.fetch('value')) %>
-                  </td>
-                </tr>
-              <% end%>
-            </table>
-          </div>
-        </td>
+        <% if @case.fields %>
+          <th>Fields</th>
+          <td colspan="3">
+            <div class="table-responsive">
+              <table class="table table-sm table-striped table-bordered">
+                <% @case.fields.each do |field| %>
+                  <tr>
+                    <th scope="row" class="shrink">
+                      <%= field.fetch('name') %>
+                    </th>
+                    <td class="expand">
+                      <%= simple_format(field.fetch('value')) %>
+                    </td>
+                  </tr>
+                <% end%>
+              </table>
+            </div>
+          </td>
+        <% elsif @case.change_motd_request %>
+          <th>Requested MOTD</th>
+          <td><%= simple_format(@case.change_motd_request.motd) %></td>
+        <% end %>
       </tr>
       <%= render 'cases/time_worked' %>
       <tr>

--- a/config/initializers/vcr.rb
+++ b/config/initializers/vcr.rb
@@ -4,7 +4,7 @@ return unless defined?(VCR)
 VCR.configure do |c|
   # Have VCR cassettes be regenerated occasionally, as a last guard against
   # these getting out of date with actual APIs.
-  c.default_cassette_options = { :re_record_interval => 30.days }
+  c.default_cassette_options = { :re_record_interval => 90.days }
 
   # Log most recent debug output from VCR here.
   c.debug_logger = File.open('log/vcr.log', 'w')

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -94,6 +94,11 @@ FactoryBot.define do
 
     factory :level_1_tier do
       level 1
+
+      factory :tier_with_tool do
+        tool :motd
+        fields { nil }
+      end
     end
   end
 

--- a/spec/features/case_form_spec.rb
+++ b/spec/features/case_form_spec.rb
@@ -77,4 +77,24 @@ RSpec.describe 'Case form', type: :feature, js: true do
 
     it_behaves_like 'it allows Case creation'
   end
+
+  describe 'motd tool' do
+    let! :tier do
+      create(:tier_with_tool, issue: issue, tool: :motd)
+    end
+
+    it 'allows creation of Case with associated ChangeMotdRequest' do
+      motd = 'My new MOTD'
+
+      visit new_case_path(as: user)
+      fill_in 'New MOTD', with: motd
+      expect do
+        click_button 'Create Case'
+      end.to change { cluster.reload.cases.length }.by(1)
+
+      new_case = cluster.cases.first
+      expect(new_case.fields).to be_nil
+      expect(new_case.change_motd_request.motd).to eq(motd)
+    end
+  end
 end

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -102,6 +102,25 @@ RSpec.describe 'Case page' do
   let :comment_form_class { '#new_case_comment' }
   let :comment_button_text { 'Add new comment' }
 
+  describe 'data display' do
+    it 'shows table of fields for Case with fields' do
+      field_name = 'Some field'
+      field_value = 'Some value'
+      kase = create(
+        :case,
+        fields: [{name: field_name, value: field_value}],
+        cluster: cluster
+      )
+
+      visit case_path(kase, as: contact)
+
+      header_text = all('th').map(&:text)
+      expect(header_text).to include(field_name)
+      data_text = all('td').map(&:text)
+      expect(data_text).to include(field_value)
+    end
+  end
+
   describe 'events list' do
     it 'shows events in reverse chronological order' do
       create(:case_comment, case: open_case, user: admin, created_at: 2.hours.ago, text: 'Second')

--- a/spec/features/cases_spec.rb
+++ b/spec/features/cases_spec.rb
@@ -119,6 +119,21 @@ RSpec.describe 'Case page' do
       data_text = all('td').map(&:text)
       expect(data_text).to include(field_value)
     end
+
+    it 'shows requested MOTD for Case with associated ChangeMotdRequest' do
+      motd = 'Some new MOTD'
+      kase = create(
+        :case,
+        fields: nil,
+        cluster: cluster,
+        change_motd_request: build(:change_motd_request, motd: motd),
+      )
+
+      visit case_path(kase, as: contact)
+
+      data_text = all('td').map(&:text)
+      expect(data_text).to include(motd)
+    end
   end
 
   describe 'events list' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -38,5 +38,23 @@ RSpec.describe ApplicationHelper do
       expect(boolean_symbol(false)).to eq(raw('&cross;'))
     end
   end
+
+  describe '#simple_format_if_needed' do
+    it 'simple_formats multi-line text' do
+      text = "my\ntext"
+
+      result  = simple_format_if_needed(text)
+
+      expect(result).to eq(simple_format(text))
+    end
+
+    it 'does not simple_format single line text' do
+      text = "my text"
+
+      result  = simple_format_if_needed(text)
+
+      expect(result).to eq(text)
+    end
+  end
 end
 

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Case, type: :model do
   describe '#valid?' do
     subject { create(:case) }
 
-    it { is_expected.to validate_presence_of(:fields) }
     it { is_expected.to validate_presence_of(:tier_level) }
     it { is_expected.to have_one(:change_motd_request) }
 
@@ -15,6 +14,32 @@ RSpec.describe Case, type: :model do
         .only_integer
         .is_greater_than_or_equal_to(1)
         .is_less_than_or_equal_to(3)
+    end
+
+    describe 'fields validation' do
+      it { is_expected.to validate_presence_of(:fields) }
+
+      context 'when has fields' do
+        subject do
+          build(:case, fields: [{type: 'input', name: 'Some field'}])
+        end
+
+        it { is_expected.to validate_absence_of(:change_motd_request) }
+        it { is_expected.to be_valid }
+      end
+
+      context 'when has change_mode_request' do
+        subject do
+          build(
+            :case,
+            fields: nil,
+            change_motd_request: build(:change_motd_request)
+          )
+        end
+
+        it { is_expected.to validate_absence_of(:fields) }
+        it { is_expected.to be_valid }
+      end
     end
   end
 

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Case, type: :model do
   let :random_token_regex { /[A-Z][0-9][A-Z][0-9][A-Z]/ }
 
+  it { is_expected.to have_one(:change_motd_request).autosave(true) }
+
   describe '#valid?' do
     subject { create(:case) }
 

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -270,6 +270,14 @@ RSpec.describe Case, type: :model do
     let(:component) { create(:component, name: 'node01', cluster: cluster) }
     let(:service) { create(:service, name: 'Some service', cluster: cluster) }
 
+    let :fields do
+      [
+        {name: 'field1', value: 'value1'},
+        {name: 'field2', value: 'value2', optional: true},
+      ]
+    end
+    let :change_motd_request { nil }
+
     let(:kase) {
       create(
         :case,
@@ -281,10 +289,8 @@ RSpec.describe Case, type: :model do
         user: requestor,
         subject: 'my_subject',
         tier_level: 3,
-        fields: [
-          {name: 'field1', value: 'value1'},
-          {name: 'field2', value: 'value2', optional: true},
-        ]
+        fields: fields,
+        change_motd_request: change_motd_request,
       )
     }
 
@@ -320,6 +326,20 @@ RSpec.describe Case, type: :model do
 
       it 'does not include corresponding line' do
         expect(kase.email_properties).not_to include(:'Associated service')
+      end
+    end
+
+    context 'when Case has ChangeMotdRequest rather than fields' do
+      let :fields { nil }
+
+      let :motd { 'My new MOTD' }
+      let :change_motd_request do
+        build(:change_motd_request, motd: motd)
+      end
+
+      it 'includes requested MOTD and not fields' do
+        expect(kase.email_properties).to include(:'Requested MOTD' => motd)
+        expect(kase.email_properties).not_to include(:Fields)
       end
     end
   end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -391,4 +391,47 @@ RSpec.describe Case, type: :model do
       end
     end
   end
+
+  describe '#tool_fields=' do
+    subject do
+      build(:case, fields: nil)
+    end
+
+    let :motd_tool_fields {
+      {
+        type: 'motd',
+        motd: motd_field,
+      }
+    }
+    let :motd_field { 'New MOTD' }
+
+
+    it 'also works when keys are strings' do
+      stringified_tool_fields = motd_tool_fields.deep_stringify_keys
+      subject.tool_fields = stringified_tool_fields
+
+      expect(subject.change_motd_request).not_to be_nil
+    end
+
+    context "when given hash with type field 'motd'" do
+      it "builds ChangeMotdRequest from given 'motd' field" do
+        subject.tool_fields = motd_tool_fields
+
+        expect(subject.change_motd_request).not_to be_nil
+        expect(subject.change_motd_request.motd).to eq motd_field
+        expect(subject.change_motd_request).to be_valid
+        # Should initially be unsaved, and should be saved iff the Case itself
+        # is successfully saved.
+        expect(subject.change_motd_request).not_to be_persisted
+      end
+    end
+
+    context "when given hash with unknown type field" do
+      it "raises error" do
+        expect do
+          subject.tool_fields = { type: 'foo' }
+        end.to raise_error("Unknown type: 'foo'")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR implements handling of submission from the MOTD tool within the Case form app; in brief this involves:

- appropriately encoding the data for this within the Case form app;

- decoding and handling this data appropriately within Rails, to create a `ChangeMotdRequest` along with the new `Case`;

- handling displaying of these Cases appropriately within both emails and the Case table on the Case page.

This has all been done in such a way that it should be comparatively straightforward to slot handling for future Tier 1 tools into this process. 

Trello: https://trello.com/c/7b2HzqKz/284-handle-submission-of-motd-tool-appropriately.