### PR TITLE
Reword 'commenting disabled because tier' message.

### DIFF
--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -40,8 +40,8 @@ class CaseDecorator < ApplicationDecorator
       "Commenting is disabled as this case is #{state}."
     elsif current_user.contact? && !consultancy?
       <<~TITLE.squish
-            This is a non-consultancy support case and so additional discussion is
-            not available. If you wish to request additional support please either
+            Additional discussion is not available for cases in the current
+            support tier. If you wish to request additional support please either
             escalate this case (which may incur a charge), or open a
             new support case.
       TITLE

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe 'Case page' do
           find(comment_form_class)
         end.to raise_error(Capybara::ElementNotFound)
 
-        expect(find('.card.bg-light').text).to match 'This is a non-consultancy support case and so additional discussion is not available.'
+        expect(find('.card.bg-light').text).to match 'Additional discussion is not available for cases in the current support tier'
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/pNogpTWE/312-when-disabling-commenting-in-case-form-refer-commenting-on-support-for-this-to-tier-being-unavailable-not-consultancy