### PR TITLE
Fix Draper ViewContext issue once

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,4 +10,16 @@ class ApplicationMailer < ActionMailer::Base
   layout 'mailer'
   helper 'mailer'
   helper 'application'
+
+  # Need to clear the Draper view context after each mailer action, as when an
+  # email is rendered this changes the view context from what we otherwise
+  # expect; this was sometimes causing accessing view helper methods in
+  # decorators via `h`, which should normally be available, to sometimes fail
+  # due to Draper getting confused and not making the correct helpers
+  # available. Doing this after we render each email appears to prevent this.
+  #
+  # Related discussion:
+  # https://alces.slack.com/archives/C72GT476Y/p1523613894000429; somewhat
+  # related issue: https://github.com/drapergem/draper/issues/814.
+  after_action { Draper::ViewContext.clear! }
 end

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -30,26 +30,7 @@ RSpec.describe ApplicationDecorator do
 
   describe '#cluster_part_icons' do
     describe 'maintenance icons' do
-      subject do
-        component.decorate.tap do
-          # Need to clear the Draper view context before calling the needed
-          # method on the decorator; this determines which helper methods
-          # should be available within this example group under `h`.
-          #
-          # This is needed as the act of creating this Component with some
-          # MaintenanceWindows causes these to be transitioned to the correct
-          # state (which is needed to create the corresponding transition
-          # model); this transition in turn triggers MaintenanceNotifier to
-          # attempt to send emails, which renders these emails, and this
-          # changes the view context from what it should be in these tests to
-          # the mailer context. This is all a bit convoluted, but uncomment
-          # this line to see what I mean.
-          #
-          # Related discussion: https://alces.slack.com/archives/C72GT476Y/p1523613894000429
-          # Somewhat related issue: https://github.com/drapergem/draper/issues/814
-          Draper::ViewContext.clear!
-        end.cluster_part_icons
-      end
+      subject { component.decorate.cluster_part_icons }
       let(:component) { create(:component, name: 'mycomponent') }
 
       it 'includes correct icon when has requested maintenance window' do

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe CaseDecorator do
     let(:cluster) { subject.cluster }
 
     context 'when Case has Component' do
-      subject do
-        create(:case_with_component).decorate.tap do
-          Draper::ViewContext.clear!
-        end
-      end
+      subject { create(:case_with_component).decorate }
 
       let(:component) { subject.component }
 
@@ -33,11 +29,7 @@ RSpec.describe CaseDecorator do
     end
 
     context 'when Case has Service' do
-      subject do
-        create(:case_with_service).decorate.tap do
-          Draper::ViewContext.clear!
-        end
-      end
+      subject { create(:case_with_service).decorate }
 
       let(:service) { subject.service }
 
@@ -60,11 +52,7 @@ RSpec.describe CaseDecorator do
     end
 
     context 'when Case has no Component or Service' do
-      subject do
-        create(:case).decorate.tap do
-          Draper::ViewContext.clear!
-        end
-      end
+      subject { create(:case).decorate }
 
       it 'returns link to Cluster' do
         expect(
@@ -80,9 +68,7 @@ RSpec.describe CaseDecorator do
     it 'returns link to Case page with display_id as text' do
       kase = create(:case, rt_ticket_id: 12345)
 
-      link = kase.decorate.tap do
-        Draper::ViewContext.clear!
-      end.case_link
+      link = kase.decorate.case_link
 
       expect(link).to eq h
         .link_to('RT12345', h.cluster_case_path(kase.cluster, kase), title: kase.subject)

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -86,9 +86,7 @@ RSpec.describe MaintenanceWindowDecorator do
   describe '#confirm_path' do
     subject { window.decorate.confirm_path }
     let :window do
-      create(:maintenance_window, associated_model: associated_model).tap do
-        Draper::ViewContext.clear!
-      end
+      create(:maintenance_window, associated_model: associated_model)
     end
 
     context 'when associated model is cluster' do


### PR DESCRIPTION
Rather than needing to do this all over the place whenever/wherever we
notice the issue; since the issue is caused by rendering emails and
Draper getting confused, we can just do this after emails are rendered,
which appears to fix the problem in every case (and probably future
cases too).