### PR TITLE
Change `From:` addresses to `alces-flight.com` domain.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,9 +37,9 @@ module AlcesFlightCenter
     config.active_job.queue_adapter = :resque
 
     config.email_from = if ENV['STAGING']
-                          'Alces Flight Center Staging <center+staging@alces-software.com>'
+                          'Alces Flight Center Staging <center+staging@alces-flight.com>'
                         else
-                          'Alces Flight Center <center@alces-software.com>'
+                          'Alces Flight Center <center@alces-flight.com>'
                         end
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
As title.

Trello: https://trello.com/c/h9YdNOD3/324-correct-emails-displayed-by-flight-center-to-be-alces-flightcom