### PR TITLE
Extract path logic from decorators

### DIFF
--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -1,7 +1,7 @@
 class CaseCommentsController < ApplicationController
   def create
     my_case = Case.find_from_id!(params.require(:case_id))
-    fallback_location = @scope.decorate.dashboard_case_path(my_case)
+    fallback_location = @scope.dashboard_case_path(my_case)
 
     new_comment = my_case.case_comments.create(
         user: current_user,

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -73,7 +73,7 @@ class CasesController < ApplicationController
     end
   rescue ActionController::ParameterMissing
     flash[:error] = 'You must specify a credit charge to close this case.'
-    redirect_to @scope.decorate.dashboard_case_path(case_from_params)
+    redirect_to @scope.dashboard_case_path(case_from_params)
   end
 
   def assign
@@ -133,7 +133,7 @@ class CasesController < ApplicationController
     rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
       flash[:error] = "Error updating support case: #{format_errors(@case)}"
     end
-    redirect_to @scope.decorate.dashboard_case_path(@case)
+    redirect_to @scope.dashboard_case_path(@case)
   end
 
   def case_from_params

--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -8,10 +8,6 @@ class AllSitesDecorator < ApplicationDecorator
     ]
   end
 
-  def dashboard_case_path(kase)
-    h.cluster_case_path(kase.cluster, kase)
-  end
-
   private
 
   def cases_tab

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -59,10 +59,6 @@ class ApplicationDecorator < Draper::Decorator
     s.match?(/\A(.+_)?scope_(.+_)?path\Z/) ? :scope_path : super
   end
 
-  def dashboard_case_path(kase)
-    h.polymorphic_path([self, kase])
-  end
-
   private
 
   def convert_scope_path(s)

--- a/app/models/all_sites.rb
+++ b/app/models/all_sites.rb
@@ -11,4 +11,8 @@ class AllSites
   def ==(other_object)
     other_object.is_a?(AllSites)
   end
+
+  def dashboard_case_path(kase)
+    Rails.application.routes.url_helpers.cluster_case_path(kase.cluster, kase)
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -19,6 +19,10 @@ class ApplicationRecord < ActiveRecord::Base
     self.class.to_s.foreign_key.to_sym
   end
 
+  def dashboard_case_path(kase)
+    Rails.application.routes.url_helpers.polymorphic_path([self, kase])
+  end
+
   class << self
     # Every model in app is assumed to be related to a specific Site, unless it
     # is explicitly defined as global by overriding this method.

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to kase.display_id, scope.decorate.dashboard_case_path(kase) %></td>
+  <td><%= link_to kase.display_id, scope.dashboard_case_path(kase) %></td>
   <%= timestamp_td(
     description:  'Support case created',
     timestamp: kase.created_at

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -211,6 +211,17 @@ RSpec.describe 'Case page' do
       expect(options).to eq(['Nobody', 'A Scientist', '* A Scientist'])
     end
 
+    it 'changes assigned user when assignee is selected' do
+      user = create(:admin, name: 'Jerry')
+
+      visit case_path(open_case, as: admin)
+      find('#case-assignment').select(user.name)
+      click_button('Change assignment')
+      open_case.reload
+
+      expect(open_case.assignee).to eq(user)
+    end
+
     context 'when a case has an assignee' do
       let(:assignee) { contact }
       it 'preselects the current assignee' do


### PR DESCRIPTION
The problem that #328 fixes relates to changes made in this PR. It became apparent that handling the case paths for the various dashboards in their `Decorator` was problematic because of the problem described in #328.

Therefore this PR extracts `dashboard_case_path` to the relevant models, removing itself from the issue of `Draper` context switching. On top of this a test has been added to check the assignment button on a `Case` works. This was previously not being tested and would have picked up on the issue sooner.