### PR TITLE
Display the number of cases in dropdown and subtitle

### DIFF
--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -4,13 +4,26 @@ class AllSitesDecorator < ApplicationDecorator
   def tabs
     [
       { id: :all_sites, path: h.root_path },
-      {
-        id: :cases, text: 'All Cases', path: h.cases_path,
-        dropdown: [
-          { text: 'Current', path: h.cases_path },
-          { text: 'Resolved', path: h.resolved_cases_path }
-        ]
-      }
+      cases_tab
     ]
+  end
+
+  private
+
+  def cases_tab
+    tabs_builder.cases.merge(text: 'All Cases').tap do |tab|
+      tab[:dropdown] = tab[:dropdown].reject do |item|
+        item[:text] == 'Create'
+      end
+    end
+  end
+
+  # We override these to generate the top level path names
+  def scope_name_for_paths
+    ''
+  end
+
+  def arguments_for_scope_path(*a)
+    a
   end
 end

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -13,7 +13,7 @@ module TabsHelper
         id: :cases, path: scope.scope_cases_path,
         dropdown: [
           { text: 'Create', path: scope.new_scope_case_path },
-          { text: 'Current', path: scope.scope_cases_path },
+          { text: "Current (#{scope.cases.active.size})", path: scope.scope_cases_path },
           { text: 'Resolved', path: scope.resolved_scope_cases_path }
         ]
       }

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -118,6 +118,7 @@ class Case < ApplicationRecord
   after_update :maybe_send_new_assignee_email
 
   scope :active, -> { where(state: 'open') }
+  scope :inactive, -> { where.not(state: 'open') }
 
   scope :assigned_to, ->(user) { where(assignee: user) }
   scope :not_assigned_to, ->(user) { where.not(assignee: user).or(where(assignee: nil)) }

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,5 +1,8 @@
+<%
+  cases = @show_resolved ? @scope.cases.inactive : @scope.cases.active
+%>
 <%= content_for :subtitle do
-  "#{@show_resolved ? 'Resolved' : 'Open'} Cases"
+  "#{cases.length} #{@show_resolved ? 'Resolved' : 'Open'} Cases"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
   <div class='table-responsive'>
@@ -20,14 +23,14 @@ end %>
       </thead>
 
       <tbody class="assigned-cases">
-        <% @scope.cases.assigned_to(current_user).decorate.each do |c| %>
-          <%= render 'partials/case_table_row', kase: c, show_resolved: @show_resolved %>
+        <% cases.assigned_to(current_user).decorate.each do |c| %>
+          <%= render 'partials/case_table_row', kase: c %>
         <% end %>
       </tbody>
 
       <tbody>
-        <% @scope.cases.not_assigned_to(current_user).decorate.each do |c| %>
-          <%= render 'partials/case_table_row', kase: c, show_resolved: @show_resolved %>
+        <% cases.not_assigned_to(current_user).decorate.each do |c| %>
+          <%= render 'partials/case_table_row', kase: c %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,23 +1,21 @@
-<% if show_resolved != kase.open?  %>
-  <tr>
-    <td><%= link_to kase.display_id, case_path(kase) %></td>
-    <%= timestamp_td(
-      description:  'Support case created',
-      timestamp: kase.created_at
-    ) %>
-    <td><%= kase.user_facing_state %></td>
-    <td class="nowrap"><%= kase.user.name %></td>
-    <td><%= link_to kase.subject, case_path(kase) %></td>
-    <td>
-      <% if current_user == kase.assignee %>
-        <%= raw('<strong>Me</strong>') %>
-      <% else %>
-        <%= kase.assignee&.name || 'Nobody' %>
-      <% end %>
-    </td>
-    <td><%= kase.association_info %></td>
-    <% if show_resolved %>
-      <td><%= kase.credit_charge %></td>
+<tr>
+  <td><%= link_to kase.display_id, case_path(kase) %></td>
+  <%= timestamp_td(
+    description:  'Support case created',
+    timestamp: kase.created_at
+  ) %>
+  <td><%= kase.user_facing_state %></td>
+  <td style="white-space: nowrap;"><%= kase.user.name %></td>
+  <td><%= link_to kase.subject, case_path(kase) %></td>
+  <td>
+    <% if current_user == kase.assignee %>
+      <%= raw('<strong>Me</strong>') %>
+    <% else %>
+      <%= kase.assignee&.name || 'Nobody' %>
     <% end %>
-  </tr>
-<% end %>
+  </td>
+  <td><%= kase.association_info %></td>
+  <% if kase.resolved? || kase.closed? %>
+    <td><%= kase.credit_charge %></td>
+  <% end %>
+</tr>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -5,7 +5,8 @@
       <li class="list-group-item">
         <%= link_to site.name, site_path(site) %>
         &mdash;
-        <%= link_to 'Manage Support Cases', site_cases_path(site) %>
+        <%= link_to "Manage Support Cases (#{site.cases.active.size})",
+            site_cases_path(site) %>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
This PR implements showing the total number of cases for a page in various places. On the page itself it will state how many cases there are in the format `# <case_state> Cases` e.g. `13 Open Cases`. 

However in the `Cases` dropdown menu a number will also be displayed in brackets next to `Current`. This is only done for `Current` and not `Resolved` as the number of resolved/closed cases will be racking up ad finem so displaying this within the dropdown seems unnecessary and unhelpful. 

Whereas showing the total number of open cases within the dropdown is potentially useful for seeing if there are any, and how many, open cases available. But it is still nice to have a record of the total number of resolved/closes cases within the subtitle of the page itself.

[Trello](https://trello.com/c/K7I7g3gw/95-indicate-number-of-cases-in-various-cases-tables)