### PR TITLE
Slack Notifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,6 @@ export AWS_DOCUMENTS_PREFIX=development-documents
 
 #These can be used in development and are not needed in production
 #export SLACK_CHANNEL=ABC
-#export SLACK_USERNAME=ABC
 
 # The following need setting in production but are not needed in development.
 # SECRET_KEY_BASE=ABC

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ export AWS_REGION=eu-west-2
 export AWS_DOCUMENTS_BUCKET=alces-flight-center
 export AWS_DOCUMENTS_PREFIX=development-documents
 
+#These can be used in development and are not needed in production
+#export SLACK_CHANNEL=ABC
+#export SLACK_USERNAME=ABC
+
 # The following need setting in production but are not needed in development.
 # SECRET_KEY_BASE=ABC
 # DATABASE_URL=ABC
@@ -16,6 +20,7 @@ export AWS_DOCUMENTS_PREFIX=development-documents
 # SMTP_USERNAME=ABC
 # SMTP_PASSWORD=ABC
 # SENTRY_DSN=ABC
+# SLACK_WEBHOOK_URL=ABC
 #
 # SSO_BASE_URL=ABC - base URL for SSO server. In production, should be
 # `https://accounts.alces-flight.com`. This is passed through into the

--- a/Gemfile
+++ b/Gemfile
@@ -113,3 +113,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'slack-notifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.1)
       tilt (~> 2.0)
+    slack-notifier (2.3.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -481,6 +482,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   shoulda-matchers
+  slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
   state_machines-activerecord!

--- a/README.md
+++ b/README.md
@@ -209,6 +209,23 @@ updating to support new features/content/styles etc. for these. To do this:
 
 4. Make the necessary manual updates output at the end of this script.
 
+### To set up Slack notifications for your development environment
+
+There are two environment variables that need to be set in your .env file
+before Slack notifications will work within your development environment,
+`SLACK_CHANNEL` and `SLACK_WEBHOOK_URL`.
+
+The former refers to the channel that the notifier will send all notifications
+to. Therefore if you wish to receive all Slack notfications via private messages
+you will need to set this to `@<your_slack_username_here>`.
+
+The latter however is vital to making the notifier function properly and should
+be kept secret. This URL can be found within the `Incoming WebHooks` section
+of our Slack workspace. From there you need to navigate to the `Alces Flight
+Center` configuration which will display the URL for you in its configuration
+page. Once you copy this URL to its respective environment variable you should
+be able to send notfications to Slack from your development environment.
+
 ## Creating accounts for customers
 
 - If they don't have a Flight SSO account, they should register for one first.

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,3 +1,4 @@
+require 'slack-notifier'
 class LogsController < ApplicationController
   def index
     @new_log = Log.new
@@ -15,6 +16,7 @@ class LogsController < ApplicationController
     else
       error_flash_models [new_log], 'Could not add log entry'
     end
+    slack.log_notification(new_log)
     redirect_back fallback_location: @cluster
   end
 
@@ -24,6 +26,10 @@ class LogsController < ApplicationController
     params.require(:log)
           .permit(:details, :component_id, case_ids: [])
           .merge(engineer: current_user)
+  end
+
+  def slack
+    @slack ||= SlackNotifier.new
   end
 end
 

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -16,7 +16,7 @@ class LogsController < ApplicationController
     else
       error_flash_models [new_log], 'Could not add log entry'
     end
-    slack.log_notification(new_log)
+    SlackNotifier.log_notification(new_log)
     redirect_back fallback_location: @cluster
   end
 
@@ -26,10 +26,6 @@ class LogsController < ApplicationController
     params.require(:log)
           .permit(:details, :component_id, case_ids: [])
           .merge(engineer: current_user)
-  end
-
-  def slack
-    @slack ||= SlackNotifier.new
   end
 end
 

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -11,7 +11,7 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients.reject { |contact| contact == @case.user.email }, # Exclude the user raising the case
       subject: @case.email_subject
     )
-    slack.case_notification(@case)
+    SlackNotifier.case_notification(@case)
   end
 
   def change_assignee(my_case, new_assignee)
@@ -21,7 +21,7 @@ class CaseMailer < ApplicationMailer
       cc: new_assignee&.email, # Send to new assignee only
       subject: @case.email_reply_subject
     )
-    slack.assignee_notification(@case, @assignee)
+    SlackNotifier.assignee_notification(@case, @assignee)
   end
 
   def comment(comment)
@@ -31,7 +31,7 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients.reject { |contact| contact == @comment.user.email }, # Exclude the user making the comment
       subject: @case.email_reply_subject,
     )
-    slack.comment_notification(@case, @comment)
+    SlackNotifier.comment_notification(@case, @comment)
   end
 
   def maintenance(my_case, text)
@@ -41,10 +41,6 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients,
       subject: @case.email_reply_subject
     )
-    slack.maintenance_notification(@case, @text)
-  end
-
-  def slack
-    @slack ||= SlackNotifier.new
+    SlackNotifier.maintenance_notification(@case, @text)
   end
 end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -13,6 +13,7 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients.reject { |contact| contact == @case.user.email }, # Exclude the user raising the case
       subject: @case.email_subject
     )
+    @slack.case_notification(@case)
   end
 
   def change_assignee(my_case, new_assignee)

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -41,6 +41,7 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients,
       subject: @case.email_reply_subject
     )
+    slack.maintenance_notification(@case, @text)
   end
 
   def slack

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -32,6 +32,7 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients.reject { |contact| contact == @comment.user.email }, # Exclude the user making the comment
       subject: @case.email_reply_subject,
     )
+    @slack.comment_notification(@case, @comment)
   end
 
   def maintenance(my_case, text)

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -21,6 +21,7 @@ class CaseMailer < ApplicationMailer
       cc: new_assignee&.email, # Send to new assignee only
       subject: @case.email_reply_subject
     )
+    slack.assignee_notification(@case)
   end
 
   def comment(comment)

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -5,15 +5,13 @@ class CaseMailer < ApplicationMailer
 
   default bcc: Rails.application.config.email_bcc_address
 
-  before_action { @slack = SlackNotifier.new }
-
   def new_case(my_case)
     @case = my_case
     mail(
       cc: @case.email_recipients.reject { |contact| contact == @case.user.email }, # Exclude the user raising the case
       subject: @case.email_subject
     )
-    @slack.case_notification(@case)
+    slack.case_notification(@case)
   end
 
   def change_assignee(my_case, new_assignee)
@@ -32,7 +30,7 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients.reject { |contact| contact == @comment.user.email }, # Exclude the user making the comment
       subject: @case.email_reply_subject,
     )
-    @slack.comment_notification(@case, @comment)
+    slack.comment_notification(@case, @comment)
   end
 
   def maintenance(my_case, text)
@@ -42,5 +40,9 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients,
       subject: @case.email_reply_subject
     )
+  end
+
+  def slack
+    @slack ||= SlackNotifier.new
   end
 end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -1,8 +1,11 @@
+require 'slack-notifier'
 class CaseMailer < ApplicationMailer
 
   layout 'case_mailer'
 
   default bcc: Rails.application.config.email_bcc_address
+
+  before_action { @slack = SlackNotifier.new }
 
   def new_case(my_case)
     @case = my_case

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -21,7 +21,7 @@ class CaseMailer < ApplicationMailer
       cc: new_assignee&.email, # Send to new assignee only
       subject: @case.email_reply_subject
     )
-    slack.assignee_notification(@case)
+    slack.assignee_notification(@case, @assignee)
   end
 
   def comment(comment)

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -182,7 +182,7 @@ class Case < ApplicationRecord
       Tier: decorate.tier_description,
       Fields: field_hash,
       'Requested MOTD': change_motd_request&.motd
-    }.reject { |_k, v| v.nil? }
+    }.compact
   end
 
   def consultancy?

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -128,7 +128,7 @@ class SlackNotifier
     end
 
     def subject_and_id_title(kase)
-      "#{kase.subject} - #{kase.display_id}"
+      "[#{kase.display_id}] #{kase.subject}"
     end
 
     def format_fields(hash, url)

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -94,8 +94,8 @@ class SlackNotifier
     end
 
     def log_notification(log)
-      notification_text = "New log created by #{log.engineer.name} on " \
-        "#{log.cluster.name} #{log&.component ? 'for ' + log.component.name : nil }"
+      notification_text = "New log created on #{log.cluster.name}" \
+        " #{log&.component ? 'for ' + log.component.name : nil }"
 
       logs_url = cluster_logs_url(log.cluster)
 
@@ -103,6 +103,7 @@ class SlackNotifier
         fallback: notification_text,
         color: "#8daec2",
         pretext: notification_text,
+        author_name: log.engineer.name,
         title: "Details",
         title_link: logs_url,
         text: restrict_text_length(log.details, logs_url),

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -11,11 +11,10 @@ class SlackNotifier
 
       case_url = url_helpers('cluster_case_url', kase.cluster, kase)
 
-      notification_details = "*Tier #{kase.tier_level}*"
-      kase.fields.each do |field|
-        notification_details << "\n*#{field["name"]}*"\
-          "\n#{restrict_text_length(field["value"], case_url)}"
-      end unless kase.fields.nil?
+      notification_details = [
+          "*Tier #{kase.tier_level}*",
+          *format_fields(kase.email_properties, case_url)
+      ].join("\n")
 
       case_note = {
         fallback: notification_text,
@@ -132,8 +131,14 @@ class SlackNotifier
       "#{kase.subject} - #{kase.display_id}"
     end
 
-    def url_helpers(helper, *args)
-      Rails.application.routes.url_helpers.public_send(helper, *args)
+    def format_fields(hash, url)
+      hash.map do |key, value|
+        if value.is_a?(Hash)
+          format_fields(value, url)
+        else
+          "*#{key}*\n#{restrict_text_length(value, url)}"
+        end
+      end.flatten
     end
   end
 end

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -102,12 +102,14 @@ class SlackNotifier
     private
 
     def notifier
-      @notifier = Slack::Notifier.new "https://hooks.slack.com/services/" \
-    "T025J03QZ/BAV4MH1SM/pKlzYfY1efTsl0bFWGtKg8bQ"
+      Slack::Notifier.new Rails.application.config.slack_webhook_url
     end
 
     def send(note)
-      notifier.ping attachments: note
+      return unless Rails.application.config.slack_webhook_url
+      notifier.ping channel: Rails.application.config.slack_channel,
+        username: Rails.application.config.slack_username,
+        attachments: note
     end
 
     def restrict_text_length(text, url)

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -9,7 +9,7 @@ class SlackNotifier
       kase.fields.each do |field|
         (@notification_details ||= "*Tier #{kase.tier_level}*") << "\n*#{field["name"]}*"\
           "\n#{restrict_text_length(field["value"], case_url)}"
-      end
+      end unless kase.fields.nil?
 
       case_note = {
         fallback: notification_text,

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -34,8 +34,8 @@ class SlackNotifier
     notifier.ping attachments: case_note
   end
 
-  def assignee_notification(kase)
-    notification_text = "#{kase.assignee.name} has been assigned to #{kase.display_id}"
+  def assignee_notification(kase, assignee)
+    notification_text = "#{assignee.name} has been assigned to #{kase.display_id}"
     assignee_note = {
       fallback: notification_text,
       color: "#6e5494",
@@ -50,7 +50,7 @@ class SlackNotifier
         },
         {
           title: "Assigned to",
-          value: kase.assignee.name,
+          value: assignee.name,
           short: true
         }
       ]

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -1,6 +1,11 @@
 require 'slack-notifier'
 class SlackNotifier
   class << self
+    delegate :slack_webhook_url,
+      :slack_channel,
+      :slack_username,
+      to: 'Rails.application.config'
+
     def case_notification(kase)
       notification_text = "New case created on #{kase.cluster.name}"
 
@@ -108,13 +113,13 @@ class SlackNotifier
     private
 
     def notifier
-      Slack::Notifier.new Rails.application.config.slack_webhook_url
+      Slack::Notifier.new slack_webhook_url
     end
 
     def send(note)
-      return unless Rails.application.config.slack_webhook_url
-      notifier.ping channel: Rails.application.config.slack_channel,
-        username: Rails.application.config.slack_username,
+      return unless slack_webhook_url
+      notifier.ping channel: slack_channel,
+        username: slack_username,
         attachments: note
     end
 

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -34,7 +34,29 @@ class SlackNotifier
     notifier.ping attachments: case_note
   end
 
-  def assignee
+  def assignee_notification(kase)
+    notification_text = "#{kase.assignee.name} has been assigned to #{kase.display_id}"
+    assignee_note = {
+      fallback: notification_text,
+      color: "#2c3e50",
+      pretext: notification_text,
+      title: kase.subject,
+      title_link: Rails.application.routes.url_helpers.cluster_case_url(kase.cluster, kase),
+      fields: [
+        {
+          title: "ID",
+          value: kase.display_id,
+          short: true
+        },
+        {
+          title: "Assigned to",
+          value: kase.assignee.name,
+          short: true
+        }
+      ]
+    }
+
+    notifier.ping attachments: assignee_note
   end
 
   def comment_notification(kase, comment)

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -28,7 +28,7 @@ class SlackNotifier
         footer: "<#{url_helpers('cluster_cases_url', kase.cluster)}|#{kase.cluster.name} Cases>"
       }
 
-      send(case_note)
+      send_notification(case_note)
     end
 
     def assignee_notification(kase, assignee)
@@ -48,7 +48,7 @@ class SlackNotifier
         ]
       }
 
-      send(assignee_note)
+      send_notification(assignee_note)
     end
 
     def comment_notification(kase, comment)
@@ -68,7 +68,7 @@ class SlackNotifier
         ]
       }
 
-      send(comment_note)
+      send_notification(comment_note)
     end
 
     def maintenance_notification(kase, text)
@@ -87,7 +87,7 @@ class SlackNotifier
         footer: "<#{url_helpers('cluster_maintenance_windows_url', kase.cluster)}|#{kase.cluster.name} Maintenance>"
       }
 
-      send(maintenance_note)
+      send_notification(maintenance_note)
     end
 
     def log_notification(log)
@@ -107,7 +107,7 @@ class SlackNotifier
         footer: "<#{logs_url}|#{log.cluster.name} Logs>"
       }
 
-      send(log_note)
+      send_notification(log_note)
     end
 
     private
@@ -116,7 +116,7 @@ class SlackNotifier
       Slack::Notifier.new slack_webhook_url
     end
 
-    def send(note)
+    def send_notification(note)
       return unless slack_webhook_url
       notifier.ping channel: slack_channel,
         username: slack_username,

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -88,9 +88,27 @@ class SlackNotifier
         }
       ]
     }
+
     notifier.ping attachments: maintenance_note
   end
 
-  def log
+  def log_notification(log)
+    notification_text = "New log created by #{log.engineer.name} on " \
+      "#{log.cluster.name} #{log&.component ? 'for ' + log.component.name : nil }"
+    log_note = {
+      fallback: notification_text,
+      color: "#8daec2",
+      pretext: notification_text,
+      fields: [
+        {
+          title: "Details",
+          value: log.details,
+          short: false
+        }
+      ],
+      footer: "<#{Rails.application.routes.url_helpers.cluster_logs_url(log.cluster)}|#{log.cluster.name} Logs>"
+    }
+
+    notifier.ping attachments: log_note
   end
 end

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -11,7 +11,7 @@ class SlackNotifier
     def case_notification(kase)
       notification_text = "New case created on #{kase.cluster.name}"
 
-      case_url = cluster_case_url.(kase.cluster, kase)
+      case_url = cluster_case_url(kase.cluster, kase)
 
       notification_details = [
           "*Tier #{kase.tier_level}*",
@@ -26,8 +26,7 @@ class SlackNotifier
         title: subject_and_id_title(kase),
         title_link: case_url,
         text: notification_details,
-        mrkdwn: true,
-        footer: "<#{cluster_cases_url(kase.cluster)}|#{kase.cluster.name} Cases>"
+        mrkdwn: true
       }
 
       send_notification(case_note)
@@ -85,9 +84,7 @@ class SlackNotifier
             value: text,
             short: false
           }
-        ],
-        footer: "<#{cluster_maintenance_windows_url(kase.cluster)}|#{kase
-          .cluster.name} Maintenance>"
+        ]
       }
 
       send_notification(maintenance_note)
@@ -107,8 +104,7 @@ class SlackNotifier
         title: "Details",
         title_link: logs_url,
         text: restrict_text_length(log.details, logs_url),
-        mrkdwn: true,
-        footer: "<#{logs_url}|#{log.cluster.name} Logs>"
+        mrkdwn: true
       }
 
       send_notification(log_note)

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -1,126 +1,125 @@
 require 'slack-notifier'
 class SlackNotifier
+  class << self
+    def case_notification(kase)
+      notification_text = "New case created on #{kase.cluster.name}"
 
-  attr_reader :notifier
+      case_url = url_helpers('cluster_case_url', kase.cluster, kase)
 
-  def initialize
-    @notifier = Slack::Notifier.new "https://hooks.slack.com/services/" \
-    "T025J03QZ/BAV4MH1SM/pKlzYfY1efTsl0bFWGtKg8bQ"
-  end
+      kase.fields.each do |field|
+        (@notification_details ||= "*Tier #{kase.tier_level}*") << "\n*#{field["name"]}*"\
+          "\n#{restrict_text_length(field["value"], case_url)}"
+      end
 
-  def case_notification(kase)
-    notification_text = "New case created on #{kase.cluster.name}"
+      case_note = {
+        fallback: notification_text,
+        color: "#18bc9c",
+        pretext: notification_text,
+        author_name: kase.user.name,
+        title: subject_and_id_title(kase),
+        title_link: case_url,
+        text: @notification_details,
+        mrkdwn: true,
+        footer: "<#{url_helpers('cluster_cases_url', kase.cluster)}|#{kase.cluster.name} Cases>"
+      }
 
-    case_url = url_helpers('cluster_case_url', kase.cluster, kase)
-
-    kase.fields.each do |field|
-      (@notification_details ||= "*Tier #{kase.tier_level}*") << "\n*#{field["name"]}*"\
-        "\n#{restrict_text_length(field["value"], case_url)}"
+      send(case_note)
     end
 
-    case_note = {
-      fallback: notification_text,
-      color: "#18bc9c",
-      pretext: notification_text,
-      author_name: kase.user.name,
-      title: subject_and_id_title(kase),
-      title_link: case_url,
-      text: @notification_details,
-      mrkdwn: true,
-      footer: "<#{url_helpers('cluster_cases_url', kase.cluster)}|#{kase.cluster.name} Cases>"
-    }
+    def assignee_notification(kase, assignee)
+      notification_text = "#{assignee.name} has been assigned to #{kase.display_id}"
 
-    send(case_note)
-  end
+      assignee_note = {
+        fallback: notification_text,
+        color: "#6e5494",
+        title: subject_and_id_title(kase),
+        title_link: url_helpers('cluster_case_url', kase.cluster, kase),
+        fields: [
+          {
+            title: "Assigned to",
+            value: assignee.name,
+            short: true
+          }
+        ]
+      }
 
-  def assignee_notification(kase, assignee)
-    notification_text = "#{assignee.name} has been assigned to #{kase.display_id}"
+      send(assignee_note)
+    end
 
-    assignee_note = {
-      fallback: notification_text,
-      color: "#6e5494",
-      title: subject_and_id_title(kase),
-      title_link: url_helpers('cluster_case_url', kase.cluster, kase),
-      fields: [
-        {
-          title: "Assigned to",
-          value: assignee.name,
-          short: true
-        }
-      ]
-    }
+    def comment_notification(kase, comment)
+      notification_text = "New comment from #{comment.user.name} on #{kase.display_id}"
+      comment_note = {
+        fallback: notification_text,
+        color: "#2794d8",
+        author_name: comment.user.name,
+        title: subject_and_id_title(kase),
+        title_link: url_helpers('cluster_case_url', kase.cluster, kase),
+        text: comment.text
+      }
 
-    send(assignee_note)
-  end
+      send(comment_note)
+    end
 
-  def comment_notification(kase, comment)
-    notification_text = "New comment from #{comment.user.name} on #{kase.display_id}"
-    comment_note = {
-      fallback: notification_text,
-      color: "#2794d8",
-      author_name: comment.user.name,
-      title: subject_and_id_title(kase),
-      title_link: url_helpers('cluster_case_url', kase.cluster, kase),
-      text: comment.text
-    }
+    def maintenance_notification(kase, text)
+      maintenance_note = {
+        fallback: text,
+        color: "#000000",
+        title: subject_and_id_title(kase),
+        title_link: url_helpers('cluster_case_url', kase.cluster, kase),
+        fields: [
+          {
+            title: "Maintenance Info",
+            value: text,
+            short: false
+          }
+        ],
+        footer: "<#{url_helpers('cluster_maintenance_windows_url', kase.cluster)}|#{kase.cluster.name} Maintenance>"
+      }
 
-    send(comment_note)
-  end
+      send(maintenance_note)
+    end
 
-  def maintenance_notification(kase, text)
-    maintenance_note = {
-      fallback: text,
-      color: "#000000",
-      title: subject_and_id_title(kase),
-      title_link: url_helpers('cluster_case_url', kase.cluster, kase),
-      fields: [
-        {
-          title: "Maintenance Info",
-          value: text,
-          short: false
-        }
-      ],
-      footer: "<#{url_helpers('cluster_maintenance_windows_url', kase.cluster)}|#{kase.cluster.name} Maintenance>"
-    }
+    def log_notification(log)
+      notification_text = "New log created by #{log.engineer.name} on " \
+        "#{log.cluster.name} #{log&.component ? 'for ' + log.component.name : nil }"
 
-    send(maintenance_note)
-  end
+      logs_url = url_helpers('cluster_logs_url', log.cluster)
 
-  def log_notification(log)
-    notification_text = "New log created by #{log.engineer.name} on " \
-      "#{log.cluster.name} #{log&.component ? 'for ' + log.component.name : nil }"
+      log_note = {
+        fallback: notification_text,
+        color: "#8daec2",
+        pretext: notification_text,
+        title: "Details",
+        title_link: logs_url,
+        text: restrict_text_length(log.details, logs_url),
+        mrkdwn: true,
+        footer: "<#{logs_url}|#{log.cluster.name} Logs>"
+      }
 
-    logs_url = url_helpers('cluster_logs_url', log.cluster)
+      send(log_note)
+    end
 
-    log_note = {
-      fallback: notification_text,
-      color: "#8daec2",
-      pretext: notification_text,
-      title: "Details",
-      title_link: logs_url,
-      text: restrict_text_length(log.details, logs_url),
-      mrkdwn: true,
-      footer: "<#{logs_url}|#{log.cluster.name} Logs>"
-    }
+    private
 
-    send(log_note)
-  end
+    def notifier
+      @notifier = Slack::Notifier.new "https://hooks.slack.com/services/" \
+    "T025J03QZ/BAV4MH1SM/pKlzYfY1efTsl0bFWGtKg8bQ"
+    end
 
-  private
+    def send(note)
+      notifier.ping attachments: note
+    end
 
-  def send(note)
-    notifier.ping attachments: note
-  end
+    def restrict_text_length(text, url)
+      text.length > 80 ? text[0, 80] + "<#{url}|...>" : text
+    end
 
-  def restrict_text_length(text, url)
-    text.length > 80 ? text[0, 80] + "<#{url}|...>" : text
-  end
+    def subject_and_id_title(kase)
+      "#{kase.subject} - #{kase.display_id}"
+    end
 
-  def subject_and_id_title(kase)
-    "#{kase.subject} - #{kase.display_id}"
-  end
-
-  def url_helpers(helper, *args)
-    Rails.application.routes.url_helpers.public_send(helper, *args)
+    def url_helpers(helper, *args)
+      Rails.application.routes.url_helpers.public_send(helper, *args)
+    end
   end
 end

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -12,7 +12,7 @@ class SlackNotifier
     notification_text = "New case created on #{kase.cluster.name}"
     case_note = {
       fallback: notification_text,
-      color: "#2794d8",
+      color: "#18bc9c",
       pretext: notification_text,
       author_name: kase.user.name,
       title: kase.subject,
@@ -28,7 +28,7 @@ class SlackNotifier
           value: kase.display_id,
           short: true
         },
-      ],
+      ]
     }
 
     notifier.ping attachments: case_note
@@ -37,7 +37,19 @@ class SlackNotifier
   def assignee
   end
 
-  def comment
+  def comment_notification(kase, comment)
+    notification_text = "New comment from #{comment.user.name} on #{kase.display_id}"
+    comment_note = {
+      fallback: notification_text,
+      color: "#2794d8",
+      pretext: notification_text,
+      author_name: comment.user.name,
+      title: kase.subject,
+      title_link: Rails.application.routes.url_helpers.cluster_case_url(kase.cluster, kase),
+      text: comment.text
+    }
+
+    notifier.ping attachments: comment_note
   end
 
   def maintenance

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -1,0 +1,26 @@
+require 'slack-notifier'
+class SlackNotifier
+
+  attr_accessor :notifier
+
+  def initialize
+    @notifier = Slack::Notifier.new "https://hooks.slack.com/services/" \
+    "T025J03QZ/BAV4MH1SM/pKlzYfY1efTsl0bFWGtKg8bQ"
+  end
+
+  def case
+  end
+
+  def assignee
+
+  end
+
+  def comment
+  end
+
+  def maintenance
+  end
+
+  def log
+  end
+end

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -1,18 +1,40 @@
 require 'slack-notifier'
 class SlackNotifier
 
-  attr_accessor :notifier
+  attr_reader :notifier
 
   def initialize
     @notifier = Slack::Notifier.new "https://hooks.slack.com/services/" \
     "T025J03QZ/BAV4MH1SM/pKlzYfY1efTsl0bFWGtKg8bQ"
   end
 
-  def case
+  def case_notification(kase)
+    notification_text = "New case created on #{kase.cluster.name}"
+    case_note = {
+      fallback: notification_text,
+      color: "#2794d8",
+      pretext: notification_text,
+      author_name: kase.user.name,
+      title: kase.subject,
+      title_link: Rails.application.routes.url_helpers.cluster_case_url(kase.cluster, kase),
+      fields: [
+        {
+          title: "Tier",
+          value: kase.tier_level,
+          short: true
+        },
+        {
+          title: "ID",
+          value: kase.display_id,
+          short: true
+        },
+      ],
+    }
+
+    notifier.ping attachments: case_note
   end
 
   def assignee
-
   end
 
   def comment

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -11,8 +11,9 @@ class SlackNotifier
 
       case_url = url_helpers('cluster_case_url', kase.cluster, kase)
 
+      notification_details = "*Tier #{kase.tier_level}*"
       kase.fields.each do |field|
-        (@notification_details ||= "*Tier #{kase.tier_level}*") << "\n*#{field["name"]}*"\
+        notification_details << "\n*#{field["name"]}*"\
           "\n#{restrict_text_length(field["value"], case_url)}"
       end unless kase.fields.nil?
 
@@ -23,7 +24,7 @@ class SlackNotifier
         author_name: kase.user.name,
         title: subject_and_id_title(kase),
         title_link: case_url,
-        text: @notification_details,
+        text: notification_details,
         mrkdwn: true,
         footer: "<#{url_helpers('cluster_cases_url', kase.cluster)}|#{kase.cluster.name} Cases>"
       }

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -38,7 +38,7 @@ class SlackNotifier
     notification_text = "#{kase.assignee.name} has been assigned to #{kase.display_id}"
     assignee_note = {
       fallback: notification_text,
-      color: "#2c3e50",
+      color: "#6e5494",
       pretext: notification_text,
       title: kase.subject,
       title_link: Rails.application.routes.url_helpers.cluster_case_url(kase.cluster, kase),
@@ -74,7 +74,21 @@ class SlackNotifier
     notifier.ping attachments: comment_note
   end
 
-  def maintenance
+  def maintenance_notification(kase, text)
+    maintenance_note = {
+      fallback: text,
+      color: "#000000",
+      title: "#{kase.subject} (#{kase.display_id})",
+      title_link: Rails.application.routes.url_helpers.cluster_case_url(kase.cluster, kase),
+      fields: [
+        {
+          title: "Maintenance Info",
+          value: text,
+          short: false
+        }
+      ]
+    }
+    notifier.ping attachments: maintenance_note
   end
 
   def log

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -54,7 +54,13 @@ class SlackNotifier
         author_name: comment.user.name,
         title: subject_and_id_title(kase),
         title_link: url_helpers('cluster_case_url', kase.cluster, kase),
-        text: comment.text
+        fields: [
+          {
+            title: "New comment",
+            value: comment.text,
+            short: false
+          }
+        ]
       }
 
       send(comment_note)

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -1,6 +1,8 @@
 require 'slack-notifier'
 class SlackNotifier
   class << self
+    include Rails.application.routes.url_helpers
+
     delegate :slack_webhook_url,
       :slack_channel,
       :slack_username,
@@ -9,7 +11,7 @@ class SlackNotifier
     def case_notification(kase)
       notification_text = "New case created on #{kase.cluster.name}"
 
-      case_url = url_helpers('cluster_case_url', kase.cluster, kase)
+      case_url = cluster_case_url.(kase.cluster, kase)
 
       notification_details = [
           "*Tier #{kase.tier_level}*",
@@ -25,7 +27,7 @@ class SlackNotifier
         title_link: case_url,
         text: notification_details,
         mrkdwn: true,
-        footer: "<#{url_helpers('cluster_cases_url', kase.cluster)}|#{kase.cluster.name} Cases>"
+        footer: "<#{cluster_cases_url(kase.cluster)}|#{kase.cluster.name} Cases>"
       }
 
       send_notification(case_note)
@@ -38,7 +40,7 @@ class SlackNotifier
         fallback: notification_text,
         color: "#6e5494",
         title: subject_and_id_title(kase),
-        title_link: url_helpers('cluster_case_url', kase.cluster, kase),
+        title_link: cluster_case_url(kase.cluster, kase),
         fields: [
           {
             title: "Assigned to",
@@ -58,7 +60,7 @@ class SlackNotifier
         color: "#2794d8",
         author_name: comment.user.name,
         title: subject_and_id_title(kase),
-        title_link: url_helpers('cluster_case_url', kase.cluster, kase),
+        title_link: cluster_case_url(kase.cluster, kase),
         fields: [
           {
             title: "New comment",
@@ -76,7 +78,7 @@ class SlackNotifier
         fallback: text,
         color: "#000000",
         title: subject_and_id_title(kase),
-        title_link: url_helpers('cluster_case_url', kase.cluster, kase),
+        title_link: cluster_case_url(kase.cluster, kase),
         fields: [
           {
             title: "Maintenance Info",
@@ -84,7 +86,8 @@ class SlackNotifier
             short: false
           }
         ],
-        footer: "<#{url_helpers('cluster_maintenance_windows_url', kase.cluster)}|#{kase.cluster.name} Maintenance>"
+        footer: "<#{cluster_maintenance_windows_url(kase.cluster)}|#{kase
+          .cluster.name} Maintenance>"
       }
 
       send_notification(maintenance_note)
@@ -94,7 +97,7 @@ class SlackNotifier
       notification_text = "New log created by #{log.engineer.name} on " \
         "#{log.cluster.name} #{log&.component ? 'for ' + log.component.name : nil }"
 
-      logs_url = url_helpers('cluster_logs_url', log.cluster)
+      logs_url = cluster_logs_url(log.cluster)
 
       log_note = {
         fallback: notification_text,

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -31,7 +31,7 @@ class SlackNotifier
       ]
     }
 
-    notifier.ping attachments: case_note
+    send(case_note)
   end
 
   def assignee_notification(kase, assignee)
@@ -56,7 +56,7 @@ class SlackNotifier
       ]
     }
 
-    notifier.ping attachments: assignee_note
+    send(assignee_note)
   end
 
   def comment_notification(kase, comment)
@@ -71,7 +71,7 @@ class SlackNotifier
       text: comment.text
     }
 
-    notifier.ping attachments: comment_note
+    send(comment_note)
   end
 
   def maintenance_notification(kase, text)
@@ -89,7 +89,7 @@ class SlackNotifier
       ]
     }
 
-    notifier.ping attachments: maintenance_note
+    send(maintenance_note)
   end
 
   def log_notification(log)
@@ -109,6 +109,10 @@ class SlackNotifier
       footer: "<#{Rails.application.routes.url_helpers.cluster_logs_url(log.cluster)}|#{log.cluster.name} Logs>"
     }
 
-    notifier.ping attachments: log_note
+    send(log_note)
+  end
+
+  def send(note)
+    notifier.ping attachments: note
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Host to use when generating URls in emails.
+  # Host to use when generating URLs in emails.
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Do not send emails in development.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,4 +66,8 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.sso_base_url = ENV['SSO_BASE_URL'] || 'http://accounts.alces-flight.lvh.me:4000'
+
+  config.slack_webhook_url = ENV['SLACK_WEBHOOK_URL']
+  config.slack_channel = ENV['SLACK_CHANNEL']
+  config.slack_username = ENV['SLACK_USERNAME']
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,5 +71,5 @@ Rails.application.configure do
 
   config.slack_webhook_url = ENV['SLACK_WEBHOOK_URL']
   config.slack_channel = ENV['SLACK_CHANNEL']
-  config.slack_username = ENV['SLACK_USERNAME']
+  config.slack_username = 'Alces Flight Center [Development]'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,9 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Host to use when generating URLs in emails.
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = {
+    host: 'center.alces-flight.lvh.me:3000'
+  }
 
   # Do not send emails in development.
   config.action_mailer.perform_deliveries = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,6 +109,20 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  
+
   config.sso_base_url = ENV.fetch('SSO_BASE_URL')
+
+  config.slack_webhook_url = ENV.fetch('SLACK_WEBHOOK_URL')
+  config.slack_channel, config.slack_username =
+    if ENV['STAGING']
+      [
+        '#alces-flight-center',
+        'Alces Flight Center [Staging]'
+      ]
+    else
+      [
+        '#support',
+        'Alces Flight Center'
+      ]
+    end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
 
-  # Host to use when generating URls in emails.
+  # Host to use when generating URLs in emails.
   url_options_host = if ENV['STAGING']
                        'staging.center.alces-flight.com'
                      else

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Host to use when generating URls in emails.
+  # Host to use when generating URLs in emails.
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Required so emails always appear in `ActionMailer::Base.deliveries` even if

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,8 @@ Rails.application.configure do
   config.middleware.use Clearance::BackDoor
 
   config.sso_base_url = 'http://example.com/sso_base_url'
+
+  config.slack_webhook_url = 'http://example.com/slack'
+  config.slack_channel = '#test'
+  config.slack_username = 'test'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,8 +34,11 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Host to use when generating URLs in emails.
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  # Host to use when generating URLs in emails (same as in production for
+  # clearer failures).
+  config.action_mailer.default_url_options = {
+    host: 'center.alces-flight.com'
+  }
 
   # Required so emails always appear in `ActionMailer::Base.deliveries` even if
   # `deliver_later` is used.

--- a/config/initializers/routes.rb
+++ b/config/initializers/routes.rb
@@ -1,3 +1,6 @@
 
 Rails.application.routes.default_url_options[:protocol] = 'https' unless Rails.env.development?
-Rails.application.routes.default_url_options[:host] = 'center.alces-flight.com'
+
+# Use same host as configured for environment for mailers when generating URLs.
+Rails.application.routes.default_url_options[:host] =
+  Rails.application.config.action_mailer.default_url_options[:host]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -31,5 +31,5 @@ test:
 # and move the `production:` environment over there.
 
 production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  json_web_token_secret: <%= ENV['JSON_WEB_TOKEN_SECRET'] %>
+  secret_key_base: <%= ENV.fetch("SECRET_KEY_BASE") if Rails.env.production? %>
+  json_web_token_secret: <%= ENV.fetch('JSON_WEB_TOKEN_SECRET') if Rails.env.production? %>

--- a/spec/features/log/index_spec.rb
+++ b/spec/features/log/index_spec.rb
@@ -90,8 +90,9 @@ RSpec.feature Log, type: :feature do
     end
 
     it 'sends a notification to slack' do
-      expect(SlackNotifier).to receive(:log_notification)
-      submit_log
+      submit_log do |log|
+        expect(SlackNotifier).to receive(:log_notification).with(log)
+      end
     end
   end
 

--- a/spec/features/log/index_spec.rb
+++ b/spec/features/log/index_spec.rb
@@ -88,6 +88,11 @@ RSpec.feature Log, type: :feature do
         end.to raise_error(Capybara::ElementNotFound)
       end
     end
+
+    it 'sends a notification to slack' do
+      expect(SlackNotifier).to receive(:log_notification)
+      submit_log
+    end
   end
 
   context 'when visiting the cluster log' do

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -96,12 +96,6 @@ RSpec.feature "Maintenance windows", type: :feature do
   let(:cancel_button_text) { 'Cancel' }
   let(:extend_button_text) { 'Extend' }
 
-  before :each do
-    # The only way I can get Capybara to use the correct URL; may be a better
-    # way though.
-    default_url_options[:host] = Rails.application.routes.default_url_options[:host]
-  end
-
   def fill_in_datetime_selects(identifier, with:)
     select with.year.to_s, from: "#{identifier}-datetime-select-year"
     month_name = with.strftime('%B')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,4 +100,19 @@ RSpec.configure do |config|
     # visited.
     allow_any_instance_of(Cluster).to receive(:documents).and_return([])
   end
+
+  # Below ensures that the Slack integration with flight center doesn't cause
+  # issues with tests that monitor HTTP packets using VCR
+  class NoOpHTTPClient
+    def self.post uri, params={}
+    end
+  end
+
+  config.before do
+    allow(Slack::Notifier).to receive(:new).and_wrap_original do |m, *args|
+      m.call(*args) do
+        http_client NoOpHTTPClient
+      end
+    end
+  end
 end


### PR DESCRIPTION
Introduced in this PR is the Slack integration for `Alces Flight Center`. This notifier is intended to send notifications to the support channel of our Slack workspace whenever an email would normally be sent, or a new log is created. For a full list of notification events see towards the bottom of this PR.

## Environment Variables
There are a few environment variables associated with this integration, the WebHook URL, channel and username. The former is vital for sending notifications whereas the latter can be used for mostly development purposes.
### WebHook URL
Within your `.env` file you will need to set the `SLACK_WEBHOOK_URL` to match the value found within the `Alces Flight Center` Incoming WebHook on Slack. Without this the application will not be able to send the notifications to Slack but should only silently fail if you choose not to set this. 
### Channel 
Found under `SLACK_CHANNEL` this can be set to any channel in the workspace, including users via private messages. This can be useful for sending any test notifications during development to your own private messages via slackbot.
Example: `export SLACK_CHANNEL=@Jerry` will send all notifications to user 'Jerry' within the workspace
### Username
Using `SLACK_USERNAME` the display name for the notifications can be changed. This can be used to better differentiate which environment the notifications are coming from.
Example `export SLACK_USERNAME='Alces Flight Center [Dev]`

## Notification Events
- New case
- New comment
- New log
- Assignee change on a case
- Maintenance information

Note: @bobwhitelock as discussed before the links in the notifications currently point to `center.alces-flight.com/...` at all times. 

[Trello](https://trello.com/c/lcYYCyjL/313-have-support-slack-channel-be-notified-about-flight-center-emails-and-new-cluster-log-entries)