### PR TITLE
Keep the user in the same dashboard when viewing a case

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,19 +66,6 @@ class ApplicationController < ActionController::Base
              when /^\/services/
                id = scope_id_param(:service_id)
                @service = @cluster_part = Service.find(id)
-             when /^\/cases/
-               begin
-                 id = scope_id_param(:case_id)
-                 Case.find_from_id!(id).associated_model
-               rescue ActiveRecord::RecordNotFound
-                 # There are various routes which begin `/cases/` but are not
-                 # the route for a particular Case; if we can't find the Case
-                 # we must either be in one of these, or we are trying to find
-                 # a Case which actually doesn't exist. Either way assign the
-                 # Site scope rather than blow up, then carry on and let
-                 # specific controller we are in handle this as normal.
-                 assign_site_scope
-               end
              else
                assign_site_scope
              end

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -3,6 +3,7 @@ class CaseCommentsController < ApplicationController
 
   def create
     my_case = Case.find_from_id!(params.require(:case_id))
+    fallback_location = @scope.decorate.dashboard_case_path(my_case)
 
     new_comment = my_case.case_comments.create(
         user: current_user,
@@ -17,10 +18,10 @@ class CaseCommentsController < ApplicationController
       flash[:error] = "Your comment was not added. #{new_comment.errors.full_messages.join('; ').strip}"
     end
 
-    redirect_back fallback_location: @scope.decorate.dashboard_case_path(my_case)
+    redirect_back fallback_location: fallback_location
 
   rescue ActionController::ParameterMissing
     flash[:error] = 'Empty comments are not permitted.'
-    redirect_back fallback_location: @scope.decorate.dashboard_case_path(my_case)
+    redirect_back fallback_location: fallback_location
   end
 end

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -17,10 +17,10 @@ class CaseCommentsController < ApplicationController
       flash[:error] = "Your comment was not added. #{new_comment.errors.full_messages.join('; ').strip}"
     end
 
-    redirect_to case_path(my_case)
+    redirect_back fallback_location: @scope.decorate.dashboard_case_path(my_case)
 
   rescue ActionController::ParameterMissing
     flash[:error] = 'Empty comments are not permitted.'
-    redirect_to case_path(my_case)
+    redirect_back fallback_location: @scope.decorate.dashboard_case_path(my_case)
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -14,8 +14,12 @@ class CasesController < ApplicationController
 
   def show
     @case = case_from_params
-    not_found unless @scope.cases.include? @case
-    @comment = @case.case_comments.new
+    if [AllSites, Site].include? @scope.class
+      redirect_to cluster_case_path(@case.cluster, @case)
+    else
+      not_found unless @scope.cases.include? @case
+      @comment = @case.case_comments.new
+    end
   end
 
   def new
@@ -45,7 +49,7 @@ class CasesController < ApplicationController
         format.json do
           # Return no errors and success status to case form app; it will
           # redirect to the path we give it.
-          render json: { redirect: case_path(@case) }
+          render json: { redirect: cluster_case_path(@case.cluster, @case) }
         end
       else
         errors = format_errors(@case)
@@ -58,8 +62,7 @@ class CasesController < ApplicationController
 
       format.html do
         flash[:error] = "Error creating support case: #{errors}." if errors
-        redirect_path = @case.cluster ? cluster_path(@case.cluster) : root_path
-        redirect_to redirect_path
+        redirect_back fallback_location: @case.cluster ? cluster_path(@case.cluster) : root_path
       end
     end
   end
@@ -72,7 +75,7 @@ class CasesController < ApplicationController
     end
   rescue ActionController::ParameterMissing
     flash[:error] = 'You must specify a credit charge to close this case.'
-    redirect_to case_path
+    redirect_to @scope.decorate.dashboard_case_path(case_from_params)
   end
 
   def assign
@@ -132,7 +135,7 @@ class CasesController < ApplicationController
     rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
       flash[:error] = "Error updating support case: #{format_errors(@case)}"
     end
-    redirect_to case_path(@case)
+    redirect_to @scope.decorate.dashboard_case_path(@case)
   end
 
   def case_from_params

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -13,6 +13,7 @@ class CasesController < ApplicationController
   end
 
   def show
+    not_found unless @scope.cases.include? case_from_params
     @case = case_from_params
     @comment = @case.case_comments.new
   end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -13,8 +13,8 @@ class CasesController < ApplicationController
   end
 
   def show
-    not_found unless @scope.cases.include? case_from_params
     @case = case_from_params
+    not_found unless @scope.cases.include? @case
     @comment = @case.case_comments.new
   end
 

--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -9,7 +9,7 @@ class AllSitesDecorator < ApplicationDecorator
   end
 
   def dashboard_case_path(kase)
-    Rails.application.routes.url_helpers.cluster_case_path(kase.cluster, kase)
+    h.cluster_case_path(kase.cluster, kase)
   end
 
   private

--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -8,6 +8,10 @@ class AllSitesDecorator < ApplicationDecorator
     ]
   end
 
+  def dashboard_case_path(kase)
+    Rails.application.routes.url_helpers.cluster_case_path(kase.cluster, kase)
+  end
+
   private
 
   def cases_tab
@@ -21,9 +25,5 @@ class AllSitesDecorator < ApplicationDecorator
   # We override these to generate the top level path names
   def scope_name_for_paths
     ''
-  end
-
-  def arguments_for_scope_path(*a)
-    a
   end
 end

--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -26,4 +26,8 @@ class AllSitesDecorator < ApplicationDecorator
   def scope_name_for_paths
     ''
   end
+
+  def arguments_for_scope_path(*a)
+    a
+  end
 end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -59,6 +59,10 @@ class ApplicationDecorator < Draper::Decorator
     s.match?(/\A(.+_)?scope_(.+_)?path\Z/) ? :scope_path : super
   end
 
+  def dashboard_case_path(kase)
+    h.polymorphic_path([self, kase])
+  end
+
   private
 
   def convert_scope_path(s)

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -19,7 +19,11 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def case_link
-    h.link_to(display_id, h.case_path(self), title: subject)
+    h.link_to(
+      display_id,
+      h.cluster_case_path(self.cluster, self),
+      title: subject
+    )
   end
 
   def request_maintenance_path

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -27,13 +27,13 @@ end %>
 
     <tbody class="assigned-cases">
       <% cases.assigned_to(current_user).decorate.each do |c| %>
-        <%= render 'partials/case_table_row', kase: c %>
+        <%= render 'partials/case_table_row', kase: c, scope: @scope %>
       <% end %>
     </tbody>
 
     <tbody>
       <% cases.not_assigned_to(current_user).decorate.each do |c| %>
-        <%= render 'partials/case_table_row', kase: c %>
+        <%= render 'partials/case_table_row', kase: c, scope: @scope %>
       <% end %>
     </tbody>
   <% end %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to kase.display_id, case_path(kase) %></td>
+  <td><%= link_to kase.display_id, polymorphic_path([scope, kase]) %></td>
   <%= timestamp_td(
     description:  'Support case created',
     timestamp: kase.created_at

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,12 +1,12 @@
 <tr>
-  <td><%= link_to kase.display_id, polymorphic_path([scope, kase]) %></td>
+  <td><%= link_to kase.display_id, scope.decorate.dashboard_case_path(kase) %></td>
   <%= timestamp_td(
     description:  'Support case created',
     timestamp: kase.created_at
   ) %>
   <td><%= kase.user_facing_state %></td>
   <td style="white-space: nowrap;"><%= kase.user.name %></td>
-  <td><%= link_to kase.subject, case_path(kase) %></td>
+  <td><%= kase.subject %></td>
   <td>
     <% if current_user == kase.assignee %>
       <%= raw('<strong>Me</strong>') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
   end
 
   resolved_cases = Proc.new do |**params, &block|
-    params[:only] = Array.wrap(params[:only]).concat [:new, :index]
+    params[:only] = Array.wrap(params[:only]).concat [:show, :new, :index]
     resources :cases, **params do
       collection do
         get :resolved
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
 
     root 'sites#index'
     resources :sites, only: [:show, :index] do
-      resolved_cases.call(only: :show)
+      resolved_cases.call
     end
 
     resources :cases, only: [] do
@@ -133,7 +133,7 @@ Rails.application.routes.draw do
     root 'sites#show'
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 
-    resolved_cases.call(only: [:show, :create]) do
+    resolved_cases.call(only: [:create]) do
       resources :case_comments, only: :create
       member do
         post :escalate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
     resources :maintenance_windows, path: :maintenance, only: :index
   end
 
-  resolved_cases = Proc.new do |**params, &block|
+  cases = Proc.new do |**params, &block|
     params[:only] = Array.wrap(params[:only]).concat [:show, :new, :index]
     resources :cases, **params do
       collection do
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
 
     root 'sites#index'
     resources :sites, only: [:show, :index] do
-      resolved_cases.call
+      cases.call
     end
 
     resources :cases, only: [] do
@@ -133,7 +133,7 @@ Rails.application.routes.draw do
     root 'sites#show'
     delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
 
-    resolved_cases.call(only: [:create]) do
+    cases.call(only: [:create]) do
       resources :case_comments, only: :create
       member do
         post :escalate
@@ -141,7 +141,7 @@ Rails.application.routes.draw do
     end
 
     resources :clusters, only: :show do
-      resolved_cases.call
+      cases.call
       resources :services, only: :index
       maintenance_windows.call
       resources :components, only: :index
@@ -151,7 +151,7 @@ Rails.application.routes.draw do
     end
 
     resources :components, only: :show do
-      resolved_cases.call
+      cases.call
       maintenance_windows.call
       resources :component_expansions,
                 path: component_expansions_alias,
@@ -168,7 +168,7 @@ Rails.application.routes.draw do
     end
 
     resources :services, only: :show do
-      resolved_cases.call
+      cases.call
       maintenance_windows.call
       confirm_maintenance_form.call
     end

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe CaseDecorator do
       end.case_link
 
       expect(link).to eq h
-        .link_to('RT12345', h.case_path(kase), title: kase.subject)
+        .link_to('RT12345', h.cluster_case_path(kase.cluster, kase), title: kase.subject)
     end
   end
 

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -514,20 +514,21 @@ RSpec.describe 'Case page' do
   describe 'redirection' do
     let (:kase) { create(:case, cluster: cluster) }
 
-    context 'as contact' do
-      it 'redirects from site dashboard to cluster dashboard case page' \
-        ' when visiting /cases/:id' do
-        visit(case_path(kase, as: contact))
+    RSpec.shared_examples 'redirect examples' do
+      it "redirects to the cluster dashboard case page from /cases/:id" do
+        visit(case_path(kase, as: user))
         expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
       end
     end
 
+    context 'as contact' do
+      let (:user) { contact }
+      include_examples 'redirect examples'
+    end
+
     context 'as admin' do
-      it 'redirects from all sites dashboard to cluster dashboard case page' \
-        ' when visiting /cases/:id' do
-        visit(case_path(kase, as: admin))
-        expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
-      end
+      let (:user) { admin }
+      include_examples 'redirect examples'
     end
   end
 end

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe 'Case page' do
       end.to change { request.reload.transitions.length }.by(1)
 
       expect(request).to be_applied
-      expect(current_path).to eq(case_path(subject))
+      expect(current_path).to eq(cluster_case_path(subject.cluster, subject))
       expect(
         find('.alert')
       ).to have_text('The cluster has been updated to reflect this change.')
@@ -508,6 +508,14 @@ RSpec.describe 'Case page' do
           expect(page).not_to have_button(button_text)
         end
       end
+    end
+  end
+
+  describe 'redirects' do
+    let (:kase) { create(:case, cluster: cluster) }
+    it 'to cluster dashboard case page when visiting /cases/:id' do
+      visit(case_path(kase, as: contact))
+      expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
     end
   end
 end

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -511,11 +511,23 @@ RSpec.describe 'Case page' do
     end
   end
 
-  describe 'redirects' do
+  describe 'redirection' do
     let (:kase) { create(:case, cluster: cluster) }
-    it 'to cluster dashboard case page when visiting /cases/:id' do
-      visit(case_path(kase, as: contact))
-      expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
+
+    context 'as contact' do
+      it 'redirects from site dashboard to cluster dashboard case page' \
+        ' when visiting /cases/:id' do
+        visit(case_path(kase, as: contact))
+        expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
+      end
+    end
+
+    context 'as admin' do
+      it 'redirects from all sites dashboard to cluster dashboard case page' \
+        ' when visiting /cases/:id' do
+        visit(case_path(kase, as: admin))
+        expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
+      end
     end
   end
 end

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -513,11 +513,26 @@ RSpec.describe 'Case page' do
 
   describe 'redirection' do
     let (:kase) { create(:case, cluster: cluster) }
+    let (:another_kase) { create(:case, cluster: another_cluster) }
+    let (:another_site) { create(:site, name: 'Not My Site') }
+    let (:another_cluster) { create(:cluster, site: another_site) }
+
 
     RSpec.shared_examples 'redirect examples' do
       it "redirects to the cluster dashboard case page from /cases/:id" do
         visit(case_path(kase, as: user))
         expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
+      end
+
+      it 'correctly visits the case page for an associated case' do
+        visit(cluster_case_path(cluster, kase, as: user))
+        expect(page).to have_http_status(200)
+      end
+
+      it 'returns a routing error when visiting an unassociated case page' do
+        expect do
+          visit(cluster_case_path(cluster, another_kase, as: user))
+        end.to raise_error(ActionController::RoutingError)
       end
     end
 

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -100,24 +100,6 @@ RSpec.feature 'Navigation Bar', type: :feature do
       before(:each) { visit_subject :service_path }
       it_behaves_like 'a cluster navigation bar'
     end
-
-    context 'when visiting a case' do
-      subject do
-        create(:case_requiring_component, component: associated_model)
-      end
-      let(:associated_model) { create(:component, cluster: cluster) }
-
-      let :expected_cluster_links do
-        [
-          cluster_path(associated_model.cluster),
-          component_group_path(associated_model.component_group),
-          component_path(associated_model),
-        ]
-      end
-
-      before(:each) { visit_subject :case_path }
-      it_behaves_like 'a cluster navigation bar'
-    end
   end
 
   context 'with an admin logged in' do


### PR DESCRIPTION
This PR implements the ability to view cases from within the same dashboard you were previously in. Meaning you will no longer be unexpectedly moved to a different dashboard after clicking a link to view a specific case that may be relating to a different context than your current dashboard.

[Trello](https://trello.com/c/BtXmytRu/326-need-multiple-pages-for-a-case-for-each-level-it-is-available-for)