### PR TITLE
Migrate database in post-deploy hook [skip ci]

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "dokku": {
+      "predeploy": "",
+      "postdeploy": "deploy/post-deploy"
+    }
+  }
+}

--- a/deploy/post-deploy
+++ b/deploy/post-deploy
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+rake db:migrate:with_data


### PR DESCRIPTION
Rather than by running another Rake task on the container after the
deploy. From a brief test in staging this appears to work, and should
have the advantages of:

- hopefully preventing an issue we've seen occur a couple of times,
where the app can be deployed but seemingly using old knowledge of the
database, leading to odd errors until it is restarted (see
https://trello.com/c/EXlN6VuQ/323-investigate-why-new-code-didnt-entirely-appear-to-be-running-after-deploy);

- meaning we don't have a brief period when the app is running but the
database has not been (fully) migrated, which could potentially cause
various odd issues in this period regardless of if the above occurs.

Following this change we also need to update when we import the staging
database to also run migrations, since this does need to run as an extra
task after the deploy (as it needs to shut down the app container to
remove database connections, run the import, and then restart the
container). The migrations need to be run when doing this immediately
after importing the production data, and before obfuscating the imported
Users.