### PR TITLE
Pluralise the cases subtitle correctly

### DIFF
--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -2,7 +2,8 @@
   cases = @show_resolved ? @scope.cases.inactive : @scope.cases.active
 %>
 <%= content_for :subtitle do
-  "#{cases.length} #{@show_resolved ? 'Resolved' : 'Open'} Cases"
+  "#{cases.length} #{@show_resolved ? 'Resolved' : 'Open'}
+  #{'Case'.pluralize(cases.length)}"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
   <div class='table-responsive'>


### PR DESCRIPTION
Based off #273 so merge that first ideally.

This is a simple fix that ensures the subtitle is pluralised correctly. I noticed this was a problem when viewing a case page containing only a single case.

[Trello](https://trello.com/c/K7I7g3gw/95-indicate-number-of-cases-in-various-cases-tables)