### PR TITLE
Validate services for advice based clusters

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -18,8 +18,7 @@ class Cluster < ApplicationRecord
   validates :name, presence: true
   validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true
   validates :canonical_name, presence: true
-  validate :validate_all_components_advice, if: :advice?
-  validate :validate_all_services_advice, if: :advice?
+  validate :validate_all_cluster_parts_advice, if: :advice?
   validates :shortcode, presence: true, uniqueness: true
   # validates_presence_of :motd
 
@@ -76,17 +75,14 @@ class Cluster < ApplicationRecord
 
   private
 
-  def validate_all_components_advice
-    unless components.all?(&:advice?)
-      errors.add(:base, 'advice Cluster cannot be associated with managed Components')
+  def validate_all_cluster_parts_advice
+    ['components', 'services'].each do |cluster_part|
+      unless eval(cluster_part).all?(&:advice?)
+        errors.add(:base, "advice Cluster cannot be associated with managed #{cluster_part.capitalize}")
+      end
     end
   end
 
-  def validate_all_services_advice
-    unless services.all?(&:advice?)
-      errors.add(:base, 'advice Cluster cannot be associated with managed Services')
-    end
-  end
 
   def create_automatic_services
     ServiceType.automatic.each do |service_type|

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -19,6 +19,7 @@ class Cluster < ApplicationRecord
   validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true
   validates :canonical_name, presence: true
   validate :validate_all_components_advice, if: :advice?
+  validate :validate_all_services_advice, if: :advice?
   validates :shortcode, presence: true, uniqueness: true
   # validates_presence_of :motd
 
@@ -78,6 +79,12 @@ class Cluster < ApplicationRecord
   def validate_all_components_advice
     unless components.all?(&:advice?)
       errors.add(:base, 'advice Cluster cannot be associated with managed Components')
+    end
+  end
+
+  def validate_all_services_advice
+    unless services.all?(&:advice?)
+      errors.add(:base, 'advice Cluster cannot be associated with managed Services')
     end
   end
 

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -77,12 +77,11 @@ class Cluster < ApplicationRecord
 
   def validate_all_cluster_parts_advice
     ['components', 'services'].each do |cluster_part|
-      unless eval(cluster_part).all?(&:advice?)
+      unless self.public_send(cluster_part).all?(&:advice?)
         errors.add(:base, "advice Cluster cannot be associated with managed #{cluster_part.capitalize}")
       end
     end
   end
-
 
   def create_automatic_services
     ServiceType.automatic.each do |service_type|

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -16,7 +16,8 @@ class Component < ApplicationRecord
 
   validates_associated :component_group,
                        :asset_record_fields,
-                       :component_expansions
+                       :component_expansions,
+                       :cluster
 
   after_create :create_component_expansions_from_defaults
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,4 +6,6 @@ class Service < ApplicationRecord
   belongs_to :cluster
 
   delegate :description, to: :service_type
+
+  validates_associated :cluster
 end

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Cluster, type: :model do
 
         it { is_expected.to be_valid }
       end
+
+      context 'with managed service' do
+        before :each do
+          create(:managed_service, cluster: subject)
+        end
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context 'when advice cluster' do
@@ -60,6 +68,20 @@ RSpec.describe Cluster, type: :model do
         end
 
         it { is_expected.to be_valid }
+      end
+
+      context 'with managed service' do
+        before :each do
+          create(:managed_service, cluster: subject)
+          subject.reload
+        end
+
+        it 'should be invalid' do
+          expect(subject).to be_invalid
+          expect(subject.errors.messages).to include(
+            base: [/advice Cluster cannot be associated with managed Services/]
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
This PR validates `Services` in the same manner that `Components` are validated for advice based clusters.

[Trello](https://trello.com/c/AK9Truy4/120-missing-corresponding-validation-that-advice-cluster-does-not-have-managed-services-as-for-components)