### PR TITLE
Update null constraints and validation

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -36,12 +36,9 @@ class Case < ApplicationRecord
 
   audited only: [:assignee_id, :time_worked, :credit_charge, :tier_level], on: [ :update ]
 
-  # XXX Remove if: display_id when we can do so
-  validates :display_id, uniqueness: true, if: :display_id
+  validates :display_id, uniqueness: true
 
-  # XXX We want to enable this validation when we've migrated production over -
-  # otherwise historical migrations will fail :(
-  #validate :has_display_id_when_saved
+  validate :has_display_id_when_saved
 
   validates :token, presence: true
   validates :subject, presence: true

--- a/app/models/maintenance_window/validator.rb
+++ b/app/models/maintenance_window/validator.rb
@@ -1,5 +1,5 @@
 
-class MaintenanceWindow
+class MaintenanceWindow < ApplicationRecord
   class Validator < ActiveModel::Validator
     def validate(record)
       @record = record

--- a/db/migrate/20180521143035_add_needed_null_constraints.rb
+++ b/db/migrate/20180521143035_add_needed_null_constraints.rb
@@ -1,0 +1,7 @@
+class AddNeededNullConstraints < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :cases, :tier_level, false
+    change_column_null :cases, :display_id, false
+    change_column_null :clusters, :shortcode, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180521142349) do
+ActiveRecord::Schema.define(version: 20180521143035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,11 +106,11 @@ ActiveRecord::Schema.define(version: 20180521142349) do
     t.text "token", null: false
     t.text "subject", null: false
     t.datetime "completed_at"
-    t.integer "tier_level"
+    t.integer "tier_level", null: false
     t.json "fields"
     t.text "state", default: "open", null: false
     t.bigint "assignee_id"
-    t.string "display_id"
+    t.string "display_id", null: false
     t.integer "time_worked", default: 0, null: false
     t.integer "credit_charge"
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
@@ -165,7 +165,7 @@ ActiveRecord::Schema.define(version: 20180521142349) do
     t.datetime "updated_at", null: false
     t.string "canonical_name", null: false
     t.string "charging_info"
-    t.string "shortcode"
+    t.string "shortcode", null: false
     t.integer "case_index", default: 0, null: false
     t.text "motd"
     t.index ["shortcode"], name: "index_clusters_on_shortcode", unique: true


### PR DESCRIPTION
This PR uses the `bin/generate-needed-null-constraint-migrations` script to add in a few more null constraints that weren't previously present.

I've also taken the opportunity to reenable the validation on `Case.display_id` that was disabled in 99f85c7e41bf97567fca6ea8ceeb8a4c3f57fa50

I've confirmed that `alces:data:import_and_migrate_production` completes successfully.

Note that there was also a small change to `maintenance_window/validator.rb` as `nullalign` was falling over the otherwise inconsistent type hierarchy.

Trello: https://trello.com/c/gtl57vpG/264-run-bin-generate-needed-null-constraint-migrations-and-add-any-constraints-we-can-now-add-after-running-migrations-in-production