### PR TITLE
Let Rails 5.2 update schema version

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180521143035) do
+ActiveRecord::Schema.define(version: 2018_05_21_143035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Apparently Rails 5.2 changed the schema version format, so let it update
this as it wants.