### PR TITLE
Remove obsolete columns from a couple of places

### DIFF
--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -22,10 +22,6 @@ class CaseDecorator < ApplicationDecorator
     h.link_to(display_id, h.case_path(self), title: subject)
   end
 
-  def chargeable_symbol
-    h.boolean_symbol(chargeable)
-  end
-
   def request_maintenance_path
     assoc_class = model.associated_model.underscored_model_name
     h.send("new_#{assoc_class}_maintenance_window_path", model.associated_model, case_id: model.id)

--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -9,7 +9,6 @@ class IssueDecorator < ApplicationDecorator
       name: name,
       defaultSubject: default_subject,
       requiresComponent: requires_component,
-      supportType: support_type,
       chargeable: chargeable,
       tiers: tiers.map(&:case_form_json)
     }

--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -9,7 +9,6 @@ class IssueDecorator < ApplicationDecorator
       name: name,
       defaultSubject: default_subject,
       requiresComponent: requires_component,
-      chargeable: chargeable,
       tiers: tiers.map(&:case_form_json)
     }
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -19,7 +19,7 @@ class Case < ApplicationRecord
   has_many :case_state_transitions
   alias_attribute :transitions, :case_state_transitions
 
-  delegate :category, :chargeable, to: :issue
+  delegate :category, to: :issue
   delegate :site, to: :cluster, allow_nil: true
 
   state_machine initial: :open do

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -42,7 +42,6 @@ class Issue < ApplicationRecord
 
   validates :name, presence: true
   validates :identifier, uniqueness: true, if: :identifier
-  validates :chargeable, inclusion: {in: [true, false]}
 
   validates :service_type,
             absence: {

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,8 +1,5 @@
 class Issue < ApplicationRecord
   include AdminConfig::Issue
-  include HasSupportType
-
-  SUPPORT_TYPES = SupportType::VALUES + ['advice-only']
 
   class << self
     def globally_available?
@@ -44,7 +41,6 @@ class Issue < ApplicationRecord
   has_many :tiers
 
   validates :name, presence: true
-  validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true
   validates :identifier, uniqueness: true, if: :identifier
   validates :chargeable, inclusion: {in: [true, false]}
 
@@ -55,16 +51,6 @@ class Issue < ApplicationRecord
             unless: :requires_service
 
   after_create :create_standard_consultancy_tier
-
-  def advice_only?
-    support_type == 'advice-only'
-  end
-
-  # Automatically picked up by rails_admin so only these options displayed when
-  # selecting support type.
-  def support_type_enum
-    SUPPORT_TYPES
-  end
 
   def special?
     IDENTIFIER_NAMES.include?(identifier&.to_sym)

--- a/db/data_migrations/20180509115018_add_change_motd_issue.rb
+++ b/db/data_migrations/20180509115018_add_change_motd_issue.rb
@@ -4,9 +4,6 @@ class AddChangeMotdIssue < ActiveRecord::DataMigration
     hpc_environment_type = ServiceType.find_by_name!('HPC Environment')
     issue = end_user_assistance.issues.create!(
       name: 'Request change of MOTD',
-      # XXX Now junk field which is still required, will be able to be removed
-      # once current staging changes deployed.
-      support_type: 'managed',
       requires_service: true,
       service_type: hpc_environment_type,
     )

--- a/db/migrate/20180521104319_remove_obsolete_columns.rb
+++ b/db/migrate/20180521104319_remove_obsolete_columns.rb
@@ -1,0 +1,7 @@
+class RemoveObsoleteColumns < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :cases, :details, :string
+    remove_column :issues, :details_template, :string
+    remove_column :issues, :support_type, :string, null: false
+  end
+end

--- a/db/migrate/20180521142349_remove_chargeable_from_issues.rb
+++ b/db/migrate/20180521142349_remove_chargeable_from_issues.rb
@@ -1,0 +1,5 @@
+class RemoveChargeableFromIssues < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :issues, :chargeable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,7 +95,6 @@ ActiveRecord::Schema.define(version: 20180521102158) do
   end
 
   create_table "cases", force: :cascade do |t|
-    t.string "details"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "cluster_id", null: false
@@ -237,8 +236,6 @@ ActiveRecord::Schema.define(version: 20180521102158) do
     t.boolean "requires_component", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "details_template"
-    t.string "support_type", null: false
     t.string "identifier"
     t.boolean "requires_service", default: false, null: false
     t.bigint "service_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180521102158) do
+ActiveRecord::Schema.define(version: 20180521142349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -239,7 +239,6 @@ ActiveRecord::Schema.define(version: 20180521102158) do
     t.string "identifier"
     t.boolean "requires_service", default: false, null: false
     t.bigint "service_type_id"
-    t.boolean "chargeable", default: false, null: false
     t.bigint "category_id"
     t.index ["category_id"], name: "index_issues_on_category_id"
     t.index ["service_type_id"], name: "index_issues_on_service_type_id"

--- a/spec/decorators/issue_decorator_spec.rb
+++ b/spec/decorators/issue_decorator_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe IssueDecorator do
         requires_component: false,
         requires_service: service_type.present?,
         service_type: service_type,
-        support_type: :managed,
         chargeable: true,
         tiers: [tier]
       ).tap do |issue|
@@ -30,7 +29,6 @@ RSpec.describe IssueDecorator do
         name: 'New user request',
         defaultSubject: 'New user request',
         requiresComponent: false,
-        supportType: 'managed',
         chargeable: true,
         tiers: [tier.decorate.case_form_json]
       )

--- a/spec/decorators/issue_decorator_spec.rb
+++ b/spec/decorators/issue_decorator_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe IssueDecorator do
         requires_component: false,
         requires_service: service_type.present?,
         service_type: service_type,
-        chargeable: true,
         tiers: [tier]
       ).tap do |issue|
         # Issue creates a Tier by default on create, so remove any associated
@@ -29,7 +28,6 @@ RSpec.describe IssueDecorator do
         name: 'New user request',
         defaultSubject: 'New user request',
         requiresComponent: false,
-        chargeable: true,
         tiers: [tier.decorate.case_form_json]
       )
     end

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -4,9 +4,6 @@ FactoryBot.define do
     name 'New user/group'
     requires_component false
 
-    factory :advice_issue do
-    end
-
     factory :issue_requiring_component do
       requires_component true
 

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -3,10 +3,8 @@ FactoryBot.define do
   factory :issue do
     name 'New user/group'
     requires_component false
-    support_type :managed
 
     factory :advice_issue do
-      support_type :advice
     end
 
     factory :issue_requiring_component do
@@ -14,13 +12,11 @@ FactoryBot.define do
 
       factory :request_component_becomes_advice_issue do
         identifier Issue::IDENTIFIERS.request_component_becomes_advice
-        support_type 'managed'
         tiers { [create(:level_1_tier)] }
       end
 
       factory :request_component_becomes_managed_issue do
         identifier Issue::IDENTIFIERS.request_component_becomes_managed
-        support_type 'advice-only'
         tiers { [create(:level_1_tier)] }
       end
     end
@@ -30,13 +26,11 @@ FactoryBot.define do
 
       factory :request_service_becomes_advice_issue do
         identifier Issue::IDENTIFIERS.request_service_becomes_advice
-        support_type 'managed'
         tiers { [create(:level_1_tier)] }
       end
 
       factory :request_service_becomes_managed_issue do
         identifier Issue::IDENTIFIERS.request_service_becomes_managed
-        support_type 'advice-only'
         tiers { [create(:level_1_tier)] }
       end
     end


### PR DESCRIPTION
This PR removes some database columns that have become obsolete:

- `Case.details`
- `Issue.details_template`
- `Issue.support_type`

Trello: https://trello.com/c/YrsAysHk/226-remove-no-longer-needed-columns