### PR TITLE
Switch to user roles

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -195,7 +195,7 @@ class Case < ApplicationRecord
 
   def potential_assignees
     User.where(site: site).order(:name) +
-        User.where(admin: true).order(:name)
+        User.where(role: :admin).order(:name)
   end
 
   def assignee=(new_assignee)

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -23,10 +23,10 @@ class Site < ApplicationRecord
   end
 
   def primary_contact
-    users.find_by(primary_contact: true)
+    users.find_by(role: 'primary_contact')
   end
 
   def secondary_contacts
-    users.where(primary_contact: false)
+    users.where(role: 'secondary_contact')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,9 +38,10 @@ class User < ApplicationRecord
   end
 
   def validates_primary_contact_assignment
-    return if site&.primary_contact.nil?
-    errors.add(:primary_contact, 'is already set for this site') if
-      primary_contact && site.primary_contact != self
+    return unless site_primary_contact
+    if primary_contact? && site_primary_contact != self
+      errors.add(:role, 'primary contact is already set for this site')
+    end
   end
 
   def self.globally_available?
@@ -51,5 +52,9 @@ class User < ApplicationRecord
 
   def role_inquiry
     role&.inquiry
+  end
+
+  def site_primary_contact
+    @site_primary_contact ||= site&.primary_contact
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   include Clearance::User
   include AdminConfig::User
 
+  ROLES = %w{admin primary_contact secondary_contact viewer}
+
   belongs_to :site, required: false
 
   validates_associated :site
@@ -12,6 +14,7 @@ class User < ApplicationRecord
             presence: true,
             email_format: { message: Constants::EMAIL_FORMAT_MESSAGE }
   validates :password, length: { minimum: 5 }, if: :password
+  validates :role, presence: true, inclusion: ROLES
 
   validates :site, {
     presence: {if: :contact?},

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,16 +26,15 @@ class User < ApplicationRecord
   }
   validate :validates_primary_contact_assignment
 
-  alias_attribute :primary_contact?, :primary_contact
-
-  alias_attribute :admin?, :admin
+  delegate :admin?,
+    :primary_contact?,
+    :secondary_contact?,
+    :viewer?,
+    to: :role_inquiry,
+    allow_nil: true
 
   def contact?
     !admin?
-  end
-
-  def secondary_contact?
-    contact? && !primary_contact?
   end
 
   def validates_primary_contact_assignment
@@ -46,5 +45,11 @@ class User < ApplicationRecord
 
   def self.globally_available?
     true
+  end
+
+  private
+
+  def role_inquiry
+    role&.inquiry
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,10 +20,6 @@ class User < ApplicationRecord
     presence: {if: :contact?},
     absence: {if: :admin?}
   }
-  validates :primary_contact, {
-    inclusion: {in: [true, false], if: :contact?},
-    absence: {if: :admin?}
-  }
   validate :validates_primary_contact_assignment
 
   delegate :admin?,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
     allow_nil: true
 
   def contact?
-    !admin?
+    primary_contact? || secondary_contact?
   end
 
   def validates_primary_contact_assignment

--- a/app/views/cases/_case_assignment_controls.html.erb
+++ b/app/views/cases/_case_assignment_controls.html.erb
@@ -6,7 +6,7 @@
             :assignee_id,
             @case.potential_assignees,
             :id,
-            Proc.new { |a| "#{a.admin ? '* ' : ''}#{a.name}"},
+            Proc.new { |a| "#{a.admin? ? '* ' : ''}#{a.name}"},
             {
               include_blank: 'Nobody',
             },

--- a/db/data/20180525164417_set_user_roles.rb
+++ b/db/data/20180525164417_set_user_roles.rb
@@ -1,0 +1,19 @@
+class SetUserRoles < ActiveRecord::Migration[5.2]
+  def up
+    User.all.each do |user|
+      role = if user.admin
+               :admin
+             elsif user.primary_contact
+               :primary_contact
+             else
+               :secondary_contact
+             end
+
+      user.update!(role: role)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,2 @@
+# encoding: UTF-8
+DataMigrate::Data.define(version: 20180525164417)

--- a/db/migrate/20180525161250_add_role_to_users.rb
+++ b/db/migrate/20180525161250_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :text
+  end
+end

--- a/db/migrate/20180525175459_replace_old_user_type_fields.rb
+++ b/db/migrate/20180525175459_replace_old_user_type_fields.rb
@@ -1,0 +1,8 @@
+class ReplaceOldUserTypeFields < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :users, :role, false
+
+    remove_column :users, :admin, :boolean
+    remove_column :users, :primary_contact, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_25_161250) do
+ActiveRecord::Schema.define(version: 2018_05_25_175459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -332,10 +332,8 @@ ActiveRecord::Schema.define(version: 2018_05_25_161250) do
     t.string "encrypted_password", limit: 128, null: false
     t.string "remember_token", limit: 128, null: false
     t.integer "site_id"
-    t.boolean "admin", default: false, null: false
     t.string "confirmation_token", limit: 128
-    t.boolean "primary_contact", default: false
-    t.text "role"
+    t.text "role", null: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
     t.index ["site_id"], name: "index_users_on_site_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_21_143035) do
+ActiveRecord::Schema.define(version: 2018_05_25_161250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,6 +335,7 @@ ActiveRecord::Schema.define(version: 2018_05_21_143035) do
     t.boolean "admin", default: false, null: false
     t.string "confirmation_token", limit: 128
     t.boolean "primary_contact", default: false
+    t.text "role"
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
     t.index ["site_id"], name: "index_users_on_site_id"

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -35,7 +35,7 @@ namespace :alces do
       task obfuscate_users: :environment do
         staging_password = Deployment::Staging.password
 
-        User.where(admin: false).each do |user|
+        User.where.not(role: :admin).each do |user|
           local_part = user.email.split('@').first
           new_email = "center+#{local_part}@alces-software.com"
           user.update!(email: new_email, password: staging_password)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -9,18 +9,22 @@ FactoryBot.define do
 
     factory :contact do
       admin false
+      role :primary_contact
 
       factory :primary_contact do
         primary_contact true
+        role :primary_contact
       end
 
       factory :secondary_contact do
         primary_contact false
+        role :secondary_contact
       end
     end
 
     factory :admin do
       admin true
+      role :admin
       site nil
     end
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,22 +8,18 @@ FactoryBot.define do
     role :secondary_contact
 
     factory :contact do
-      admin false
       role :primary_contact
 
       factory :primary_contact do
-        primary_contact true
         role :primary_contact
       end
 
       factory :secondary_contact do
-        primary_contact false
         role :secondary_contact
       end
     end
 
     factory :admin do
-      admin true
       role :admin
       site nil
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     name 'A Scientist'
     email
     password 'definitely_encrypted'
+    role :secondary_contact
 
     factory :contact do
       admin false

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -454,4 +454,27 @@ RSpec.describe Case, type: :model do
       end
     end
   end
+
+  describe '#potential_assignees' do
+    subject { kase.potential_assignees.map(&:name) }
+    let(:kase) { create(:case) }
+
+    it 'includes any admin' do
+      create(:admin, name: 'some_admin')
+
+      expect(subject).to include('some_admin')
+    end
+
+    it 'includes any contact for site of Case' do
+      create(:contact, name: 'some_contact', site: kase.site)
+
+      expect(subject).to include('some_contact')
+    end
+
+    it 'does not include unrelated contact' do
+      create(:contact, name: 'some_contact')
+
+      expect(subject).not_to include('some_contact')
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,6 +32,36 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#contact?' do
+    subject do
+      build(:user, role: role).contact?
+    end
+
+    context "when role is 'primary_contact'" do
+      let (:role) { :primary_contact }
+
+      it { is_expected.to be true }
+    end
+
+    context "when role is 'secondary_contact'" do
+      let (:role) { :secondary_contact }
+
+      it { is_expected.to be true }
+    end
+
+    context "when role is 'admin'" do
+      let (:role) { :admin }
+
+      it { is_expected.to be false }
+    end
+
+    context "when role is 'viewer'" do
+      let (:role) { :viewer }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#validates_primary_contact_assignment' do
     subject do
       build(:user, primary_contact: true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,22 +64,26 @@ RSpec.describe User, type: :model do
 
   describe '#validates_primary_contact_assignment' do
     subject do
-      build(:user, primary_contact: true)
+      build(:user, role: 'primary_contact', site: site)
     end
 
-    context 'with no primary contact' do
-      it 'should not error' do
+    let(:site) { create(:site) }
+
+    context 'with no existing primary contact for site' do
+      it 'should be valid' do
         expect(subject).to be_valid
       end
     end
 
-    context 'with an existing primary contact for the current site' do
-      let!(:primary_contact) { create(:user, primary_contact: true, site: subject.site) }
+    context 'with an existing primary contact for site' do
+      before :each do
+        create(:user, role: 'primary_contact', site: site)
+      end
 
-      it 'should error' do
+      it 'should be invalid' do
         expect(subject).not_to be_valid
         expect(subject.errors.messages).to match(
-          primary_contact: ['is already set for this site']
+          role: ['primary contact is already set for this site']
         )
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  it { is_expected.to validate_presence_of(:role) }
+  it do is_expected.to validate_inclusion_of(:role).in_array([
+    'admin', 'primary_contact', 'secondary_contact', 'viewer'
+  ])
+  end
+
   describe '#secondary_contact?' do
     context 'when User is primary contact' do
       subject { create(:primary_contact).secondary_contact? }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,20 +7,28 @@ RSpec.describe User, type: :model do
   ])
   end
 
-  describe '#secondary_contact?' do
-    context 'when User is primary contact' do
-      subject { create(:primary_contact).secondary_contact? }
-      it { is_expected.to be false }
-    end
+  roles = described_class::ROLES
+  roles.each do |role|
+    role_query_method = role + '?'
 
-    context 'when User is secondary contact' do
-      subject { create(:secondary_contact).secondary_contact? }
-      it { is_expected.to be true }
-    end
+    describe "##{role_query_method}" do
+      subject do
+        build(:user, role: subject_role).public_send(role_query_method)
+      end
 
-    context 'when User is admin' do
-      subject { create(:admin).secondary_contact? }
-      it { is_expected.to be false }
+      context "when role is '#{role}'" do
+        let(:subject_role) { role }
+
+        it { is_expected.to be true }
+      end
+
+      context "when role is not '#{role}'" do
+        another_role = roles.reject{|r| r == role}.sample
+
+        let(:subject_role) { another_role }
+
+        it { is_expected.to be false }
+      end
     end
   end
 


### PR DESCRIPTION
This PR switches Flight Center to using a `role` field to distinguish different types of Users with different abilities, of which there are currently 4 - `admin`, `primary_contact`, `secondary_contact`, and `viewer` (a new type of User, with special handling still to come).

Trello: https://trello.com/c/vezaEjgb/338-update-data-model-with-user-roles. This is the first step towards implementing https://github.com/alces-software/alces-flight-center/issues/301.