### PR TITLE
Move cluster documents to their own tab

### DIFF
--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -1,3 +1,6 @@
 class ClustersController < ApplicationController
   decorates_assigned :cluster
+
+  def documents
+  end
 end

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -15,6 +15,7 @@ class ClusterDecorator < ApplicationDecorator
   def tabs
     [
       tabs_builder.overview,
+      documents.empty? ? nil :{ id: :documents, path: h.cluster_documents_path(self) },
       tabs_builder.logs,
       tabs_builder.cases,
       tabs_builder.maintenance,
@@ -28,7 +29,7 @@ class ClusterDecorator < ApplicationDecorator
           }
         end.push(text: 'All', path: h.cluster_components_path(self))
       }
-    ]
+    ].compact
   end
 
   def case_form_json

--- a/app/views/clusters/documents.html.erb
+++ b/app/views/clusters/documents.html.erb
@@ -1,14 +1,12 @@
 <% content_for(:subtitle) { 'Documents' } %>
 <%= render 'partials/tabs', activate: :documents do %>
-  <div class='card'>
-    <ul class="list-group list-group-flush">
-      <% cluster.documents.each do |document| %>
-        <li class="list-group-item">
-          <%= link_to document.name, document.url, target: '_blank' %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <ul class="list-group list-group-flush">
+    <% cluster.documents.each do |document| %>
+      <li class="list-group-item">
+        <%= link_to document.name, document.url, target: '_blank' %>
+      </li>
+    <% end %>
+  </ul>
 <% end %>
 
 

--- a/app/views/clusters/documents.html.erb
+++ b/app/views/clusters/documents.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:subtitle) { 'Documents' } %>
+<%= render 'partials/tabs', activate: :documents do %>
+  <div class='card'>
+    <ul class="list-group list-group-flush">
+      <% cluster.documents.each do |document| %>
+        <li class="list-group-item">
+          <%= link_to document.name, document.url, target: '_blank' %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,7 @@ Rails.application.routes.draw do
       resources :components, only: :index
       logs.call
       confirm_maintenance_form.call
+      get 'documents', controller: :clusters, action: :documents
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,7 @@ Rails.application.routes.draw do
       resources :components, only: :index
       logs.call
       confirm_maintenance_form.call
-      get 'documents', controller: :clusters, action: :documents
+      get :documents
     end
 
     resources :components, only: :show do

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -6,15 +6,16 @@ RSpec.describe 'cluster tabs', type: :feature do
 
   let :tabs { page.find('ul.nav-tabs') }
   let :maintenance_tab { tabs.find('li', text: /Maintenance/) }
-
-  before :each do
-    # Prevent attempting to retrieve documents from S3 when Cluster page
-    # visited.
-    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
-  end
+  let(:documents_tab) { tabs.find('li', text: /Documents/) }
+  let(:user) { create(:contact, site: cluster.site) }
 
   context 'when visiting the cluster page' do
-    before :each { visit cluster_path(cluster, as: user) }
+
+    subject { cluster }
+
+    before :each {
+      visit cluster_path(subject, as: user)
+    }
 
     context 'with an admin user' do
       let :user { create(:admin) }
@@ -33,10 +34,15 @@ RSpec.describe 'cluster tabs', type: :feature do
         path = new_cluster_maintenance_window_path(cluster)
         expect(maintenance_tab).to have_link(href: path)
       end
+
+      it 'does not have a Documents tab' do
+        expect do
+          documents_tab
+        end.to raise_error(Capybara::ElementNotFound)
+      end
     end
 
     context 'with a contact user' do
-      let :user { create(:contact, site: cluster.site) }
 
       it 'does not have dropdown menu for maintenance tab' do
         expect(maintenance_tab).not_to match_css('.dropdown')
@@ -51,6 +57,42 @@ RSpec.describe 'cluster tabs', type: :feature do
         path = new_cluster_maintenance_window_path(cluster)
         expect(maintenance_tab).not_to have_link(href: path)
       end
+
+      it 'does not have a Documents tab' do
+        expect do
+          documents_tab
+        end.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+
+    context 'for a cluster with documents' do
+      subject do
+        cluster.tap do |c|
+          allow_any_instance_of(Cluster).to receive(:documents).and_return([
+             Cluster::DocumentsRetriever::Document.new(
+                 'Fake Document',
+                 'http://www.example.com')
+          ])
+        end
+      end
+
+      context 'as an admin' do
+        let(:user) { create(:admin) }
+        it 'shows a documents tab' do
+          expect do
+            documents_tab
+          end.not_to raise_error
+        end
+      end
+
+      context 'as a contact' do
+        it 'shows a documents tab' do
+          expect do
+            documents_tab
+          end.not_to raise_error
+        end
+      end
     end
   end
+
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -100,10 +100,6 @@ RSpec.feature "Maintenance windows", type: :feature do
     # The only way I can get Capybara to use the correct URL; may be a better
     # way though.
     default_url_options[:host] = Rails.application.routes.default_url_options[:host]
-
-    # Prevent attempting to retrieve documents from S3 when Cluster page
-    # visited.
-    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
   end
 
   def fill_in_datetime_selects(identifier, with:)

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -10,12 +10,6 @@ RSpec.feature 'Navigation Bar', type: :feature do
   let :contact { create(:primary_contact, site: site) }
   let :cluster { create(:cluster, site: site) }
 
-  before :each do
-    # Prevent attempting to retrieve documents from S3 when Cluster page
-    # visited.
-    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
-  end
-
   def visit_subject(path_helper)
     visit send(path_helper, subject, as: user)
   end

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe Cluster, type: :model do
         VCR.use_cassette(VcrCassettes::S3_READ_DOCUMENTS) do |cassette|
           Development::Utils.upload_document_fixtures_for(subject) if cassette.recording?
 
+          # This is the one place we actually want the original method to be called,
+          # so here we override our default return value of [] (set in spec_helper).
+          allow_any_instance_of(Cluster).to receive(:documents).and_call_original
+
           documents = subject.documents
 
           # `upload_document_fixtures_for` will upload 'folder' objects (S3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,6 +58,16 @@ Capybara.add_selector(:test_element) do
   end
 end
 
+# Override Capybara Selenium driver with increased timeout, to (hopefully)
+# avoid intermittent failures on tiny CI server (see
+# https://stackoverflow.com/a/33898828/2620402).
+Capybara.register_driver :selenium do |app|
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.timeout = 120 # Instead of default 60s timeout.
+  Capybara::Selenium::Driver.new(app, browser: :firefox, profile: profile, http_client: client)
+end
+
 # Convenience function to use above.
 def test_element(data_test_value)
   find(:test_element, data_test_value)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,9 +63,9 @@ end
 # https://stackoverflow.com/a/33898828/2620402).
 Capybara.register_driver :selenium do |app|
   profile = Selenium::WebDriver::Firefox::Profile.new
-  client = Selenium::WebDriver::Remote::Http::Default.new
-  client.timeout = 120 # Instead of default 60s timeout.
-  Capybara::Selenium::Driver.new(app, browser: :firefox, profile: profile, http_client: client)
+  client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 120, read_timeout: 120)
+  options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: options, http_client: client)
 end
 
 # Convenience function to use above.

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -11,11 +11,6 @@ RSpec.describe 'Navigation variable assignments', type: :request do
   end
   let! :service { create(:service, cluster: cluster) }
 
-  before :each do
-    # Avoid making any S3 requests for Cluster documents.
-    allow_any_instance_of(Cluster).to receive(:documents).and_return []
-  end
-
   let :default_nav_variables do
     {
       scope: subject,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,4 +94,10 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.before :example do
+    # Prevent attempting to retrieve documents from S3 when Cluster page
+    # visited.
+    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
+  end
 end

--- a/spec/support/shared_examples/support_type_change_buttons.rb
+++ b/spec/support/shared_examples/support_type_change_buttons.rb
@@ -4,10 +4,6 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
   part_class_name = part_name.to_s.titlecase
 
   before :each do
-    # Prevent attempting to retrieve documents from S3 when Cluster page
-    # visited.
-    allow_any_instance_of(Cluster).to receive(:documents).and_return([])
-
     create(:"request_#{part_name}_becomes_managed_issue")
     create(:"request_#{part_name}_becomes_advice_issue")
   end


### PR DESCRIPTION
This PR moves the "Documents" section on the cluster dashboard to its own tab, which is only shown if there are documents present.

Testing for this was a little tricky, so I've had to add 
```ruby
allow_any_instance_of(Cluster).to receive(:documents).and_return([])
```
into the RSpec config in `spec_helper.rb`, overriding it manually in the existing VCR-based test for S3 document retrieval.

For manual testing, I've also dropped a file in S3 for the demo cluster. It's not a long read.

Trello: https://trello.com/c/xomUxdm6/300-move-cluster-documents-into-a-tab