### PR TITLE
Display log entries in case history

### DIFF
--- a/app/decorators/log_decorator.rb
+++ b/app/decorators/log_decorator.rb
@@ -1,0 +1,9 @@
+class LogDecorator < ApplicationDecorator
+  def event_card
+    h.render 'cases/event',
+             name: object.engineer.name,
+             date: object.created_at,
+             text: object.details,
+             type: 'pencil-square-o'
+  end
+end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -143,7 +143,8 @@ class Case < ApplicationRecord
         # date. We clearly don't want to include that in the events stream.
       maintenance_windows.map(&:transitions).flatten.select(&:event) +
       case_state_transitions +
-      audits
+      audits +
+      logs
     ).sort_by(&:created_at).reverse!
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -12,7 +12,7 @@ class Case < ApplicationRecord
   belongs_to :assignee, class_name: 'User', required: false
 
   has_many :maintenance_windows
-  has_and_belongs_to_many :log
+  has_and_belongs_to_many :logs
   has_many :case_comments
   has_one :change_motd_request, required: false, autosave: true
 

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe 'Case page' do
       create(:case_comment, case: open_case, user: admin, created_at: 2.hours.ago, text: 'Second')
       create(
         :maintenance_window_state_transition,
-        maintenance_window: mw,
-        user: admin,
-        event: :request
+      maintenance_window: mw,
+      user: admin,
+      event: :request
       )
       create(:case_comment, case: open_case, user: admin, created_at: 4.hours.ago, text: 'First')
 
@@ -81,24 +81,29 @@ RSpec.describe 'Case page' do
       open_case.tier_level = 3
       open_case.save
 
+      # And a log entry
+      create(:log, cases: [open_case], cluster: cluster, details: 'Loggy McLogface')
 
       visit case_path(open_case, as: admin)
 
       event_cards = all('.event-card')
-      expect(event_cards.size).to eq(6)
+      expect(event_cards.size).to eq(7)
 
-      expect(event_cards[5].find('.card-body').text).to eq('First')
-      expect(event_cards[4].find('.card-body').text).to eq('Second')
-      expect(event_cards[3].find('.card-body').text).to match(
+      expect(event_cards[6].find('.card-body').text).to eq('First')
+      expect(event_cards[5].find('.card-body').text).to eq('Second')
+      expect(event_cards[4].find('.card-body').text).to match(
         /Maintenance requested for .* from .* until .* by A Scientist; to proceed this maintenance must be confirmed on the cluster dashboard/
       )
-      expect(event_cards[2].find('.card-body').text).to eq 'Changed time worked from 0m to 2h 3m.'
+      expect(event_cards[3].find('.card-body').text).to eq 'Changed time worked from 0m to 2h 3m.'
 
-      expect(event_cards[1].find('.card-body').text).to eq(
+      expect(event_cards[2].find('.card-body').text).to eq(
           'Assigned this case to A Scientist.'
       )
-      expect(event_cards[0].find('.card-body').text).to eq(
+      expect(event_cards[1].find('.card-body').text).to eq(
           'Escalated this case to tier 3 (General Support).'
+      )
+      expect(event_cards[0].find('.card-body').text).to eq(
+          'Loggy McLogface'
       )
     end
 


### PR DESCRIPTION
This PR adds log entries related to a `Case` to its events feed.

See https://trello.com/c/UhTEqeIH/179-should-we-support-markdown-rendering-for-log-entries-and-comments for a question on how these are rendered; for now we just use plain text, as in other places.

Trello: https://trello.com/c/wjZ6C9tM/317-associated-log-entries-should-appear-in-case-history
Fixes #234.