### PR TITLE
Actually remove documents section from its old home.

### DIFF
--- a/app/views/clusters/show.html.erb
+++ b/app/views/clusters/show.html.erb
@@ -2,16 +2,3 @@
 <%= render 'partials/tabs', activate: :overview do %>
   <%= render 'clusters/details', cluster: cluster %>
 <% end %>
-
-<div class='card'>
-  <%= render 'partials/card_header_nav', title: 'Documents' %>
-
-  <ul class="list-group list-group-flush">
-    <% cluster.documents.each do |document| %>
-      <li class="list-group-item">
-        <%= link_to document.name, document.url, target: '_blank' %>
-      </li>
-    <% end %>
-  </ul>
-</div>
-


### PR DESCRIPTION
That was a little embarrassing...

Trello: https://trello.com/c/0VCWfKRN/308-remove-documents-section-shown-on-cluster-dashboard