### PR TITLE
Fix production data import error being obscured

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -17,7 +17,9 @@ namespace :alces do
     EOF
     task :import_production do
       # Delegate out to the shell script which does all the work.
-      system('bin/import-production-data')
+      unless system('bin/import-production-data')
+        abort 'Production data import failed!'
+      end
     end
   end
 end


### PR DESCRIPTION
When running `rake alces:data:import_and_migrate_production`, if running
the `bin/import-production-data` script failed (which could happen for
many reasons - lack of AWS keys being available, network error etc.) we
would previously blindly carry on. This would then cause an odd error to
occur as the Rake task would then attempt to run all the regular and
data migrations over an empty database, which doesn't work (normally it
should run just the migrations since we last deployed to production over
the imported production database).

This commit fixes this by aborting the task in this case, so you can
then easily see the real reason that things failed.

^ @atoghill this should make it more obvious what went wrong next time you get that issue.