### PR TITLE
Send resque errors to Sentry with resque-sentry (fixes #257) [backport of #310]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'sass'
 # For async emails
 gem 'resque'
 gem 'resque_mailer'
+gem 'resque-sentry' # For Sentry integration; must be after `gem 'resque'`.
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,9 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-sentry (1.2.0)
+      resque (>= 1.18.0)
+      sentry-raven (>= 0.4.6)
     resque_mailer (2.4.3)
       actionmailer (>= 3.0)
       activesupport (>= 3.0)
@@ -450,6 +453,7 @@ DEPENDENCIES
   rails_email_preview (~> 2.0.4)
   request_store
   resque
+  resque-sentry
   resque_mailer
   roadie-rails (~> 1.0)
   rspec-rails

--- a/config/initializers/resque-sentry.rb
+++ b/config/initializers/resque-sentry.rb
@@ -1,0 +1,9 @@
+require 'resque/failure/multiple'
+require 'resque/failure/redis'
+require 'resque-sentry'
+
+# Custom logger value to use when sending to Sentry (default is 'root').
+Resque::Failure::Sentry.logger = 'resque'
+
+Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::Sentry]
+Resque::Failure.backend = Resque::Failure::Multiple


### PR DESCRIPTION
Thanks @jamesremuscat for pointing me towards this:
https://github.com/alces-software/alces-flight-center/issues/257#issuecomment-390653217.

Backport of #310.