### PR TITLE
Email tweaks

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -6,7 +6,7 @@ class ApplicationMailer < ActionMailer::Base
   include Roadie::Rails::Automatic
   extend Alces::Mailer::Resender
 
-  default from: "#{Rails.application.config.email_app_name} <center@alces-flight.com>"
+  default from: "#{Rails.application.config.email_from}"
   layout 'mailer'
   helper 'mailer'
   helper 'application'

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,11 @@ module AlcesFlightCenter
 
     config.active_job.queue_adapter = :resque
 
-    config.email_app_name = ENV['EMAIL_APP_NAME'] || 'Alces Flight Center'
+    config.email_from = if ENV['STAGING']
+                          'Alces Flight Center Staging <center+staging@alces-software.com>'
+                        else
+                          'Alces Flight Center <center@alces-software.com>'
+                        end
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Host to use when generating URls in emails.
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
+  # Do not send emails in development.
+  config.action_mailer.perform_deliveries = false
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,12 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   # Host to use when generating URls in emails.
-  config.action_mailer.default_url_options = { host: ENV.fetch('ACTION_MAILER_URL_OPTIONS_HOST', 'center.alces-flight.com') }
+  url_options_host = if ENV['STAGING']
+                       'staging.center.alces-flight.com'
+                     else
+                       'center.alces-flight.com'
+                     end
+  config.action_mailer.default_url_options = { host: url_options_host }
 
   config.roadie.url_options = config.action_mailer.default_url_options
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -36,7 +36,8 @@ namespace :alces do
         staging_password = Deployment::Staging.password
 
         User.where(admin: false).each do |user|
-          new_email = "center+#{user.name.gsub(/ /, '')}@alces-software.com"
+          local_part = user.email.split('@').first
+          new_email = "center+#{local_part}@alces-software.com"
           user.update!(email: new_email, password: staging_password)
         end
       end

--- a/spec/lib/tasks/deploy_spec.rb
+++ b/spec/lib/tasks/deploy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'alces:deploy:staging:obfuscate_user_data' do
   include_context 'rake'
 
   let! :contact do
-    create(:contact, name: 'Some Contact', email: 'some.contact@example.com')
+    create(:contact, name: 'Some Contact', email: 'some.contact.email@example.com')
   end
 
   let! :admin do
@@ -19,10 +19,10 @@ RSpec.describe 'alces:deploy:staging:obfuscate_user_data' do
 
   it_behaves_like 'it has prerequisite', :environment
 
-  it 'changes contacts to have `@alces-software.com` emails' do
+  it 'changes contacts to have `center+${local_part}@alces-software.com` emails' do
     subject.invoke
 
-    expect(contact.reload.email).to eq 'center+somecontact@alces-software.com'
+    expect(contact.reload.email).to eq 'center+some.contact.email@alces-software.com'
   end
 
   it 'sets contact passwords to STAGING_PASSWORD environment variable' do


### PR DESCRIPTION
This PR makes some changes to our email settings for staging, as prompted by @mjtko's requests in https://trello.com/c/Ej03zix1/321-in-staging-send-emails-from-centerstagingalces-softwarecom. Specifically we now:

- prevent sending emails in development;

- send emails from `center+staging@alces-software.com` in staging, so these can be more easily filtered;

- use a `STAGING` environment variable to toggle all staging vs production settings, so this is explicit in the code rather than configured in various places by the environment;

- fixed the obfuscating of contact emails to the form `center+...@alces-software.com`, so this doesn't blow up when run in staging.

I don't think there's anything too crazy here, and this is running seemingly successfully in staging atm, but @jamesremuscat would you be able to take a quick look to check I've not missed anything :slightly_smiling_face:.