### PR TITLE
Remove now unused `rt_format` method

### DIFF
--- a/app/lib/utils.rb
+++ b/app/lib/utils.rb
@@ -1,16 +1,6 @@
 
 module Utils
   class << self
-    # Format a hash consisting of string/symbol keys and values into the format
-    # expected by the rt API (https://rt-wiki.bestpractical.com/wiki/REST),
-    # which is also fairly human readable.
-    def rt_format(properties)
-      properties.map do |key, value|
-        indented_value = value.to_s.gsub("\n", "\n ").strip + "\n"
-        "#{key}: #{indented_value}"
-      end.join("\n").squeeze("\n")
-    end
-
     # From https://stackoverflow.com/a/7987501.
     def generate_password(length:)
       SecureRandom.urlsafe_base64(length).delete('_-')[0, length]

--- a/spec/lib/utils_spec.rb
+++ b/spec/lib/utils_spec.rb
@@ -3,28 +3,6 @@ require 'rails_helper'
 require 'utils'
 
 RSpec.describe Utils do
-  describe '#rt_format' do
-    it 'appropriately formats a hash as text' do
-      expect(
-        described_class.rt_format(foo: 'bar',
-                                  multiline_string: <<-EOF.strip_heredoc,
-          is
-          appropriately
-          indented
-          EOF
-                                  another_key: 'value')
-      ).to eq(
-        <<-EOF.strip_heredoc
-          foo: bar
-          multiline_string: is
-           appropriately
-           indented
-          another_key: value
-        EOF
-      )
-    end
-  end
-
   describe '#generate_password' do
     it 'generates a string of uppercase, lowercase, or digit characters' do
       expect(


### PR DESCRIPTION
We have now removed RT integration, and no longer use this method.