### PR TITLE
Manage cluster credit balance

### DIFF
--- a/app/assets/stylesheets/clusters.scss
+++ b/app/assets/stylesheets/clusters.scss
@@ -1,0 +1,35 @@
+.cluster-shortcode {
+  font-size: 1rem;
+  line-height: 1rem;
+  border: 1px solid #C0C0C0;
+  padding: 0.25rem;
+  vertical-align: middle;
+}
+
+p.credit-balance {
+  font-size: 2.5rem;
+  text-align: center;
+  margin: auto;
+}
+
+.card.credit-balance .card-body {
+  display: flex;
+  flex-direction: column;
+}
+
+li.credit-charge-entry {
+  display: flex;
+  justify-content: space-between;
+  justify-items: center;
+
+  * {
+    flex-grow: 0;
+    flex-shrink: 1;
+  }
+
+  .text {
+    flex-grow: 1;
+    padding: 0 1rem;
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1,6 +1,3 @@
-// Place all the styles related to the Components controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
 .support-type-button {
   width: 100%;
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -33,9 +33,4 @@ li.credit-charge-entry {
     padding: 0 1rem;
     font-weight: bold;
   }
-
-  .fa {
-    display: inline-block;
-    vertical-align: middle;
-  }
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -5,3 +5,11 @@
 .support-type-button {
   width: 100%;
 }
+
+.cluster-shortcode {
+  font-size: 1rem;
+  line-height: 1rem;
+  border: 1px solid #C0C0C0;
+  padding: 0.25rem;
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -17,3 +17,25 @@
   font-size: 2.5rem;
   text-align: center;
 }
+
+li.credit-charge-entry {
+  display: flex;
+  justify-content: space-between;
+  justify-items: center;
+
+  * {
+    flex-grow: 0;
+    flex-shrink: 1;
+  }
+
+  .text {
+    flex-grow: 1;
+    padding: 0 1rem;
+    font-weight: bold;
+  }
+
+  .fa {
+    display: inline-block;
+    vertical-align: middle;
+  }
+}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -10,9 +10,15 @@
   vertical-align: middle;
 }
 
-.credit-balance {
+p.credit-balance {
   font-size: 2.5rem;
   text-align: center;
+}
+
+.card.credit-balance .card-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
 }
 
 li.credit-charge-entry {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1,7 +1,6 @@
 // Place all the styles related to the Components controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-
 .support-type-button {
   width: 100%;
 }
@@ -12,4 +11,9 @@
   border: 1px solid #C0C0C0;
   padding: 0.25rem;
   vertical-align: middle;
+}
+
+.credit-balance {
+  font-size: 2.5rem;
+  text-align: center;
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1,39 +1,3 @@
 .support-type-button {
   width: 100%;
 }
-
-.cluster-shortcode {
-  font-size: 1rem;
-  line-height: 1rem;
-  border: 1px solid #C0C0C0;
-  padding: 0.25rem;
-  vertical-align: middle;
-}
-
-p.credit-balance {
-  font-size: 2.5rem;
-  text-align: center;
-  margin: auto;
-}
-
-.card.credit-balance .card-body {
-  display: flex;
-  flex-direction: column;
-}
-
-li.credit-charge-entry {
-  display: flex;
-  justify-content: space-between;
-  justify-items: center;
-
-  * {
-    flex-grow: 0;
-    flex-shrink: 1;
-  }
-
-  .text {
-    flex-grow: 1;
-    padding: 0 1rem;
-    font-weight: bold;
-  }
-}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -13,12 +13,12 @@
 p.credit-balance {
   font-size: 2.5rem;
   text-align: center;
+  margin: auto;
 }
 
 .card.credit-balance .card-body {
   display: flex;
   flex-direction: column;
-  justify-content: space-evenly;
 }
 
 li.credit-charge-entry {

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -71,9 +71,12 @@ class CasesController < ApplicationController
   end
 
   def close
-    charge = params.require(:case).require(:credit_charge).to_i
+    charge_params = params.require(:credit_charge)
+                          .permit(:amount)
+                          .merge(user: current_user)
+
     change_action "Support case %s closed." do |kase|
-      kase.create_credit_charge(amount: charge, user: current_user)
+      kase.create_credit_charge(charge_params)
       kase.close!(current_user)
     end
   rescue ActionController::ParameterMissing

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -73,7 +73,7 @@ class CasesController < ApplicationController
   def close
     charge = params.require(:case).require(:credit_charge).to_i
     change_action "Support case %s closed." do |kase|
-      kase.credit_charge = charge
+      kase.create_credit_charge(amount: charge, user: current_user)
       kase.close!(current_user)
     end
   rescue ActionController::ParameterMissing

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -1,3 +1,8 @@
 class ClustersController < ApplicationController
   decorates_assigned :cluster
+
+  def credit_usage
+    @accrued = 0
+    @used = 0
+  end
 end

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -5,15 +5,14 @@ class ClustersController < ApplicationController
   after_action :verify_authorized, except: NO_AUTH_ACTIONS + [:credit_usage]
 
   def credit_usage
+    credit_events = ClusterCreditEvents.new(@cluster, start_date, end_date)
 
-    @events = @cluster.credit_events_in_period(start_date, end_date)
-                      .map(&:decorate)
+    @events = credit_events.events.map(&:decorate)
 
-    @accrued = @cluster.total_accrual_in_period(start_date, end_date)
-    @used = @cluster.total_charges_in_period(start_date, end_date)
+    @accrued = credit_events.total_accrual
+    @used = credit_events.total_charges
 
-    @free_of_charge = @cluster.cases_closed_free_in_period(start_date, end_date)
-
+    @free_of_charge = credit_events.cases_closed_without_charge
   end
 
   def deposit

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -2,7 +2,42 @@ class ClustersController < ApplicationController
   decorates_assigned :cluster
 
   def credit_usage
-    @accrued = 0
-    @used = 0
+
+    @events = (charges + deposits).sort_by(&:created_at)
+
+    @accrued = deposits.reduce(0) do |total, deposit|
+      total += deposit.amount
+    end
+
+    @used = charges.reduce(0) do |total, kase|
+      total += kase.credit_charge.amount
+    end
+
+  end
+
+  private
+
+  def start_date
+    @start_date ||= begin
+      parse_start_date.beginning_of_quarter
+    rescue
+      Date.today.beginning_of_quarter
+    end
+  end
+
+  def end_date
+    @end_date ||= start_date.end_of_quarter
+  end
+
+  def parse_start_date
+    Date.parse(params[:start_date])
+  end
+
+  def charges
+    @cluster.cases.with_charge_in_period(start_date, end_date)
+  end
+
+  def deposits
+    @cluster.credit_deposits.in_period(start_date, end_date)
   end
 end

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -39,16 +39,22 @@ class ClustersController < ApplicationController
   end
 
   def charges
-    @cluster.cases.with_charge_in_period(start_date, end_date).map(&:credit_charge)
+    @cluster.cases.with_charge_in_period(
+      Time.zone.local_to_utc(start_date.to_datetime),
+      Time.zone.local_to_utc(end_date.to_datetime)
+    ).map(&:credit_charge)
   end
 
   def deposits
-    @cluster.credit_deposits.in_period(start_date, end_date)
+    @cluster.credit_deposits.in_period(
+      Time.zone.local_to_utc(start_date.to_datetime),
+      Time.zone.local_to_utc(end_date.to_datetime)
+    )
   end
 
   def all_quarter_start_dates
     first_quarter = @cluster.created_at.beginning_of_quarter
-    last_quarter = Date.today.beginning_of_quarter
+    last_quarter =  Date.today.beginning_of_quarter.to_datetime
 
     [].tap do |qs|
       curr_quarter = last_quarter

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -16,6 +16,8 @@ class ClustersController < ApplicationController
       total += kase.amount
     end
 
+    @all_quarter_start_dates = all_quarter_start_dates
+
   end
 
   private
@@ -42,5 +44,18 @@ class ClustersController < ApplicationController
 
   def deposits
     @cluster.credit_deposits.in_period(start_date, end_date)
+  end
+
+  def all_quarter_start_dates
+    first_quarter = @cluster.created_at.beginning_of_quarter
+    last_quarter = Date.today.beginning_of_quarter
+
+    [].tap do |qs|
+      curr_quarter = last_quarter
+      while curr_quarter >= first_quarter
+        qs << curr_quarter
+        curr_quarter -= 3.months
+      end
+    end
   end
 end

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -39,10 +39,10 @@ class ClustersController < ApplicationController
   end
 
   def charges
-    @cluster.cases.with_charge_in_period(
+    @cluster.credit_charges.in_period(
       Time.zone.local_to_utc(start_date.to_datetime),
       Time.zone.local_to_utc(end_date.to_datetime)
-    ).map(&:credit_charge)
+    )
   end
 
   def deposits

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -18,6 +18,8 @@ class ClustersController < ApplicationController
 
     @all_quarter_start_dates = all_quarter_start_dates
 
+    @free_of_charge = charges.where(amount: 0).count
+
   end
 
   private

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -18,11 +18,13 @@ class ClustersController < ApplicationController
 
   def deposit
 
-    amount = params.require(:credit_deposit).permit(:amount).require(:amount).to_i
+    deposit_params = params.require(:credit_deposit)
+                           .permit(:amount)
+                           .merge(user: current_user)
 
     begin
-      @cluster.credit_deposits.create!(amount: amount, user: current_user)
-      flash[:success] = "#{view_context.pluralize(amount, 'credit')} added to cluster #{@cluster.name}."
+      deposit = @cluster.credit_deposits.create!(deposit_params)
+      flash[:success] = "#{view_context.pluralize(deposit.amount, 'credit')} added to cluster #{@cluster.name}."
     rescue
       flash[:error] = 'Error while trying to deposit credits for this cluster.'
     end

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -23,6 +23,16 @@ class ClustersController < ApplicationController
   end
 
   def deposit
+
+    amount = params.require(:credit_deposit).permit(:amount).require(:amount).to_i
+
+    begin
+      @cluster.credit_deposits.create!(amount: amount, user: current_user)
+      flash[:success] = "#{view_context.pluralize(amount, 'credit')} added to cluster #{@cluster.name}."
+    rescue
+      flash[:error] = 'Error while trying to deposit credits for this cluster.'
+    end
+
     redirect_to cluster_credit_usage_path(@cluster)
   end
 

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -1,6 +1,9 @@
 class ClustersController < ApplicationController
   decorates_assigned :cluster
 
+  # :credit_usage is a read-only action so should not require authorization.
+  after_action :verify_authorized, except: NO_AUTH_ACTIONS + [:credit_usage]
+
   def credit_usage
 
     @events = (charges + deposits)
@@ -17,6 +20,8 @@ class ClustersController < ApplicationController
   end
 
   def deposit
+
+    authorize @cluster
 
     deposit_params = params.require(:credit_deposit)
                            .permit(:amount)

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -3,14 +3,17 @@ class ClustersController < ApplicationController
 
   def credit_usage
 
-    @events = (charges + deposits).sort_by(&:created_at)
+    @events = (charges + deposits)
+              .sort_by(&:created_at)
+              .reverse!
+              .map(&:decorate)
 
     @accrued = deposits.reduce(0) do |total, deposit|
       total += deposit.amount
     end
 
     @used = charges.reduce(0) do |total, kase|
-      total += kase.credit_charge.amount
+      total += kase.amount
     end
 
   end
@@ -34,7 +37,7 @@ class ClustersController < ApplicationController
   end
 
   def charges
-    @cluster.cases.with_charge_in_period(start_date, end_date)
+    @cluster.cases.with_charge_in_period(start_date, end_date).map(&:credit_charge)
   end
 
   def deposits

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -22,6 +22,10 @@ class ClustersController < ApplicationController
 
   end
 
+  def deposit
+    redirect_to cluster_credit_usage_path(@cluster)
+  end
+
   private
 
   def start_date

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -71,18 +71,6 @@ module Audited
       end
     end
 
-    def credit_charge_text(from, to)
-      if from.nil?
-        "A charge of #{h.pluralize(to, 'credit')} was added for this case."
-      else
-        "The credit charge attached to this case was changed from #{from} to #{pluralize(to, 'credit')}"
-      end
-    end
-
-    def credit_charge_type
-      'usd'
-    end
-
     def tier_level_text(from, to)
       if to == 3 && from < 3
         "Escalated this case to tier #{h.tier_description(to)}."

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -61,6 +61,21 @@ class ClusterDecorator < ApplicationDecorator
     end
   end
 
+  # List the first day of each quarter since this cluster was created, including
+  # the current quarter (as defined by `Date.today`).
+  def all_quarter_start_dates
+    first_quarter = model.created_at.beginning_of_quarter
+    last_quarter =  Date.today.beginning_of_quarter.to_datetime
+
+    [].tap do |qs|
+      curr_quarter = last_quarter
+      while curr_quarter >= first_quarter
+        qs << curr_quarter
+        curr_quarter -= 3.months
+      end
+    end
+  end
+
   private
 
   def notes_tab
@@ -85,5 +100,4 @@ class ClusterDecorator < ApplicationDecorator
       }
     end
   end
-
 end

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -50,6 +50,16 @@ class ClusterDecorator < ApplicationDecorator
     }
   end
 
+  def credit_balance_class
+    if credit_balance.negative? || credit_balance.zero?
+      'text-danger'
+    elsif credit_balance < 10
+      'text-warning'
+    else
+      'text-success'
+    end
+  end
+
   private
 
   def notes_tab
@@ -74,4 +84,5 @@ class ClusterDecorator < ApplicationDecorator
       }
     end
   end
+
 end

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -16,6 +16,7 @@ class ClusterDecorator < ApplicationDecorator
     [
       tabs_builder.overview,
       documents.empty? ? nil : { id: :documents, path: h.cluster_documents_path(self) },
+      { id: :credit_usage, path: h.cluster_credit_usage_path(self) },
       tabs_builder.logs,
       tabs_builder.cases,
       tabs_builder.maintenance,

--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -6,7 +6,7 @@ class CreditChargeDecorator < ApplicationDecorator
     h.render 'clusters/credit_charge_entry',
              amount: -object.amount,
              date: object.created_at do
-      h.link_to link_text, h.case_path(kase)
+      h.link_to link_text, h.case_path(kase), class: 'text-danger'
     end
   end
 end

--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -1,0 +1,12 @@
+class CreditChargeDecorator < ApplicationDecorator
+  def credit_usage_card
+    kase = object.case.decorate
+    link_text = "#{kase.display_id} - #{kase.subject}"
+
+    h.render 'clusters/credit_charge_entry',
+             amount: -object.amount,
+             date: object.created_at do
+      h.link_to link_text, h.case_path(kase)
+    end
+  end
+end

--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -6,7 +6,7 @@ class CreditChargeDecorator < ApplicationDecorator
     h.render 'clusters/credit_charge_entry',
              amount: -object.amount,
              date: object.created_at do
-      h.link_to link_text, h.case_path(kase), class: 'text-danger'
+      h.link_to link_text, h.case_path(kase), class: h.credit_value_class(-object.amount)
     end
   end
 end

--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -1,4 +1,6 @@
 class CreditChargeDecorator < ApplicationDecorator
+  delegate_all
+
   def credit_usage_card
     kase = object.case.decorate
     link_text = "#{kase.display_id} - #{kase.subject}"
@@ -8,5 +10,14 @@ class CreditChargeDecorator < ApplicationDecorator
              date: object.created_at do
       h.link_to link_text, h.case_path(kase), class: h.credit_value_class(-object.amount)
     end
+  end
+
+  def event_card
+    h.render 'cases/event',
+             admin_only: false,
+             date: created_at,
+             name: user.name,
+             text:  "A charge of #{h.pluralize(amount, 'credit')} was added for this case.",
+             type: 'usd'
   end
 end

--- a/app/decorators/credit_deposit_decorator.rb
+++ b/app/decorators/credit_deposit_decorator.rb
@@ -1,0 +1,11 @@
+class CreditDepositDecorator < ApplicationDecorator
+
+  def credit_usage_card
+    h.render 'clusters/credit_charge_entry',
+             amount: object.amount,
+             date: object.created_at do
+      'Credits added'
+    end
+  end
+
+end

--- a/app/helpers/clusters_helper.rb
+++ b/app/helpers/clusters_helper.rb
@@ -9,7 +9,7 @@ module ClustersHelper
   end
 
   def quarter_display_name(start)
-    "Q#{((start.month - 1) / 3) + 1} (#{start.strftime('%d %b')} - #{start.end_of_quarter.strftime('%d %b')}) #{start.year}"
+    "#{start.year} Q#{((start.month - 1) / 3) + 1} (#{start.strftime('%d %b')} - #{start.end_of_quarter.strftime('%d %b')})"
   end
 
 end

--- a/app/helpers/clusters_helper.rb
+++ b/app/helpers/clusters_helper.rb
@@ -1,8 +1,10 @@
 module ClustersHelper
 
   def credit_value_class(value)
-    if value.negative? || value.zero?
+    if value.negative?
       'text-warning'
+    elsif value.zero?
+      'text-muted'
     else
       'text-success'
     end

--- a/app/helpers/clusters_helper.rb
+++ b/app/helpers/clusters_helper.rb
@@ -2,7 +2,7 @@ module ClustersHelper
 
   def credit_value_class(value)
     if value.negative? || value.zero?
-      'text-danger'
+      'text-warning'
     else
       'text-success'
     end

--- a/app/helpers/clusters_helper.rb
+++ b/app/helpers/clusters_helper.rb
@@ -8,4 +8,8 @@ module ClustersHelper
     end
   end
 
+  def quarter_display_name(start)
+    "Q#{((start.month - 1) / 3) + 1} (#{start.strftime('%d %b')} - #{start.end_of_quarter.strftime('%d %b')}) #{start.year}"
+  end
+
 end

--- a/app/helpers/clusters_helper.rb
+++ b/app/helpers/clusters_helper.rb
@@ -1,0 +1,11 @@
+module ClustersHelper
+
+  def credit_value_class(value)
+    if value.negative? || value.zero?
+      'text-danger'
+    else
+      'text-success'
+    end
+  end
+
+end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -99,12 +99,6 @@ class Case < ApplicationRecord
   scope :assigned_to, ->(user) { where(assignee: user) }
   scope :not_assigned_to, ->(user) { where.not(assignee: user).or(where(assignee: nil)) }
 
-  scope :with_charge, lambda {
-    where(state: 'closed')
-      .includes(:credit_charge)
-      .where.not(credit_charges: { id: nil })
-  }
-
   def to_param
     self.display_id.parameterize.upcase
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -72,6 +72,7 @@ class Case < ApplicationRecord
   validate :time_worked_not_changed_unless_allowed
 
   validates :credit_charge, presence: true,  if: :closed?
+  validates_associated :credit_charge
 
   # Only validate this type of support is available on create, as this is the
   # only point at which we should prevent users accessing support they are not

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -99,10 +99,18 @@ class Case < ApplicationRecord
   scope :assigned_to, ->(user) { where(assignee: user) }
   scope :not_assigned_to, ->(user) { where.not(assignee: user).or(where(assignee: nil)) }
 
-  scope :with_charge, -> {
+  scope :with_charge, lambda {
     where(state: 'closed')
-    .includes(:credit_charge)
-    .where.not(credit_charges: {id: nil})
+      .includes(:credit_charge)
+      .where.not(credit_charges: { id: nil })
+  }
+
+  scope :with_charge_in_period, lambda { |start_date, end_date|
+    with_charge.includes(:credit_charge)
+               .where('credit_charges.created_at BETWEEN ? AND ?',
+                      start_date,
+                      end_date
+               )
   }
 
   def to_param

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -19,6 +19,8 @@ class Case < ApplicationRecord
   has_many :case_state_transitions
   alias_attribute :transitions, :case_state_transitions
 
+  has_one :credit_charge, required: false
+
   delegate :category, to: :issue
   delegate :email_recipients, to: :site
   delegate :site, to: :cluster, allow_nil: true
@@ -68,11 +70,6 @@ class Case < ApplicationRecord
   }
 
   validate :time_worked_not_changed_unless_allowed
-
-  validates :credit_charge, numericality: {
-      only_integer: true,
-      greater_than_or_equal_to: 0
-  }, if: :credit_charge  # Credit charge can be null (not set)
 
   validates :credit_charge, presence: true,  if: :closed?
 
@@ -216,6 +213,12 @@ class Case < ApplicationRecord
   def tier_level=(new_level)
     @tier_level_changed = (new_level != tier_level)
     super(new_level)
+  end
+
+  def credit_charge=(charge_amount)
+    unless credit_charge.present?
+      credit_charge.create(amount: charge_amount)
+    end
   end
 
   def save!

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -99,7 +99,11 @@ class Case < ApplicationRecord
   scope :assigned_to, ->(user) { where(assignee: user) }
   scope :not_assigned_to, ->(user) { where.not(assignee: user).or(where(assignee: nil)) }
 
-  scope :with_charge, -> { where(state: 'closed').where('credit_charge > ?', 0) }
+  scope :with_charge, -> {
+    where(state: 'closed')
+    .includes(:credit_charge)
+    .where.not(credit_charges: {id: nil})
+  }
 
   def to_param
     self.display_id.parameterize.upcase
@@ -213,12 +217,6 @@ class Case < ApplicationRecord
   def tier_level=(new_level)
     @tier_level_changed = (new_level != tier_level)
     super(new_level)
-  end
-
-  def credit_charge=(charge_amount)
-    unless credit_charge.present?
-      credit_charge.create(amount: charge_amount)
-    end
   end
 
   def save!

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -105,14 +105,6 @@ class Case < ApplicationRecord
       .where.not(credit_charges: { id: nil })
   }
 
-  scope :with_charge_in_period, lambda { |start_date, end_date|
-    with_charge.includes(:credit_charge)
-               .where('credit_charges.created_at BETWEEN ? AND ?',
-                      start_date,
-                      end_date
-               )
-  }
-
   def to_param
     self.display_id.parameterize.upcase
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -102,6 +102,8 @@ class Case < ApplicationRecord
   scope :assigned_to, ->(user) { where(assignee: user) }
   scope :not_assigned_to, ->(user) { where.not(assignee: user).or(where(assignee: nil)) }
 
+  scope :with_charge, -> { where(state: 'closed').where('credit_charge > ?', 0) }
+
   def to_param
     self.display_id.parameterize.upcase
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -37,7 +37,7 @@ class Case < ApplicationRecord
 
   end
 
-  audited only: [:assignee_id, :time_worked, :credit_charge, :tier_level], on: [ :update ]
+  audited only: [:assignee_id, :time_worked, :tier_level], on: [ :update ]
 
   validates :display_id, uniqueness: true
 
@@ -134,7 +134,8 @@ class Case < ApplicationRecord
       maintenance_windows.map(&:transitions).flatten.select(&:event) +
       case_state_transitions +
       audits +
-      logs
+      logs +
+      [ credit_charge ].compact
     ).sort_by(&:created_at).reverse!
   end
 

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -87,13 +87,8 @@ class Cluster < ApplicationRecord
       total -= kase.amount
     end
   end
-  
-  def charged_cases
-    cases.with_charge
-  end
 
   private
-
 
   def validate_all_cluster_parts_advice
     ['components', 'services'].each do |cluster_part|

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -24,6 +24,7 @@ class Cluster < ApplicationRecord
   has_many :maintenance_windows
   has_many :logs, dependent: :destroy
   has_many :notes, dependent: :destroy
+  has_many :credit_deposits
 
   validates_associated :site
   validates :name, presence: true
@@ -76,7 +77,22 @@ class Cluster < ApplicationRecord
     end
   end
 
+  def credit_balance
+    deposits = credit_deposits.reduce(0) do |total, deposit|
+      total += deposit.amount
+    end
+
+    charged_cases.reduce(deposits) do |total, kase|
+      total -= kase.credit_charge
+    end
+  end
+  
+  def charged_cases
+    cases.with_charge
+  end
+
   private
+
 
   def validate_all_cluster_parts_advice
     ['components', 'services'].each do |cluster_part|

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -25,6 +25,7 @@ class Cluster < ApplicationRecord
   has_many :logs, dependent: :destroy
   has_many :notes, dependent: :destroy
   has_many :credit_deposits
+  has_many :credit_charges, through: :cases
 
   validates_associated :site
   validates :name, presence: true
@@ -82,8 +83,8 @@ class Cluster < ApplicationRecord
       total += deposit.amount
     end
 
-    charged_cases.reduce(deposits) do |total, kase|
-      total -= kase.credit_charge.amount
+    credit_charges.reduce(deposits) do |total, kase|
+      total -= kase.amount
     end
   end
   

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -83,7 +83,7 @@ class Cluster < ApplicationRecord
     end
 
     charged_cases.reduce(deposits) do |total, kase|
-      total -= kase.credit_charge
+      total -= kase.credit_charge.amount
     end
   end
   

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -88,46 +88,7 @@ class Cluster < ApplicationRecord
     end
   end
 
-  def credit_events_in_period(start_date, end_date)
-    (
-      charges_in_period(start_date, end_date) + deposits_in_period(start_date, end_date)
-    ).sort_by(&:created_at)
-      .reverse!
-  end
-
-  def total_accrual_in_period(start_date, end_date)
-    add_up deposits_in_period(start_date, end_date)
-  end
-
-  def total_charges_in_period(start_date, end_date)
-    add_up charges_in_period(start_date, end_date)
-  end
-
-  def deposits_in_period(start_date, end_date)
-    credit_deposits.in_period(
-        Time.zone.local_to_utc(start_date.to_datetime),
-        Time.zone.local_to_utc(end_date.to_datetime)
-    )
-  end
-
-  def charges_in_period(start_date, end_date)
-    credit_charges.in_period(
-        Time.zone.local_to_utc(start_date.to_datetime),
-        Time.zone.local_to_utc(end_date.to_datetime)
-    )
-  end
-
-  def cases_closed_free_in_period(start_date, end_date)
-    charges_in_period(start_date, end_date).where(amount: 0).count
-  end
-
   private
-
-  def add_up(things)
-    things.reduce(0) do |total, thing|
-      total += thing.amount
-    end
-  end
 
   def validate_all_cluster_parts_advice
     ['components', 'services'].each do |cluster_part|

--- a/app/models/cluster_credit_events.rb
+++ b/app/models/cluster_credit_events.rb
@@ -1,0 +1,50 @@
+# Represents a set of credit events for a cluster in a given period.
+class ClusterCreditEvents
+
+  def initialize(cluster, start_date, end_date)
+    @cluster = cluster
+    @start_date = Time.zone.local_to_utc(start_date.to_datetime)
+    @end_date = Time.zone.local_to_utc(end_date.to_datetime)
+  end
+
+  def events
+    (charges + deposits)
+      .sort_by(&:created_at)
+      .reverse!
+  end
+
+  def charges
+    @charges ||= @cluster.credit_charges.in_period(
+      @start_date,
+      @end_date
+    )
+  end
+
+  def deposits
+    @deposits ||= @cluster.credit_deposits.in_period(
+      @start_date,
+      @end_date
+    )
+  end
+
+  def total_accrual
+    add_up deposits
+  end
+
+  def total_charges
+    add_up charges
+  end
+
+  def cases_closed_without_charge
+    charges.where(amount: 0).count
+  end
+
+  private
+
+  def add_up(things)
+    things.reduce(0) do |total, thing|
+      total += thing.amount
+    end
+  end
+
+end

--- a/app/models/credit_charge.rb
+++ b/app/models/credit_charge.rb
@@ -2,4 +2,9 @@ class CreditCharge < CreditEvent
   belongs_to :case
   delegate :site, to: :case
   attr_readonly :case
+
+  validates :amount, numericality: {
+    minimum: 0,
+    only_integer: true,
+  }
 end

--- a/app/models/credit_charge.rb
+++ b/app/models/credit_charge.rb
@@ -1,18 +1,5 @@
-class CreditCharge < ApplicationRecord
+class CreditCharge < CreditEvent
   belongs_to :case
-  belongs_to :user
-
-  validates :amount,
-            presence: true,
-            numericality: {
-                only_integer: true,
-            }
-
   delegate :site, to: :case
-
-  attr_readonly :case, :user, :amount
-
-  scope :in_period, lambda { |start_date, end_date|
-    where(created_at: start_date..end_date)
-  }
+  attr_readonly :case
 end

--- a/app/models/credit_charge.rb
+++ b/app/models/credit_charge.rb
@@ -11,4 +11,8 @@ class CreditCharge < ApplicationRecord
   delegate :site, to: :case
 
   attr_readonly :case, :user, :amount
+
+  scope :in_period, lambda { |start_date, end_date|
+    where(created_at: start_date..end_date)
+  }
 end

--- a/app/models/credit_charge.rb
+++ b/app/models/credit_charge.rb
@@ -1,0 +1,14 @@
+class CreditCharge < ApplicationRecord
+  belongs_to :case
+  belongs_to :user
+
+  validates :amount,
+            presence: true,
+            numericality: {
+                only_integer: true,
+            }
+
+  delegate :site, to: :case
+
+  attr_readonly :case, :user, :amount
+end

--- a/app/models/credit_deposit.rb
+++ b/app/models/credit_deposit.rb
@@ -14,4 +14,8 @@ class CreditDeposit < ApplicationRecord
   delegate :site, to: :cluster
 
   attr_readonly :cluster, :user, :amount
+
+  scope :in_period, lambda { |start_date, end_date|
+    where(created_at: start_date..end_date)
+  }
 end

--- a/app/models/credit_deposit.rb
+++ b/app/models/credit_deposit.rb
@@ -2,4 +2,9 @@ class CreditDeposit < CreditEvent
   belongs_to :cluster
   delegate :site, to: :cluster
   attr_readonly :cluster
+
+  validates :amount, numericality: {
+    minimum: 1,
+    only_integer: true,
+  }
 end

--- a/app/models/credit_deposit.rb
+++ b/app/models/credit_deposit.rb
@@ -1,0 +1,17 @@
+class CreditDeposit < ApplicationRecord
+  belongs_to :cluster
+  belongs_to :user
+
+  # We only deal in whole credits so this must be an integer
+  # I'm not going to restrict it to be positive since we might occasionally want
+  # to do corrections or something...
+  validates :amount,
+            presence: true,
+            numericality: {
+              only_integer: true,
+            }
+
+  delegate :site, to: :cluster
+
+  attr_readonly :cluster, :user, :amount
+end

--- a/app/models/credit_deposit.rb
+++ b/app/models/credit_deposit.rb
@@ -1,21 +1,5 @@
-class CreditDeposit < ApplicationRecord
+class CreditDeposit < CreditEvent
   belongs_to :cluster
-  belongs_to :user
-
-  # We only deal in whole credits so this must be an integer
-  # I'm not going to restrict it to be positive since we might occasionally want
-  # to do corrections or something...
-  validates :amount,
-            presence: true,
-            numericality: {
-              only_integer: true,
-            }
-
   delegate :site, to: :cluster
-
-  attr_readonly :cluster, :user, :amount
-
-  scope :in_period, lambda { |start_date, end_date|
-    where(created_at: start_date..end_date)
-  }
+  attr_readonly :cluster
 end

--- a/app/models/credit_event.rb
+++ b/app/models/credit_event.rb
@@ -1,0 +1,17 @@
+class CreditEvent < ApplicationRecord
+  self.abstract_class = true
+
+  belongs_to :user
+
+  validates :amount,
+            presence: true,
+            numericality: {
+                only_integer: true,
+            }
+
+  attr_readonly :user, :amount
+
+  scope :in_period, lambda { |start_date, end_date|
+    where(created_at: start_date..end_date)
+  }
+end

--- a/app/policies/cluster_policy.rb
+++ b/app/policies/cluster_policy.rb
@@ -1,0 +1,10 @@
+class ClusterPolicy < ApplicationPolicy
+
+  alias_method :deposit?, :admin?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -22,7 +22,8 @@
                            :amount,
                            class: 'form-control',
                            min: 0,
-                           value: 0
+                           value: 0,
+                           required: 'required'
           %>
           <div class="input-group-append">
             <%= submit_tag 'Set charge and close case',

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -18,8 +18,8 @@
         ) do %>
       <div class="form-group">
         <div class="input-group">
-          <%= number_field :case,
-                           :credit_charge,
+          <%= number_field :credit_charge,
+                           :amount,
                            class: 'form-control',
                            min: 0,
                            value: 0

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -37,7 +37,7 @@
       <tr>
         <td colspan="2"></td>
         <th>Credit usage</th>
-        <td><%= pluralize(@case.credit_charge, 'credit') %></td>
+        <td><%= pluralize(@case.credit_charge.amount, 'credit') %></td>
       </tr>
       <% end %>
       <tr>

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card credit-balance">
   <div class="card-body">
     <h4>Support credit balance</h4>
     <p class="credit-balance <%= cluster.credit_balance_class %>">

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -5,5 +5,6 @@
       <i class="fa fa-circle mr-2" aria-hidden="true"></i>
       <%= pluralize(cluster.credit_balance, 'credit') %>
     </p>
+    <%= yield %>
   </div>
 </div>

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -1,0 +1,9 @@
+<div class="card">
+  <div class="card-body">
+    <h4>Support credit balance</h4>
+    <p class="credit-balance <%= cluster.credit_balance_class %>">
+      <i class="fa fa-circle mr-2" aria-hidden="true"></i>
+      <%= pluralize(cluster.credit_balance, 'credit') %>
+    </p>
+  </div>
+</div>

--- a/app/views/clusters/_credit_charge_entry.html.erb
+++ b/app/views/clusters/_credit_charge_entry.html.erb
@@ -1,0 +1,14 @@
+<li class="list-group-item credit-charge-entry">
+  <span class="<%= credit_value_class(amount) %>">
+    <i class="fa fa-circle mr-2" aria-hidden="true"></i>
+  </span>
+  <span title="<%= date.to_formatted_s(:long) %>">
+    <%= date.to_formatted_s(:day_only) %>
+  </span>
+  <span class="text">
+    <%= yield %>
+  </span>
+  <span class="<%= credit_value_class(amount) %>">
+    <%= pluralize(amount, 'credit') %>
+  </span>
+</li>

--- a/app/views/clusters/_credit_charge_entry.html.erb
+++ b/app/views/clusters/_credit_charge_entry.html.erb
@@ -1,5 +1,5 @@
-<li class="list-group-item credit-charge-entry">
-  <span class="<%= credit_value_class(amount) %>">
+<li class="list-group-item credit-charge-entry <%= credit_value_class(amount) %>">
+  <span>
     <i class="fa fa-circle mr-2" aria-hidden="true"></i>
   </span>
   <span title="<%= date.to_formatted_s(:long) %>">
@@ -8,7 +8,7 @@
   <span class="text">
     <%= yield %>
   </span>
-  <span class="<%= credit_value_class(amount) %>">
+  <span>
     <%= pluralize(amount, 'credit') %>
   </span>
 </li>

--- a/app/views/clusters/_deposit_form.html.erb
+++ b/app/views/clusters/_deposit_form.html.erb
@@ -8,7 +8,8 @@
       <div class="input-group">
         <%= number_field :credit_deposit,
                          :amount,
-                         class: 'form-control'
+                         class: 'form-control',
+                         min: 1
         %>
         <div class="input-group-append">
           <%= submit_tag 'Add credits',

--- a/app/views/clusters/_deposit_form.html.erb
+++ b/app/views/clusters/_deposit_form.html.erb
@@ -1,0 +1,24 @@
+<% if current_user.admin? %>
+  <%= form_tag({controller: 'clusters', action: 'deposit'},
+               method: :post,
+               class: 'form',
+               id: 'credit-deposit-form'
+      ) do %>
+    <div class="form-group">
+      <div class="input-group">
+        <%= number_field :credit_deposit,
+                         :amount,
+                         class: 'form-control'
+        %>
+        <div class="input-group-append">
+          <%= submit_tag 'Add credits',
+                         class: 'form-control btn btn-primary',
+                         data: {
+                             confirm: 'Are you sure you want to add support credits to this cluster?'
+                         }
+          %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -32,7 +32,11 @@
     </ul>
   </div>
   <div class="col-sm-12 col-md-6">
-    <%= render 'clusters/credit_balance', cluster: cluster %>
+    <%= render 'clusters/credit_balance', cluster: cluster do %>
+      <%= link_to 'See detailed usage', cluster_credit_usage_path(cluster),
+                  class: 'btn btn-primary float-right'
+      %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -34,7 +34,7 @@
   <div class="col-sm-12 col-md-6">
     <%= render 'clusters/credit_balance', cluster: cluster do %>
       <%= link_to 'See detailed usage', cluster_credit_usage_path(cluster),
-                  class: 'btn btn-primary float-right'
+                  class: 'btn btn-primary'
       %>
     <% end %>
   </div>

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -32,7 +32,7 @@
     </ul>
   </div>
   <div class="col-sm-12 col-md-6">
-    wip
+    <%= render 'clusters/credit_balance', cluster: cluster %>
   </div>
 </div>
 

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -1,27 +1,38 @@
-<ul class="list-group list-group-flush">
-  <li class="list-group-item">
-    <%= cluster.rendered_description %>
-  </li>
-  <li class="list-group-item">
-    <%= cluster.readable_support_type.capitalize %> cluster
-    <%= cluster.cluster_part_icons %>
-  </li>
-  <% [:component, :service].each do |part_type| %>
-    <% part_scope = @scope.public_send(part_type.to_s.pluralize) %>
-    <li class="list-group-item">
-      <%= part_scope.managed.size %>
-      <%= SupportType::MANAGED_TEXT %>
-      <%= part_type.to_s.pluralize(part_scope.managed.size) %>
-    </li>
-    <li class="list-group-item">
-      <%= part_scope.advice.size %>
-      <%= SupportType::ADVICE_TEXT %>
-      <%= part_type.to_s.pluralize(part_scope.advice.size) %>
-    </li>
-  <% end %>
-  <li class="list-group-item">
-    <h6>MOTD</h6>
-    <%= simple_format(cluster.motd) %>
-  </li>
-</ul>
+<div class="card-body row">
+  <div class="col-sm-12 col-md-6 card-text">
+    <h3>
+      <span class="cluster-shortcode"><%= cluster.shortcode %></span>
+      <%= cluster.name %>
+    </h3>
+    <p>
+      <%= cluster.rendered_description %>
+    </p>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item">
+        <%= cluster.readable_support_type.capitalize %> cluster
+        <%= cluster.cluster_part_icons %>
+      </li>
+      <% [:component, :service].each do |part_type| %>
+        <% part_scope = @scope.public_send(part_type.to_s.pluralize) %>
+        <li class="list-group-item">
+          <%= part_scope.managed.size %>
+          <%= SupportType::MANAGED_TEXT %>
+          <%= part_type.to_s.pluralize(part_scope.managed.size) %>
+        </li>
+        <li class="list-group-item">
+          <%= part_scope.advice.size %>
+          <%= SupportType::ADVICE_TEXT %>
+          <%= part_type.to_s.pluralize(part_scope.advice.size) %>
+        </li>
+      <% end %>
+      <li class="list-group-item">
+        <h6>MOTD</h6>
+        <%= simple_format(cluster.motd) %>
+      </li>
+    </ul>
+  </div>
+  <div class="col-sm-12 col-md-6">
+    wip
+  </div>
+</div>
 

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -4,23 +4,21 @@
     <div class="col-sm-12">
       <h3><%= @cluster.name %> support credit usage</h3>
     </div>
-    <div class="col-sm-12 card-deck">
+    <div class="col-sm-6">
       <%= render 'clusters/credit_balance', cluster: @cluster.decorate %>
+    </div>
+    <div class="col-sm-6">
       <div class="card">
         <div class="card-body">
           <h4>Viewing usage for:</h4>
+          <div class="text-center text-success">
+            Total accrued this period: <%= pluralize(@accrued, 'credit') %>
+          </div>
+          <div class="text-center text-danger">
+            Total used this period: <%= pluralize(@used, 'credit') %>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="col-xs-12 col-sm-6">
-      <p class="text-center text-success">
-        Total accrued this period: <%= pluralize(@accrued, 'credit') %>
-      </p>
-    </div>
-    <div class="col-xs-12 col-sm-6">
-      <p class="text-center text-danger">
-        Total used this period: <%= pluralize(@used, 'credit') %>
-      </p>
     </div>
     <div class="col-sm-12">
       <ul class="list-group">

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -37,7 +37,7 @@
             <div class="text-center text-success">
               Total accrued this period: <%= pluralize(@accrued, 'credit') %>
             </div>
-            <div class="text-center text-danger">
+            <div class="text-center text-warning">
               Total used this period: <%= pluralize(@used, 'credit') %>
             </div>
           </div>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -2,12 +2,12 @@
 <%= render 'partials/tabs', activate: :credit_usage do %>
   <div class="card-body row">
     <div class="col-sm-12">
-      <h3><%= @cluster.name %> support credit usage</h3>
+      <h3><%= cluster.name %> support credit usage</h3>
     </div>
     <div class="col-sm-12">
       <div class="card-deck mb-2">
-        <%= render 'clusters/credit_balance', cluster: @cluster.decorate do %>
-         <%= render 'clusters/deposit_form', cluster: @cluster %>
+        <%= render 'clusters/credit_balance', cluster: cluster do %>
+         <%= render 'clusters/deposit_form', cluster: cluster %>
         <% end %>
         <div class="card">
           <div class="card-body">
@@ -27,7 +27,7 @@
               </tr>
             </table>
             <form
-              action="<%= cluster_credit_usage_path(@cluster) %>"
+              action="<%= cluster_credit_usage_path(cluster) %>"
               class="form"
               id="credit-quarter-selection"
               method="get"
@@ -39,7 +39,7 @@
                 <%= select_tag(
                         :start_date,
                         options_for_select(
-                            @all_quarter_start_dates.map {|q|
+                            cluster.all_quarter_start_dates.map {|q|
                               [quarter_display_name(q), q.strftime('%Y-%m-%d')]
                             },
                             @start_date

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -40,15 +40,15 @@
       </div>
     </div>
     <div class="col-sm-12">
-      <ul class="list-group">
-        <% if @events.empty? %>
-          <p class="text-center">No credit usage or accrual in this period.</p>
-        <% else %>
+      <% if @events.empty? %>
+        <p class="text-center">No credit usage or accrual in this period.</p>
+      <% else %>
+        <ul class="list-group">
           <% @events.each do |event| %>
             <%= event.credit_usage_card %>
           <% end %>
-        <% end %>
-      </ul>
+        </ul>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -23,7 +23,11 @@
       </p>
     </div>
     <div class="col-sm-12">
-      Body
+      <ul class="list-group">
+      <% @events.each do |event| %>
+        <%= event.credit_usage_card %>
+      <% end %>
+      </ul>
     </div>
   </div>
 <% end %>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -9,40 +9,48 @@
         <%= render 'clusters/credit_balance', cluster: @cluster.decorate %>
         <div class="card">
           <div class="card-body">
-            <h4>Viewing usage for <%= quarter_display_name(@start_date) %></h4>
+            <h4>Usage for <%= quarter_display_name(@start_date) %>:</h4>
+            <table class="table table-sm">
+              <tr class="text-success">
+                <th>Total accrued</th>
+                <td><%= pluralize(@accrued, 'credit') %></td>
+              </tr>
+              <tr class="text-warning">
+                <th>Total used</th>
+                <td><%= pluralize(@used, 'credit') %></td>
+              </tr>
+              <tr>
+                <th>Cases closed without charge</th>
+                <td><%= @free_of_charge %></td>
+              </tr>
+            </table>
             <form
               action="<%= cluster_credit_usage_path(@cluster) %>"
               class="form"
               id="credit-quarter-selection"
               method="get"
             >
+              <label for="start_date">
+                View a different period:
+              </label>
               <div class="input-group">
                 <%= select_tag(
-                      :start_date,
-                      options_for_select(
-                        @all_quarter_start_dates.map { |q|
-                          [quarter_display_name(q), q.strftime('%Y-%m-%d')]
-                        },
-                        @start_date
-                      ),
-                      class: 'form-control',
-                      onchange: 'this.form.submit()'
+                        :start_date,
+                        options_for_select(
+                            @all_quarter_start_dates.map {|q|
+                              [quarter_display_name(q), q.strftime('%Y-%m-%d')]
+                            },
+                            @start_date
+                        ),
+                        class: 'form-control',
+                        onchange: 'this.form.submit()'
                     )
                 %>
                 <div class="input-group-append">
-                  <input type="submit" class="btn btn-primary" value="View" />
+                  <input type="submit" class="btn btn-primary" value="View"/>
                 </div>
               </div>
             </form>
-            <div class="text-center text-success">
-              Total accrued this period: <%= pluralize(@accrued, 'credit') %>
-            </div>
-            <div class="text-center text-warning">
-              Total used this period: <%= pluralize(@used, 'credit') %>
-            </div>
-            <p class="text-center">
-              Cases closed without charge this period: <%= @free_of_charge %>
-            </p>
           </div>
         </div>
       </div>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:subtitle) { 'Credit usage' } %>
+<% content_for(:subtitle) { "Credit usage for #{quarter_display_name(@start_date)}" } %>
 <%= render 'partials/tabs', activate: :credit_usage do %>
   <div class="card-body row">
     <div class="col-sm-12">

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -4,38 +4,37 @@
     <div class="col-sm-12">
       <h3><%= @cluster.name %> support credit usage</h3>
     </div>
-    <div class="col-sm-6">
-      <%= render 'clusters/credit_balance', cluster: @cluster.decorate %>
-    </div>
-    <div class="col-sm-6">
-      <div class="card">
-        <div class="card-body">
-          <h4>Viewing usage for <%= quarter_display_name(@start_date) %></h4>
-          <form action="<%= cluster_credit_usage_path(@cluster) %>" class="form" method="get">
-            <div class="input-group">
-              <%= select_tag(
-                    :start_date,
-                    options_for_select(
-                      @all_quarter_start_dates.map { |q|
-                        [quarter_display_name(q), q.strftime('%Y-%m-%d')]
-                      },
-                      @start_date
-                    ),
-                    class: 'form-control',
-                    onchange: 'this.form.submit()',
-                    style: 'flex-grow: 1;' # Our version of Bootstrap seems to be missing flex-grow-* classes
-                  )
-              %>
-              <div class="input-group-append">
-                <input type="submit" class="btn btn-primary" value="View" />
+    <div class="col-sm-12">
+      <div class="card-deck mb-2">
+        <%= render 'clusters/credit_balance', cluster: @cluster.decorate %>
+        <div class="card">
+          <div class="card-body">
+            <h4>Viewing usage for <%= quarter_display_name(@start_date) %></h4>
+            <form action="<%= cluster_credit_usage_path(@cluster) %>" class="form" method="get">
+              <div class="input-group">
+                <%= select_tag(
+                      :start_date,
+                      options_for_select(
+                        @all_quarter_start_dates.map { |q|
+                          [quarter_display_name(q), q.strftime('%Y-%m-%d')]
+                        },
+                        @start_date
+                      ),
+                      class: 'form-control',
+                      onchange: 'this.form.submit()'
+                    )
+                %>
+                <div class="input-group-append">
+                  <input type="submit" class="btn btn-primary" value="View" />
+                </div>
               </div>
+            </form>
+            <div class="text-center text-success">
+              Total accrued this period: <%= pluralize(@accrued, 'credit') %>
             </div>
-          </form>
-          <div class="text-center text-success">
-            Total accrued this period: <%= pluralize(@accrued, 'credit') %>
-          </div>
-          <div class="text-center text-danger">
-            Total used this period: <%= pluralize(@used, 'credit') %>
+            <div class="text-center text-danger">
+              Total used this period: <%= pluralize(@used, 'credit') %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -41,9 +41,13 @@
     </div>
     <div class="col-sm-12">
       <ul class="list-group">
-      <% @events.each do |event| %>
-        <%= event.credit_usage_card %>
-      <% end %>
+        <% if @events.empty? %>
+          <p class="text-center">No credit usage or accrual in this period.</p>
+        <% else %>
+          <% @events.each do |event| %>
+            <%= event.credit_usage_card %>
+          <% end %>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -40,6 +40,9 @@
             <div class="text-center text-warning">
               Total used this period: <%= pluralize(@used, 'credit') %>
             </div>
+            <p class="text-center">
+              Cases closed without charge this period: <%= @free_of_charge %>
+            </p>
           </div>
         </div>
       </div>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -32,6 +32,11 @@
               id="credit-quarter-selection"
               method="get"
             >
+              <script type="text/javascript">
+                function viewCreditPeriod(date) {
+                  window.location.href = "<%= cluster_credit_usage_path(cluster) %>/" + date;
+                }
+              </script>
               <label for="start_date">
                 View a different period:
               </label>
@@ -45,7 +50,7 @@
                             @start_date
                         ),
                         class: 'form-control',
-                        onchange: 'this.form.submit()'
+                        onchange: 'viewCreditPeriod(this.value)'
                     )
                 %>
                 <div class="input-group-append">

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -6,7 +6,9 @@
     </div>
     <div class="col-sm-12">
       <div class="card-deck mb-2">
-        <%= render 'clusters/credit_balance', cluster: @cluster.decorate %>
+        <%= render 'clusters/credit_balance', cluster: @cluster.decorate do %>
+         <%= render 'clusters/deposit_form', cluster: @cluster %>
+        <% end %>
         <div class="card">
           <div class="card-body">
             <h4>Usage for <%= quarter_display_name(@start_date) %>:</h4>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -10,7 +10,12 @@
         <div class="card">
           <div class="card-body">
             <h4>Viewing usage for <%= quarter_display_name(@start_date) %></h4>
-            <form action="<%= cluster_credit_usage_path(@cluster) %>" class="form" method="get">
+            <form
+              action="<%= cluster_credit_usage_path(@cluster) %>"
+              class="form"
+              id="credit-quarter-selection"
+              method="get"
+            >
               <div class="input-group">
                 <%= select_tag(
                       :start_date,

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -10,7 +10,27 @@
     <div class="col-sm-6">
       <div class="card">
         <div class="card-body">
-          <h4>Viewing usage for:</h4>
+          <h4>Viewing usage for <%= quarter_display_name(@start_date) %></h4>
+          <form action="<%= cluster_credit_usage_path(@cluster) %>" class="form" method="get">
+            <div class="input-group">
+              <%= select_tag(
+                    :start_date,
+                    options_for_select(
+                      @all_quarter_start_dates.map { |q|
+                        [quarter_display_name(q), q.strftime('%Y-%m-%d')]
+                      },
+                      @start_date
+                    ),
+                    class: 'form-control',
+                    onchange: 'this.form.submit()',
+                    style: 'flex-grow: 1;' # Our version of Bootstrap seems to be missing flex-grow-* classes
+                  )
+              %>
+              <div class="input-group-append">
+                <input type="submit" class="btn btn-primary" value="View" />
+              </div>
+            </div>
+          </form>
           <div class="text-center text-success">
             Total accrued this period: <%= pluralize(@accrued, 'credit') %>
           </div>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -1,4 +1,29 @@
 <% content_for(:subtitle) { 'Credit usage' } %>
 <%= render 'partials/tabs', activate: :credit_usage do %>
-  SOON.
+  <div class="card-body row">
+    <div class="col-sm-12">
+      <h3><%= @cluster.name %> support credit usage</h3>
+    </div>
+    <div class="col-sm-12 card-deck">
+      <%= render 'clusters/credit_balance', cluster: @cluster.decorate %>
+      <div class="card">
+        <div class="card-body">
+          <h4>Viewing usage for:</h4>
+        </div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6">
+      <p class="text-center text-success">
+        Total accrued this period: <%= pluralize(@accrued, 'credit') %>
+      </p>
+    </div>
+    <div class="col-xs-12 col-sm-6">
+      <p class="text-center text-danger">
+        Total used this period: <%= pluralize(@used, 'credit') %>
+      </p>
+    </div>
+    <div class="col-sm-12">
+      Body
+    </div>
+  </div>
 <% end %>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -41,7 +41,7 @@
     </div>
     <div class="col-sm-12">
       <% if @events.empty? %>
-        <p class="text-center">No credit usage or accrual in this period.</p>
+        <p class="text-center no-events-message">No credit usage or accrual in this period.</p>
       <% else %>
         <ul class="list-group">
           <% @events.each do |event| %>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -1,0 +1,4 @@
+<% content_for(:subtitle) { 'Credit usage' } %>
+<%= render 'partials/tabs', activate: :credit_usage do %>
+  SOON.
+<% end %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -16,6 +16,6 @@
   </td>
   <td><%= kase.association_info %></td>
   <% if kase.resolved? || kase.closed? %>
-    <td><%= kase.credit_charge %></td>
+    <td><%= kase.credit_charge&.amount %></td>
   <% end %>
 </tr>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -4,3 +4,7 @@ Time::DATE_FORMATS[:long] = lambda do |time|
 end
 
 Time::DATE_FORMATS[:short] = "%a %d %b %H:%M"
+
+Time::DATE_FORMATS[:day_only] = lambda do |time|
+  time.strftime("%A, #{time.day.ordinalize} %B %Y")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Rails.application.routes.draw do
       confirm_maintenance_form.call
       get :documents
       notes.call(false)
+      get :credit_usage
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
       request_maintenance_form.call
       admin_logs.call
       notes.call(true)
+      post :deposit
     end
 
     resources :components, only: []  do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,7 +169,7 @@ Rails.application.routes.draw do
       confirm_maintenance_form.call
       get :documents
       notes.call(false)
-      get '/credit_usage(/:start_date)', to: 'clusters#credit_usage', as: :credit_usage
+      get '/credit-usage(/:start_date)', to: 'clusters#credit_usage', as: :credit_usage
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,7 +168,7 @@ Rails.application.routes.draw do
       confirm_maintenance_form.call
       get :documents
       notes.call(false)
-      get :credit_usage
+      get '/credit_usage(/:start_date)', to: 'clusters#credit_usage', as: :credit_usage
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :clusters, only: []  do
+    resources :clusters, only: [] do
       request_maintenance_form.call
       admin_logs.call
       notes.call(true)

--- a/db/data/20180611161221_migrate_legacy_case_charges.rb
+++ b/db/data/20180611161221_migrate_legacy_case_charges.rb
@@ -1,9 +1,13 @@
-class MigrateLegacyCaseCharges < ActiveRecord::DataMigration
+class MigrateLegacyCaseCharges < ActiveRecord::Migration[5.2]
   def up
     Case.where(state: 'closed').each do |k|
       unless k.credit_charge.present?
         k.create_credit_charge(amount: k.legacy_credit_charge)
       end
     end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/data/20180611161221_migrate_legacy_case_charges.rb
+++ b/db/data/20180611161221_migrate_legacy_case_charges.rb
@@ -3,10 +3,23 @@ class MigrateLegacyCaseCharges < ActiveRecord::Migration[5.2]
     Case.where(state: 'closed').each do |k|
       unless k.credit_charge.present?
 
-        # If a Case is closed, it ought to have a transition to that state!
-        closing_user = k.transitions.find_by(to: 'closed').user
+        audits = k.audits.where(action: 'update').all
 
-        k.create_credit_charge!(amount: k.legacy_credit_charge, user: closing_user)
+        charge_audit = audits.select { |audit|
+          audit.audited_changes.include? 'credit_charge'
+        }.last
+
+        k.create_credit_charge!(
+          amount: k.legacy_credit_charge,
+          user: charge_audit.user,
+          created_at: charge_audit.created_at
+        )
+
+        # We want to delete the original audit because:
+        #  - all its relevant information is now captured in CreditCharge;
+        #  - if we don't then duplicate "charge added" entries may appear in
+        #    a Case's events feed even though the charge only gets added once
+        charge_audit.delete
       end
     end
   end

--- a/db/data/20180611161221_migrate_legacy_case_charges.rb
+++ b/db/data/20180611161221_migrate_legacy_case_charges.rb
@@ -2,7 +2,11 @@ class MigrateLegacyCaseCharges < ActiveRecord::Migration[5.2]
   def up
     Case.where(state: 'closed').each do |k|
       unless k.credit_charge.present?
-        k.create_credit_charge(amount: k.legacy_credit_charge)
+
+        # If a Case is closed, it ought to have a transition to that state!
+        closing_user = k.transitions.find_by(to: 'closed').user
+
+        k.create_credit_charge!(amount: k.legacy_credit_charge, user: closing_user)
       end
     end
   end

--- a/db/data_migrations/20180524142357_migrate_legacy_case_charges.rb
+++ b/db/data_migrations/20180524142357_migrate_legacy_case_charges.rb
@@ -1,0 +1,9 @@
+class MigrateLegacyCaseCharges < ActiveRecord::DataMigration
+  def up
+    Case.where(state: 'closed').each do |k|
+      unless k.credit_charge.present?
+        k.create_credit_charge(amount: k.legacy_credit_charge)
+      end
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180525164417)
+DataMigrate::Data.define(version: 20180611161221)

--- a/db/migrate/20180524101030_restore_credit_deposits.rb
+++ b/db/migrate/20180524101030_restore_credit_deposits.rb
@@ -1,0 +1,11 @@
+class RestoreCreditDeposits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :credit_deposits do |t|
+      t.timestamps null: false
+
+      t.references :cluster, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
+      t.integer :amount, null: false
+    end
+  end
+end

--- a/db/migrate/20180524143630_restore_credit_charges.rb
+++ b/db/migrate/20180524143630_restore_credit_charges.rb
@@ -1,0 +1,13 @@
+class RestoreCreditCharges < ActiveRecord::Migration[5.1]
+  def change
+    create_table :credit_charges do |t|
+      t.timestamps null: false
+
+      t.references :case, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
+      t.integer :amount, null: false
+    end
+
+    rename_column :cases, :credit_charge, :legacy_credit_charge
+  end
+end

--- a/db/migrate/20180612161101_remove_legacy_credit_charge_from_cases.rb
+++ b/db/migrate/20180612161101_remove_legacy_credit_charge_from_cases.rb
@@ -1,0 +1,5 @@
+class RemoveLegacyCreditChargeFromCases < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :cases, :legacy_credit_charge, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -209,6 +209,16 @@ ActiveRecord::Schema.define(version: 2018_06_11_103418) do
     t.index ["component_group_id"], name: "index_components_on_component_group_id"
   end
 
+  create_table "credit_deposits", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "cluster_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "amount", null: false
+    t.index ["cluster_id"], name: "index_credit_deposits_on_cluster_id"
+    t.index ["user_id"], name: "index_credit_deposits_on_user_id"
+  end
+
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
@@ -373,6 +383,8 @@ ActiveRecord::Schema.define(version: 2018_06_11_103418) do
   add_foreign_key "component_groups", "component_makes"
   add_foreign_key "component_makes", "component_types"
   add_foreign_key "components", "component_groups"
+  add_foreign_key "credit_deposits", "clusters"
+  add_foreign_key "credit_deposits", "users"
   add_foreign_key "expansions", "component_makes"
   add_foreign_key "expansions", "components"
   add_foreign_key "expansions", "expansion_types"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_11_103418) do
+ActiveRecord::Schema.define(version: 2018_06_12_161101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,7 +113,6 @@ ActiveRecord::Schema.define(version: 2018_06_11_103418) do
     t.string "display_id", null: false
     t.integer "time_worked", default: 0, null: false
     t.boolean "comments_enabled", default: false
-    t.integer "legacy_credit_charge"
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -112,8 +112,8 @@ ActiveRecord::Schema.define(version: 2018_06_11_103418) do
     t.bigint "assignee_id"
     t.string "display_id", null: false
     t.integer "time_worked", default: 0, null: false
-    t.integer "credit_charge"
     t.boolean "comments_enabled", default: false
+    t.integer "legacy_credit_charge"
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"
@@ -207,6 +207,16 @@ ActiveRecord::Schema.define(version: 2018_06_11_103418) do
     t.string "support_type", default: "inherit", null: false
     t.boolean "internal", default: false
     t.index ["component_group_id"], name: "index_components_on_component_group_id"
+  end
+
+  create_table "credit_charges", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "case_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "amount", null: false
+    t.index ["case_id"], name: "index_credit_charges_on_case_id"
+    t.index ["user_id"], name: "index_credit_charges_on_user_id"
   end
 
   create_table "credit_deposits", force: :cascade do |t|
@@ -383,6 +393,8 @@ ActiveRecord::Schema.define(version: 2018_06_11_103418) do
   add_foreign_key "component_groups", "component_makes"
   add_foreign_key "component_makes", "component_types"
   add_foreign_key "components", "component_groups"
+  add_foreign_key "credit_charges", "cases"
+  add_foreign_key "credit_charges", "users"
   add_foreign_key "credit_deposits", "clusters"
   add_foreign_key "credit_deposits", "users"
   add_foreign_key "expansions", "component_makes"

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe CasesController, type: :controller do
     end
 
     it 'closes a resolved case' do
-      post :close, params: { id: resolved_case.id, case: { credit_charge: 0 } }
+      post :close, params: { id: resolved_case.id, credit_charge: { amount: 0 } }
       expect(flash[:success]).to eq "Support case #{resolved_case.display_id} closed."
     end
 
@@ -197,7 +197,7 @@ RSpec.describe CasesController, type: :controller do
     end
 
     it 'does not close an open case' do
-      post :close, params: { id: open_case.id, case: { credit_charge: 0 } }
+      post :close, params: { id: open_case.id, credit_charge: { amount: 0 } }
       expect(flash[:error]).to eq 'Error updating support case: state cannot transition via "close"'
     end
   end

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ClustersController, type: :controller do
+
+  let(:site) { create(:site) }
+  let(:user) { create(:contact, site: site) }
+  let(:admin) { create(:admin) }
+  let!(:cluster) { create(:cluster, site: site, name: 'Some Cluster') }
+
+  describe 'POST #deposit' do
+
+    let(:params) {
+      { cluster_id: cluster.id, credit_deposit: { amount: 4 } }
+    }
+
+    context 'as an admin' do
+
+      before(:each) do
+        sign_in_as(admin)
+      end
+
+      it 'should allow credit deposits' do
+
+        expect(cluster.credit_balance).to eq 0
+
+        post :deposit, params: params
+
+        expect(response).to have_http_status(:found)
+        expect(response.headers['Location']).to match(/\/clusters\/#{cluster.id}\/credit_usage$/)
+        expect(flash[:success]).to eq '4 credits added to cluster Some Cluster.'
+
+        cluster.reload
+        expect(cluster.credit_balance).to eq 4
+
+        post :deposit, params: params
+        cluster.reload
+        expect(cluster.credit_balance).to eq 8
+
+        # This demonstrates that we do intentionally permit negative "deposits"
+        post :deposit, params: { cluster_id: cluster.id, credit_deposit: { amount: -6 } }
+        cluster.reload
+        expect(cluster.credit_balance).to eq 2
+      end
+
+    end
+  end
+end

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ClustersController, type: :controller do
         post :deposit, params: params
 
         expect(response).to have_http_status(:found)
-        expect(response.headers['Location']).to match(/\/clusters\/#{cluster.id}\/credit_usage$/)
+        expect(response.headers['Location']).to match(/\/clusters\/#{cluster.id}\/credit-usage$/)
         expect(flash[:success]).to eq '4 credits added to cluster Some Cluster.'
 
         cluster.reload

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -100,7 +100,6 @@ FactoryBot.define do
 
   factory :credit_charge do
     amount 1
-    association :case
     association :user, factory: :admin
-    end
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,6 @@
 
 FactoryBot.define do
+
   factory :case_state_transition do
     association :case
     event 'resolve'
@@ -96,4 +97,10 @@ FactoryBot.define do
     change_motd_request
     to :applied
   end
+
+  factory :credit_charge do
+    amount 1
+    association :case
+    association :user, factory: :admin
+    end
 end

--- a/spec/factories/case.rb
+++ b/spec/factories/case.rb
@@ -17,7 +17,12 @@ FactoryBot.define do
 
     factory :closed_case do
       state 'closed'
-      credit_charge 0
+
+      before(:create) do |k|
+        if k.credit_charge.nil?
+          k.credit_charge = build(:credit_charge, case: k)
+        end
+      end
     end
 
     factory :case_with_change_motd_request do

--- a/spec/factories/cluster.rb
+++ b/spec/factories/cluster.rb
@@ -20,4 +20,10 @@ FactoryBot.define do
       support_type :advice
     end
   end
+
+  factory :credit_deposit do
+    association :cluster
+    association :user, factory: :admin
+    amount 10
+  end
 end

--- a/spec/features/case/index_spec.rb
+++ b/spec/features/case/index_spec.rb
@@ -15,7 +15,12 @@ RSpec.describe 'Cases table', type: :feature do
   end
 
   let! :closed_case do
-    create(:closed_case, cluster: cluster, subject: 'Closed case', completed_at: 2.days.ago, credit_charge: 1138)
+    create(:closed_case,
+           cluster: cluster,
+           subject: 'Closed case',
+           completed_at: 2.days.ago,
+           credit_charge: build(:credit_charge, amount: 1138)
+    )
   end
 
   RSpec.shared_examples 'open cases table rendered' do

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -216,6 +216,16 @@ RSpec.describe 'Case page', type: :feature do
       visit case_path(closed_case, as: admin)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
     end
+
+    it 'requires a charge to be specified to close a case' do
+      visit case_path(resolved_case, as: admin)
+      fill_in 'credit_charge_amount', with: ''
+      click_button 'Set charge and close case'
+
+      resolved_case.reload
+      expect(resolved_case.state).to eq 'resolved'
+      expect(find('.alert')).to have_text 'Error updating support case: credit_charge is invalid'
+    end
   end
 
   describe 'case assignment' do

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -143,6 +143,11 @@ RSpec.describe 'Case page', type: :feature do
       expect(log_html.strip).to eq('<p><em>Loggy</em> <strong>McLogface</strong></p>')
       expect(case_comment_html.strip).to eq('<p><strong>Commenty</strong> <em>McCommentface</em></p>')
     end
+
+    it 'shows a card for creation of CreditCharge' do
+      visit case_path(closed_case, as: admin)
+      expect(find('.event-card').find('.card-body')).to have_text 'A charge of 1 credit was added for this case.'
+    end
   end
 
   describe 'comments form' do

--- a/spec/features/cluster/credit_usage_spec.rb
+++ b/spec/features/cluster/credit_usage_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe 'Cluster credit usage', type: :feature do
 
     expect(events.length).to eq 4
 
-    expect(events[3].text).to match /#{c1.display_id}.*-1 credits$/
-    expect(events[2].text).to match /#{c2.display_id}.*-2 credits$/
-    expect(events[1].text).to match /#{c3.display_id}.*-4 credits$/
-    expect(events[0].text).to match /Credits added.* 10 credits$/
+    expect(events[3].text).to match(/#{c1.display_id}.*-1 credits$/)
+    expect(events[2].text).to match(/#{c2.display_id}.*-2 credits$/)
+    expect(events[1].text).to match(/#{c3.display_id}.*-4 credits$/)
+    expect(events[0].text).to match(/Credits added.* 10 credits$/)
 
     expect(find('.credit-balance').text).to eq '3 credits'
   end

--- a/spec/features/cluster/credit_usage_spec.rb
+++ b/spec/features/cluster/credit_usage_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Cluster credit usage', type: :feature do
 
   it 'shows credit events for the current period' do
     c1 = create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 1))
-    c2 = create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 2))
+    c2 = create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 0))
     c3 = create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 4))
 
     cluster.credit_deposits.create(amount: 10, user: admin)
@@ -20,11 +20,11 @@ RSpec.describe 'Cluster credit usage', type: :feature do
     expect(events.length).to eq 4
 
     expect(events[3].text).to match(/#{c1.display_id}.*-1 credits$/)
-    expect(events[2].text).to match(/#{c2.display_id}.*-2 credits$/)
+    expect(events[2].text).to match(/#{c2.display_id}.*0 credits$/)
     expect(events[1].text).to match(/#{c3.display_id}.*-4 credits$/)
     expect(events[0].text).to match(/Credits added.* 10 credits$/)
 
-    expect(find('.credit-balance').text).to eq '3 credits'
+    expect(find('.credit-balance').text).to eq '5 credits'
   end
 
   it 'shows a friendly message with no credit events' do

--- a/spec/features/cluster/credit_usage_spec.rb
+++ b/spec/features/cluster/credit_usage_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Cluster credit usage', type: :feature do
+  let(:site) { create(:site) }
+  let(:admin) { create(:admin) }
+  let(:user) { create(:contact, site: site) }
+  let(:cluster) { create(:cluster, support_type: 'managed', site: site) }
+
+  it 'shows credit events for the current period' do
+    c1 = create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 1))
+    c2 = create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 2))
+    c3 = create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 4))
+
+    cluster.credit_deposits.create(amount: 10, user: admin)
+
+    visit cluster_credit_usage_path(cluster, as: user)
+
+    events = find_all('li.credit-charge-entry')
+
+    expect(events.length).to eq 4
+
+    expect(events[3].text).to match /#{c1.display_id}.*-1 credits$/
+    expect(events[2].text).to match /#{c2.display_id}.*-2 credits$/
+    expect(events[1].text).to match /#{c3.display_id}.*-4 credits$/
+    expect(events[0].text).to match /Credits added.* 10 credits$/
+
+    expect(find('.credit-balance').text).to eq '3 credits'
+  end
+
+  it 'shows a friendly message with no credit events' do
+    visit cluster_credit_usage_path(cluster, as: user)
+
+    expect(find('.no-events-message').text).to eq 'No credit usage or accrual in this period.'
+  end
+end

--- a/spec/features/cluster/credit_usage_spec.rb
+++ b/spec/features/cluster/credit_usage_spec.rb
@@ -32,4 +32,58 @@ RSpec.describe 'Cluster credit usage', type: :feature do
 
     expect(find('.no-events-message').text).to eq 'No credit usage or accrual in this period.'
   end
+
+  describe 'navigation through time' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    before(:each) do
+      travel_to Time.zone.local(2017, 9, 30) do
+        # Create cluster (implicitly) and charge event in Q3 2017
+        create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 1))
+      end
+
+      travel_to Time.zone.local(2017, 10, 1) do
+        # Create a deposit and charge in Q4 2017
+        create(:closed_case, cluster: cluster, credit_charge: build(:credit_charge, amount: 2))
+        cluster.credit_deposits.create(amount: 4, user: admin)
+      end
+    end
+
+    it 'lists all quarters from cluster creation to present' do
+      travel_to Time.zone.local(2018, 6, 1) do
+        visit cluster_credit_usage_path(cluster, as: user)
+
+        expect(find('.credit-balance').text).to eq '1 credit'
+        expect(find('.no-events-message').text).to eq 'No credit usage or accrual in this period.'
+
+        form = find('#credit-quarter-selection')
+
+        available_quarters = form.find_all('option').map(&:value)
+        expect(available_quarters).to eq(%w(2018-04-01 2018-01-01 2017-10-01 2017-07-01))
+      end
+    end
+
+    it 'lists events in selected quarters' do
+      visit cluster_credit_usage_path(cluster, start_date: '2017-07-01', as: user)
+
+      events = find_all('li.credit-charge-entry')
+
+      expect(events.length).to eq 1
+      expect(events[0].text).to match(/-1 credits$/)
+
+      visit cluster_credit_usage_path(cluster, start_date: '2017-10-01', as: user)
+
+      events = find_all('li.credit-charge-entry')
+
+      expect(events.length).to eq 2
+      expect(events[1].text).to match(/-2 credits$/)
+      expect(events[0].text).to match(/Credits added.* 4 credits$/)
+
+      visit cluster_credit_usage_path(cluster, start_date: '2018-01-01', as: user)
+
+      events = find_all('li.credit-charge-entry')
+
+      expect(events.length).to eq 0
+    end
+  end
 end

--- a/spec/features/cluster/credit_usage_spec.rb
+++ b/spec/features/cluster/credit_usage_spec.rb
@@ -86,4 +86,26 @@ RSpec.describe 'Cluster credit usage', type: :feature do
       expect(events.length).to eq 0
     end
   end
+
+  describe 'credit deposits' do
+    context 'as an admin' do
+      it 'shows credit deposit form' do
+        visit cluster_credit_usage_path(cluster, as: admin)
+
+        expect do
+          find('#credit-deposit-form')
+        end.not_to raise_error
+      end
+    end
+
+    context 'as a non-admin' do
+      it 'does not show credit deposit form' do
+        visit cluster_credit_usage_path(cluster, as: user)
+
+        expect do
+          find('#credit-deposit-form')
+        end.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+  end
 end

--- a/spec/features/cluster/credit_usage_spec.rb
+++ b/spec/features/cluster/credit_usage_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Cluster credit usage', type: :feature do
     expect(events[1].text).to match(/#{c3.display_id}.*-4 credits$/)
     expect(events[0].text).to match(/Credits added.* 10 credits$/)
 
-    expect(find('.credit-balance').text).to eq '5 credits'
+    expect(find('p.credit-balance').text).to eq '5 credits'
   end
 
   it 'shows a friendly message with no credit events' do
@@ -53,7 +53,7 @@ RSpec.describe 'Cluster credit usage', type: :feature do
       travel_to Time.zone.local(2018, 6, 1) do
         visit cluster_credit_usage_path(cluster, as: user)
 
-        expect(find('.credit-balance').text).to eq '1 credit'
+        expect(find('p.credit-balance').text).to eq '1 credit'
         expect(find('.no-events-message').text).to eq 'No credit usage or accrual in this period.'
 
         form = find('#credit-quarter-selection')

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -239,4 +239,28 @@ RSpec.describe Cluster, type: :model do
       expect(results).to eq [1, 2, 3]
     end
   end
+
+  describe 'support credits' do
+    subject { create(:cluster) }
+
+    let(:admin) { create(:admin) }
+
+    it 'calculates balance by summing deposits with charges on cases' do
+      create(:credit_deposit, cluster: subject, amount: 36)
+      create(:credit_deposit, cluster: subject, amount: 6)
+
+      expect(subject.credit_balance).to eq 42
+
+      create(:closed_case, cluster: subject, credit_charge: 12)
+      create(:closed_case, cluster: subject, credit_charge: 6)
+      create(:closed_case, cluster: subject, credit_charge: 3)
+
+      expect(subject.credit_balance).to eq 21
+    end
+
+    it 'allows a negative balance' do
+      create(:closed_case, cluster: subject, credit_charge: 12)
+      expect(subject.credit_balance).to eq -12
+    end
+  end
 end

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -245,6 +245,10 @@ RSpec.describe Cluster, type: :model do
 
     let(:admin) { create(:admin) }
 
+    it 'is zero with no deposits or chargeable cases' do
+      expect(subject.credit_balance).to eq 0
+    end
+
     it 'calculates balance by summing deposits with charges on cases' do
       create(:credit_deposit, cluster: subject, amount: 36)
       create(:credit_deposit, cluster: subject, amount: 6)

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -255,15 +255,15 @@ RSpec.describe Cluster, type: :model do
 
       expect(subject.credit_balance).to eq 42
 
-      create(:closed_case, cluster: subject, credit_charge: 12)
-      create(:closed_case, cluster: subject, credit_charge: 6)
-      create(:closed_case, cluster: subject, credit_charge: 3)
+      create(:closed_case, cluster: subject, credit_charge: build(:credit_charge, amount: 12))
+      create(:closed_case, cluster: subject, credit_charge: build(:credit_charge, amount: 6))
+      create(:closed_case, cluster: subject, credit_charge: build(:credit_charge, amount: 3))
 
       expect(subject.credit_balance).to eq 21
     end
 
     it 'allows a negative balance' do
-      create(:closed_case, cluster: subject, credit_charge: 12)
+      create(:closed_case, cluster: subject, credit_charge: build(:credit_charge, amount: 12))
       expect(subject.credit_balance).to eq -12
     end
   end

--- a/spec/requests/cluster_credit_deposits_spec.rb
+++ b/spec/requests/cluster_credit_deposits_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Cluster credit deposits' do
+  let(:site) { create(:site) }
+  let(:cluster) { create(:cluster) }
+  let(:user) { create(:user, site: site) }
+  let(:admin) { create(:admin) }
+
+  let(:params) {
+    { cluster_id: cluster.id, credit_deposit: { amount: 4 } }
+  }
+
+  context 'as a non-admin' do
+    it 'returns 404 when attempting to deposit' do
+      expect do
+        post cluster_deposit_path(cluster, as: user), params: params
+      end.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  context 'as an admin' do
+    it 'allows a deposit' do
+      expect do
+        post cluster_deposit_path(cluster, as: admin), params: params
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This PR (re-)introduces the concept of a per-cluster support credit balance, and adds features to support its use and management.

Admins may now add `CreditDeposit`s to a `Cluster` to increase its credit balance. This balance is reduced by charges on closed `Case`s, but can be zero or negative without error or restriction.

The current balance for a `Cluster` is shown on the newly-remodelled cluster dashboard, and a new page is introduced to allow users (both admins and not) to inspect detail of credit usage per quarter. Each closed case (regardless of charge amount, even if zero) and credit deposit is listed in this fashion, and totals for credits accrued, credits used, and cases closed with zero charge are displayed.

Closes #296.

Trello: https://trello.com/c/8HVAKl8W/332-credit-usage-summary