### PR TITLE
Handle when no items available

### DIFF
--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,16 +1,15 @@
 <%
   cases = @show_resolved ? @scope.cases.inactive : @scope.cases.active
+  empty_message = "No #{@show_resolved ? 'resolved or closed' : 'open'} cases"
 %>
 <%= content_for :subtitle do
   "#{cases.length} #{@show_resolved ? 'Resolved' : 'Open'}
   #{'Case'.pluralize(cases.length)}"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
-  <% if cases.empty? %>
-    <div style="text-align: center">
-      No <%= @show_resolved? 'resolved or closed' : 'open' %> cases
-    </div>
-  <% else %>
+  <%= render 'partials/no_item_available',
+      collection: cases,
+      message: empty_message do %>
     <div class='table-responsive'>
       <table class="table">
         <thead>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -6,35 +6,41 @@
   #{'Case'.pluralize(cases.length)}"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
-  <div class='table-responsive'>
-    <table class="table">
-      <thead>
-        <tr class="nowrap">
-          <th>ID</th>
-          <th>Date</th>
-          <th>State</th>
-          <th>Creator</th>
-          <th>Subject</th>
-          <th>Assigned to</th>
-          <th>Association</th>
-          <% if @show_resolved %>
-            <th>Credit usage</th>
+  <% if cases.empty? %>
+    <div style="text-align: center">
+      No <%= @show_resolved? 'resolved or closed' : 'open' %> cases
+    </div>
+  <% else %>
+    <div class='table-responsive'>
+      <table class="table">
+        <thead>
+          <tr class="nowrap">
+            <th>ID</th>
+            <th>Date</th>
+            <th>State</th>
+            <th>Creator</th>
+            <th>Subject</th>
+            <th>Assigned to</th>
+            <th>Association</th>
+            <% if @show_resolved %>
+              <th>Credit usage</th>
+            <% end %>
+          </tr>
+        </thead>
+
+        <tbody class="assigned-cases">
+          <% cases.assigned_to(current_user).decorate.each do |c| %>
+            <%= render 'partials/case_table_row', kase: c %>
           <% end %>
-        </tr>
-      </thead>
+        </tbody>
 
-      <tbody class="assigned-cases">
-        <% cases.assigned_to(current_user).decorate.each do |c| %>
-          <%= render 'partials/case_table_row', kase: c %>
-        <% end %>
-      </tbody>
-
-      <tbody>
-        <% cases.not_assigned_to(current_user).decorate.each do |c| %>
-          <%= render 'partials/case_table_row', kase: c %>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+        <tbody>
+          <% cases.not_assigned_to(current_user).decorate.each do |c| %>
+            <%= render 'partials/case_table_row', kase: c %>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
 <% end %>
 

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -7,39 +7,35 @@
   #{'Case'.pluralize(cases.length)}"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
-  <%= render 'partials/no_item_available',
+  <%= render 'partials/table',
       collection: cases,
       message: empty_message do %>
-    <div class='table-responsive'>
-      <table class="table">
-        <thead>
-          <tr class="nowrap">
-            <th>ID</th>
-            <th>Date</th>
-            <th>State</th>
-            <th>Creator</th>
-            <th>Subject</th>
-            <th>Assigned to</th>
-            <th>Association</th>
-            <% if @show_resolved %>
-              <th>Credit usage</th>
-            <% end %>
-          </tr>
-        </thead>
+    <thead>
+      <tr class="nowrap">
+        <th>ID</th>
+        <th>Date</th>
+        <th>State</th>
+        <th>Creator</th>
+        <th>Subject</th>
+        <th>Assigned to</th>
+        <th>Association</th>
+        <% if @show_resolved %>
+          <th>Credit usage</th>
+        <% end %>
+      </tr>
+    </thead>
 
-        <tbody class="assigned-cases">
-          <% cases.assigned_to(current_user).decorate.each do |c| %>
-            <%= render 'partials/case_table_row', kase: c %>
-          <% end %>
-        </tbody>
+    <tbody class="assigned-cases">
+      <% cases.assigned_to(current_user).decorate.each do |c| %>
+        <%= render 'partials/case_table_row', kase: c %>
+      <% end %>
+    </tbody>
 
-        <tbody>
-          <% cases.not_assigned_to(current_user).decorate.each do |c| %>
-            <%= render 'partials/case_table_row', kase: c %>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+    <tbody>
+      <% cases.not_assigned_to(current_user).decorate.each do |c| %>
+        <%= render 'partials/case_table_row', kase: c %>
+      <% end %>
+    </tbody>
   <% end %>
 <% end %>
 

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,34 +1,30 @@
 <% content_for :subtitle { 'Logs' } %>
 <%= render 'partials/tabs', activate: :logs do %>
-  <%= render 'partials/no_item_available',
+  <%= render 'partials/table',
       collection: @logs,
       message: "No logs to display" do %>
-    <div class='table-responsive'>
-      <table class='table'>
-        <thead>
-          <th>Date Created</th>
-          <th>Engineer</th>
-          <th>Details</th>
-          <th>Associated Component</th>
-          <th>Related Case(s)</th>
-        </thead>
-        <% @logs.each do |log| %>
-          <tr>
-            <%= timestamp_td(description:  'Logged', timestamp: log.created_at) %>
-            <td class="nowrap"><%= log.engineer.name %></td>
-            <td><%= log.details %></td>
-            <td>
-              <%= log.component&.decorate&.link || raw("<em>None</em>") %>
-            </td>
-            <td>
-              <% log.cases.map(&:decorate).each do |kase| %>
-                <%= kase.case_link %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </table>
-    </div>
+    <thead>
+      <th>Date Created</th>
+      <th>Engineer</th>
+      <th>Details</th>
+      <th>Associated Component</th>
+      <th>Related Case(s)</th>
+    </thead>
+    <% @logs.each do |log| %>
+      <tr>
+        <%= timestamp_td(description:  'Logged', timestamp: log.created_at) %>
+        <td class="nowrap"><%= log.engineer.name %></td>
+        <td><%= log.details %></td>
+        <td>
+          <%= log.component&.decorate&.link || raw("<em>None</em>") %>
+        </td>
+        <td>
+          <% log.cases.map(&:decorate).each do |kase| %>
+            <%= kase.case_link %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,32 +1,37 @@
 <% content_for :subtitle { 'Logs' } %>
 <%= render 'partials/tabs', activate: :logs do %>
-  <div class='table-responsive'>
-    <table class='table'>
-      <thead>
-        <th>Date Created</th>
-        <th>Engineer</th>
-        <th>Details</th>
-        <th>Associated Component</th>
-        <th>Related Case(s)</th>
-      </thead>
-      <% @logs.each do |log| %>
-        <tr>
-          <%= timestamp_td(description:  'Logged', timestamp: log.created_at) %>
-          <td class="nowrap"><%= log.engineer.name %></td>
-          <td><%= log.details %></td>
-          <td>
-            <%= log.component&.decorate&.link || raw("<em>None</em>") %>
-          </td>
-          <td>
-            <% log.cases.map(&:decorate).each do |kase| %>
-              <%= kase.case_link %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-  </div>
+  <% if @logs.empty? %>
+    <div style="text-align: center">No logs to display</div>
+  <% else %>
+    <div class='table-responsive'>
+      <table class='table'>
+        <thead>
+          <th>Date Created</th>
+          <th>Engineer</th>
+          <th>Details</th>
+          <th>Associated Component</th>
+          <th>Related Case(s)</th>
+        </thead>
+        <% @logs.each do |log| %>
+          <tr>
+            <%= timestamp_td(description:  'Logged', timestamp: log.created_at) %>
+            <td class="nowrap"><%= log.engineer.name %></td>
+            <td><%= log.details %></td>
+            <td>
+              <%= log.component&.decorate&.link || raw("<em>None</em>") %>
+            </td>
+            <td>
+              <% log.cases.map(&:decorate).each do |kase| %>
+                <%= kase.case_link %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
+  <% end %>
 <% end %>
+
 
 <% if current_user.admin? %>
   <div class='card'>
@@ -70,4 +75,3 @@
     </div>
   </div>
 <% end %>
-

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for :subtitle { 'Logs' } %>
 <%= render 'partials/tabs', activate: :logs do %>
-  <% if @logs.empty? %>
-    <div style="text-align: center">No logs to display</div>
-  <% else %>
+  <%= render 'partials/no_item_available',
+      collection: @logs,
+      message: "No logs to display" do %>
     <div class='table-responsive'>
       <table class='table'>
         <thead>

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for :subtitle { 'Pending Maintenance' } %>
 <%= render 'partials/tabs', activate: :maintenance do %>
-  <% if @scope.unfinished_related_maintenance_windows.empty? %>
-    <div style="text-align: center">No pending or requested maintenance</div>
-  <% else %>
+  <%= render 'partials/no_item_available',
+      collection: @scope.unfinished_related_maintenance_windows,
+      message: "No pending or requested maintenance" do %>
     <div class='table-responsive'>
       <table class="maintenance table">
         <thead>

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,70 +1,66 @@
 <% content_for :subtitle { 'Pending Maintenance' } %>
 <%= render 'partials/tabs', activate: :maintenance do %>
-  <%= render 'partials/no_item_available',
+  <%= render 'partials/table',
       collection: @scope.unfinished_related_maintenance_windows,
       message: "No pending or requested maintenance" do %>
-    <div class='table-responsive'>
-      <table class="maintenance table">
-        <thead>
-          <tr>
-            <th>For</th>
-            <th>Maintenance period</th>
-            <th>Requested</th>
-            <th>Confirmed</th>
-            <th>Associated case</th>
-          </tr>
-        </thead>
+    <thead>
+      <tr>
+        <th>For</th>
+        <th>Maintenance period</th>
+        <th>Requested</th>
+        <th>Confirmed</th>
+        <th>Associated case</th>
+      </tr>
+    </thead>
 
-        <tbody>
-        <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
-          <tr>
-            <td><%= window.associated_model.links %></td>
-            <td><%= window.scheduled_period %></td>
-            <td><%= window.transition_info(:requested) ||
-              raw('<em>N/A &mdash; mandatory maintenance</em>')
-            %></td>
-            <td>
-              <%= window.transition_info(:confirmed) ||
-                render('maintenance_windows/unconfirmed_buttons', window: window) %>
+    <tbody>
+    <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
+      <tr>
+        <td><%= window.associated_model.links %></td>
+        <td><%= window.scheduled_period %></td>
+        <td><%= window.transition_info(:requested) ||
+          raw('<em>N/A &mdash; mandatory maintenance</em>')
+        %></td>
+        <td>
+          <%= window.transition_info(:confirmed) ||
+            render('maintenance_windows/unconfirmed_buttons', window: window) %>
 
-              <% if window.can_end? && current_user.admin? %>
-                <%= button_to 'End ongoing maintenance',
-                  end_maintenance_window_path(window),
-                  class: ['btn', 'btn-danger', 'btn-block'],
-                  data: {
-                    confirm: <<~EOF.squish
-                      Are you sure you want to end this ongoing maintenance?
-                    EOF
-                  }
-                %>
-              <% end %>
+          <% if window.can_end? && current_user.admin? %>
+            <%= button_to 'End ongoing maintenance',
+              end_maintenance_window_path(window),
+              class: ['btn', 'btn-danger', 'btn-block'],
+              data: {
+                confirm: <<~EOF.squish
+                  Are you sure you want to end this ongoing maintenance?
+                EOF
+              }
+            %>
+          <% end %>
 
-              <% if window.can_extend_duration? && current_user.admin? %>
-                <%= form_tag(
-                  extend_maintenance_window_path(window),
-                  class: 'form-inline'
-                ) do %>
-                  <div class="extend-maintenance-form">
-                    <%= number_field_tag(
-                      :additional_days,
-                      nil,
-                      class: 'form-control extend-maintenance-form__duration-input',
-                      placeholder: 'Additional business days',
-                      min: 1,
-                      required: true
-                    ) %>
+          <% if window.can_extend_duration? && current_user.admin? %>
+            <%= form_tag(
+              extend_maintenance_window_path(window),
+              class: 'form-inline'
+            ) do %>
+              <div class="extend-maintenance-form">
+                <%= number_field_tag(
+                  :additional_days,
+                  nil,
+                  class: 'form-control extend-maintenance-form__duration-input',
+                  placeholder: 'Additional business days',
+                  min: 1,
+                  required: true
+                ) %>
 
-                    <%= submit_tag('Extend', class: 'btn btn-success') %>
-                  </div>
-                <% end %>
-              <% end %>
-            </td>
-            <td><%= window.case.case_link %></td>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
-    </div>
+                <%= submit_tag('Extend', class: 'btn btn-success') %>
+              </div>
+            <% end %>
+          <% end %>
+        </td>
+        <td><%= window.case.case_link %></td>
+      </tr>
+    <% end %>
+    </tbody>
   <% end %>
 <% end %>
 

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -1,66 +1,70 @@
 <% content_for :subtitle { 'Pending Maintenance' } %>
 <%= render 'partials/tabs', activate: :maintenance do %>
-  <div class='table-responsive'>
-    <table class="maintenance table">
-      <thead>
-        <tr>
-          <th>For</th>
-          <th>Maintenance period</th>
-          <th>Requested</th>
-          <th>Confirmed</th>
-          <th>Associated case</th>
-        </tr>
-      </thead>
+  <% if @scope.unfinished_related_maintenance_windows.empty? %>
+    <div style="text-align: center">No pending or requested maintenance</div>
+  <% else %>
+    <div class='table-responsive'>
+      <table class="maintenance table">
+        <thead>
+          <tr>
+            <th>For</th>
+            <th>Maintenance period</th>
+            <th>Requested</th>
+            <th>Confirmed</th>
+            <th>Associated case</th>
+          </tr>
+        </thead>
 
-      <tbody>
-      <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
-        <tr>
-          <td><%= window.associated_model.links %></td>
-          <td><%= window.scheduled_period %></td>
-          <td><%= window.transition_info(:requested) ||
-            raw('<em>N/A &mdash; mandatory maintenance</em>')
-          %></td>
-          <td>
-            <%= window.transition_info(:confirmed) ||
-              render('maintenance_windows/unconfirmed_buttons', window: window) %>
+        <tbody>
+        <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
+          <tr>
+            <td><%= window.associated_model.links %></td>
+            <td><%= window.scheduled_period %></td>
+            <td><%= window.transition_info(:requested) ||
+              raw('<em>N/A &mdash; mandatory maintenance</em>')
+            %></td>
+            <td>
+              <%= window.transition_info(:confirmed) ||
+                render('maintenance_windows/unconfirmed_buttons', window: window) %>
 
-            <% if window.can_end? && current_user.admin? %>
-              <%= button_to 'End ongoing maintenance',
-                end_maintenance_window_path(window),
-                class: ['btn', 'btn-danger', 'btn-block'],
-                data: {
-                  confirm: <<~EOF.squish
-                    Are you sure you want to end this ongoing maintenance?
-                  EOF
-                }
-              %>
-            <% end %>
-
-            <% if window.can_extend_duration? && current_user.admin? %>
-              <%= form_tag(
-                extend_maintenance_window_path(window),
-                class: 'form-inline'
-              ) do %>
-                <div class="extend-maintenance-form">
-                  <%= number_field_tag(
-                    :additional_days,
-                    nil,
-                    class: 'form-control extend-maintenance-form__duration-input',
-                    placeholder: 'Additional business days',
-                    min: 1,
-                    required: true
-                  ) %>
-
-                  <%= submit_tag('Extend', class: 'btn btn-success') %>
-                </div>
+              <% if window.can_end? && current_user.admin? %>
+                <%= button_to 'End ongoing maintenance',
+                  end_maintenance_window_path(window),
+                  class: ['btn', 'btn-danger', 'btn-block'],
+                  data: {
+                    confirm: <<~EOF.squish
+                      Are you sure you want to end this ongoing maintenance?
+                    EOF
+                  }
+                %>
               <% end %>
-            <% end %>
-          </td>
-          <td><%= window.case.case_link %></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-  </div>
+
+              <% if window.can_extend_duration? && current_user.admin? %>
+                <%= form_tag(
+                  extend_maintenance_window_path(window),
+                  class: 'form-inline'
+                ) do %>
+                  <div class="extend-maintenance-form">
+                    <%= number_field_tag(
+                      :additional_days,
+                      nil,
+                      class: 'form-control extend-maintenance-form__duration-input',
+                      placeholder: 'Additional business days',
+                      min: 1,
+                      required: true
+                    ) %>
+
+                    <%= submit_tag('Extend', class: 'btn btn-success') %>
+                  </div>
+                <% end %>
+              <% end %>
+            </td>
+            <td><%= window.case.case_link %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
 <% end %>
 

--- a/app/views/partials/_no_item_available.html.erb
+++ b/app/views/partials/_no_item_available.html.erb
@@ -1,5 +1,5 @@
 <% if collection.empty? %>
-  <div style="text-align: center"><%= message %></div>
+  <div style="text-align: center"><em><%= message %></em></div>
 <% else %>
   <%= yield if block_given? %>
 <% end %>

--- a/app/views/partials/_no_item_available.html.erb
+++ b/app/views/partials/_no_item_available.html.erb
@@ -1,0 +1,5 @@
+<% if collection.empty? %>
+  <div style="text-align: center"><%= message %></div>
+<% else %>
+  <%= yield if block_given? %>
+<% end %>

--- a/app/views/partials/_no_item_available.html.erb
+++ b/app/views/partials/_no_item_available.html.erb
@@ -1,5 +1,5 @@
 <% if collection.empty? %>
   <div style="text-align: center"><em><%= message %></em></div>
 <% else %>
-  <%= yield if block_given? %>
+  <%= yield %>
 <% end %>

--- a/app/views/partials/_table.html.erb
+++ b/app/views/partials/_table.html.erb
@@ -1,5 +1,9 @@
 <% if collection.empty? %>
   <div style="text-align: center"><em><%= message %></em></div>
 <% else %>
-  <%= yield %>
+  <div class='table-responsive'>
+    <table class="table">
+      <%= yield %>
+    </table>
+  </div>
 <% end %>


### PR DESCRIPTION
This PR doesn't implement anything too fancy but does handle if there are no cases, logs or maintenance to display. In the future this could be adapted to look nicer however for now it does what it needs to. It displays a short message indicating there are no items for the appropriate page to display and prevents the table headers from unnecessarily rendering.

[Trello](https://trello.com/c/W4VOTlw5/46-go-through-and-nicely-handle-when-no-items-available-in-various-cases)