### PR TITLE
Primary contact validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@ class User < ApplicationRecord
     inclusion: {in: [true, false], if: :contact?},
     absence: {if: :admin?}
   }
+  validate :validates_primary_contact_assignment
+
   alias_attribute :primary_contact?, :primary_contact
 
   alias_attribute :admin?, :admin
@@ -34,6 +36,12 @@ class User < ApplicationRecord
 
   def secondary_contact?
     contact? && !primary_contact?
+  end
+
+  def validates_primary_contact_assignment
+    return if site&.primary_contact.nil?
+    errors.add(:primary_contact, 'is already set for this site') if
+      primary_contact && site.primary_contact != self
   end
 
   def self.globally_available?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe User, type: :model do
 
   describe '#validates_primary_contact_assignment' do
     subject do
-      create(:user, primary_contact: true)
+      build(:user, primary_contact: true)
     end
 
     context 'with no primary contact' do
@@ -30,10 +30,10 @@ RSpec.describe User, type: :model do
     end
 
     context 'with an existing primary contact for the current site' do
-      let :primary_contact { create(:user, primary_contact: true, site: subject.site) }
+      let! :primary_contact { create(:user, primary_contact: true, site: subject.site) }
 
       it 'should error' do
-        expect{ primary_contact }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(subject).not_to be_valid
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,4 +17,24 @@ RSpec.describe User, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe '#validates_primary_contact_assignment' do
+    subject do
+      create(:user, primary_contact: true)
+    end
+
+    context 'with no primary contact' do
+      it 'should not error' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with an existing primary contact for the current site' do
+      let :primary_contact { create(:user, primary_contact: true, site: subject.site) }
+
+      it 'should error' do
+        expect{ primary_contact }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe User, type: :model do
 
       it 'should error' do
         expect(subject).not_to be_valid
+        expect(subject.errors.messages).to match(
+          primary_contact: ['is already set for this site']
+        )
       end
     end
   end


### PR DESCRIPTION
Sites are only meant to have one `Primary Contact` assigned to them however there was no validation to prevent multiple contacts being assigned as the `Primary Contact`. This PR resolves this issue, ensuring that there can be only one. If an admin attempts to assign a user as the `Primary Contact` of a site that already has one then it will raise an error within the admin interface preventing the user from being saved.

[Trello](https://trello.com/c/NQZqLwPF/110-add-validation-that-site-only-has-single-primary-contact)