### PR TITLE
Tier tabs

### DIFF
--- a/app/javascript/packs/Tier/DisplayWrapper.elm
+++ b/app/javascript/packs/Tier/DisplayWrapper.elm
@@ -71,19 +71,7 @@ extractId wrapper =
 
 description : DisplayWrapper -> String
 description wrapper =
-    let
-        levelDescription =
-            Level.description <| getLevel wrapper
-    in
-    case wrapper of
-        AvailableTier _ ->
-            levelDescription
-
-        UnavailableTier _ ->
-            String.join " "
-                [ levelDescription
-                , "(unavailable for selected issue)"
-                ]
+    Level.description <| getLevel wrapper
 
 
 getLevel : DisplayWrapper -> Level

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -201,7 +201,14 @@ tierTabs state =
     -- than being an independent part of the model itself. Doing what we want
     -- with it seemed difficult and convoluted, if not impossible, with the
     -- current API.
-    ul [ class "nav nav-tabs" ] tabItems
+    div []
+        [ ul [ class "nav nav-tabs" ] tabItems
+
+        -- Need hidden field and accompanying `invalid-feedback` `div`, which
+        -- Bootstrap will use to decide whether to show any validation errors
+        -- for the selected Tier.
+        , Fields.hiddenFieldWithVisibleErrors Field.Tier state
+        ]
 
 
 displayWrapperToTab : SelectList.Position -> DisplayWrapper -> Html Msg

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -232,7 +232,16 @@ displayWrapperToTab position wrapper =
                 ""
     in
     li [ class "nav-item" ]
-        [ a [ classList linkClasses, onClick clickMsg, title titleText ]
+        [ a
+            [ classList linkClasses
+            , onClick clickMsg
+            , title titleText
+
+            -- A `href` is required for Bootstrap to style the tabs correctly,
+            -- and it needs this value as we don't want it to actually go
+            -- anywhere (apart from what we handle in `onClick`).
+            , href "javascript:void(0)"
+            ]
             [ text <| Tier.DisplayWrapper.description wrapper ]
         ]
 

--- a/app/javascript/packs/View/CaseForm.elm
+++ b/app/javascript/packs/View/CaseForm.elm
@@ -28,6 +28,7 @@ import Validation
 import View.Charging as Charging
 import View.Fields as Fields
 import View.PartsField as PartsField exposing (PartsFieldConfig(..))
+import View.Utils
 
 
 view : State -> Html Msg
@@ -40,12 +41,9 @@ view state =
                 StartSubmit
 
         formElements =
-            Maybe.Extra.values
-                [ Just <| issueDrillDownSection state
-                , maybeSubjectSection state
-                , Just <| dynamicFieldsSection state
-                ]
-                |> List.intersperse (hr [] [])
+            [ issueDrillDownSection state
+            , dynamicFieldsSection state
+            ]
     in
     Html.form [ onSubmit submitMsg ] formElements
 
@@ -63,25 +61,7 @@ issueDrillDownSection state =
             , issuesField state |> Just
             , maybeComponentsField state
             , tierTabs state |> Just
-            , Charging.chargeableAlert state
             ]
-
-
-maybeSubjectSection : State -> Maybe (Html Msg)
-maybeSubjectSection state =
-    let
-        selectedTier =
-            State.selectedTier state
-    in
-    case selectedTier.level of
-        Level.Zero ->
-            -- Does not make sense to display subject field when a level 0 Tier
-            -- is selected, since the form cannot be submitted and only
-            -- information is displayed.
-            Nothing
-
-        _ ->
-            Just <| section [] [ subjectField state ]
 
 
 dynamicFieldsSection : State -> Html Msg
@@ -100,7 +80,9 @@ dynamicFieldsSection state =
                     [ tierContentElements ]
 
                 _ ->
-                    [ tierContentElements
+                    [ subjectField state
+                    , hr [] []
+                    , tierContentElements
                     , submitButton state
                     ]
 
@@ -208,6 +190,8 @@ tierTabs state =
         -- Bootstrap will use to decide whether to show any validation errors
         -- for the selected Tier.
         , Fields.hiddenFieldWithVisibleErrors Field.Tier state
+        , Charging.chargeableAlert state
+            |> Maybe.withDefault View.Utils.nothing
         ]
 
 

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -8,6 +8,7 @@ module View.Charging
 import Bootstrap.Alert as Alert
 import Bootstrap.Button as Button
 import Bootstrap.Modal as Modal
+import Bootstrap.Utilities.Spacing as Spacing
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
@@ -48,7 +49,10 @@ chargeableAlert state =
                 [ text "Click here for the charging details for this cluster." ]
     in
     if isChargeable then
-        Just <| Alert.simpleWarning [] alertChildren
+        Just <|
+            Alert.simpleWarning
+                [ Spacing.mt2, Spacing.mb0 ]
+                alertChildren
     else
         Nothing
 

--- a/app/javascript/packs/View/Charging.elm
+++ b/app/javascript/packs/View/Charging.elm
@@ -41,9 +41,8 @@ chargeableAlert state =
             Alert.link
                 [ ClusterChargingInfoModal Modal.shown |> onClick
 
-                -- This makes this display as a normal link, but clicking on it
-                -- not reload the page. There may be a better way to do this;
-                -- `href="#"` does not work.
+                -- Make this display as a normal link, but clicking on it not
+                -- reload the page.
                 , href "javascript:void(0)"
                 ]
                 [ text "Click here for the charging details for this cluster." ]

--- a/app/javascript/packs/View/Fields.elm
+++ b/app/javascript/packs/View/Fields.elm
@@ -1,6 +1,7 @@
 module View.Fields
     exposing
-        ( selectField
+        ( hiddenFieldWithVisibleErrors
+        , selectField
         , textField
         )
 
@@ -169,6 +170,24 @@ formField field item htmlFn additionalAttributes children optional help state =
         , requiredBadge
         , formElement
         , helpElement
+        , validationFeedback errors
+        ]
+
+
+hiddenFieldWithVisibleErrors : Field -> State -> Html msg
+hiddenFieldWithVisibleErrors field state =
+    let
+        errors =
+            Validation.validateField field state
+    in
+    div []
+        [ input
+            -- Bootstrap requires an input with appropriate classes as a
+            -- sibling in order to show an `invalid-feedback` `div`.
+            [ type_ "hidden"
+            , class <| formControlClasses field errors
+            ]
+            []
         , validationFeedback errors
         ]
 


### PR DESCRIPTION
This PR switches Tiers to be shown as tabs in the Case form rather than as a select box.

Trello: https://trello.com/c/6oTyaPkO/314-show-tabs-for-tiers-instead-of-select-box.

Couple of things worth noting about this:

1. The charging info alert currently looks slightly bad due to a bug in one of our dependencies; we could work around this but not a big deal and should be fixed soon (https://github.com/alces-software/alces-flight-center/commit/3cfd1e9639b13253182feaf1a93bc4410d431e6d).

2. Some refactoring could be done following this to the Tier view code, but leaving this for now since will take a little while/ things could change again soon/ not a big deal (see https://trello.com/c/sBi5g76q/185-tidy-up-tierdisplaywrapper-related-code).