### PR TITLE
Staging email changes

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -6,7 +6,7 @@ class ApplicationMailer < ActionMailer::Base
   include Roadie::Rails::Automatic
   extend Alces::Mailer::Resender
 
-  default from: 'Alces Flight Center <center@alces-flight.com>'
+  default from: "#{Rails.application.config.email_app_name} <center@alces-flight.com>"
   layout 'mailer'
   helper 'mailer'
   helper 'application'

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module AlcesFlightCenter
 
     config.active_job.queue_adapter = :resque
 
+    config.email_app_name = ENV['EMAIL_APP_NAME'] || 'Alces Flight Center'
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -36,8 +36,7 @@ namespace :alces do
         staging_password = Deployment::Staging.password
 
         User.where(admin: false).each do |user|
-          email_base = user.email.split('@').first
-          new_email = "#{email_base}@alces-software.com"
+          new_email = "center+#{user.name.gsub(/ /, '')}@alces-software.com"
           user.update!(email: new_email, password: staging_password)
         end
       end

--- a/spec/lib/tasks/deploy_spec.rb
+++ b/spec/lib/tasks/deploy_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'alces:deploy:staging:obfuscate_user_data' do
   it 'changes contacts to have `@alces-software.com` emails' do
     subject.invoke
 
-    expect(contact.reload.email).to eq 'some.contact@alces-software.com'
+    expect(contact.reload.email).to eq 'center+somecontact@alces-software.com'
   end
 
   it 'sets contact passwords to STAGING_PASSWORD environment variable' do


### PR DESCRIPTION
This PR makes a couple of small email-related changes:

- The anonymisation process for deploying staging now changes contact email addresses to `center+$username@alces-software.com`, where `$username` is the contact `User`'s `name` with spaces removed.

- Emails sent from staging can now be distinguished from those sent by production, by setting the `EMAIL_APP_NAME` environment variable to something distinct e.g. `(Staging) Alces Flight Center` in staging.

Trello: https://trello.com/c/nYyOlva8/295-staging-email-tweaks