### PR TITLE
Cluster notes

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -37,13 +37,8 @@ class NotesController < ApplicationController
   private
 
   def note_from_params
-    cluster = cluster_from_params
     flavour = params.require(:flavour)
-    cluster.notes.send(flavour).first || cluster.notes.new(flavour: flavour)
-  end
-
-  def cluster_from_params
-    Cluster.find(params.require(:cluster_id))
+    @cluster.notes.send(flavour).first || @cluster.notes.new(flavour: flavour)
   end
 
   def note_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,11 +3,7 @@ class NotesController < ApplicationController
 
   def show
     @note = note_from_params
-    if @note.persisted?
-      render :show
-    else
-      render :new
-    end
+    render :new unless @note.persisted?
   end
 
   def edit

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,19 +3,61 @@ class NotesController < ApplicationController
 
   def engineering
     @note = note_from_params(:engineering)
-    render :show
+    if @note.persisted?
+      render :show
+    else
+      render :new
+    end
   end
 
   def customer
     @note = note_from_params(:customer)
-    render :show
+    if @note.persisted?
+      render :show
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @note = Note.find(params[:id])
+  end
+
+  def create
+    cluster = cluster_from_params
+    @note = cluster.notes.build(note_params)
+    if @note.save
+      flash[:success] = 'Notes created'
+    else
+      error_flash_models [@note], "Your notes were not created. #{@note.errors.full_messages.join('; ').strip}"
+    end
+    redirect_back fallback_location: cluster
+  end
+
+  def update
+    @note = Note.find(params[:id])
+    if @note.update_attributes(note_params)
+      flash[:success] = 'Notes updated'
+      redirect_to send("#{@note.flavour}_cluster_notes_path", @note.cluster)
+    else
+      error_flash_models [@note], "Your notes were not updated. #{@note.errors.full_messages.join('; ').strip}"
+      render :edit
+    end
   end
 
   private
 
   def note_from_params(flavour)
-    cluster = Cluster.find(params.require(:cluster_id))
+    cluster = cluster_from_params
     note = cluster.notes.send(flavour).first || cluster.notes.new(flavour: flavour)
     @note = note.decorate
+  end
+
+  def cluster_from_params
+    Cluster.find(params.require(:cluster_id))
+  end
+
+  def note_params
+    params.require(:note).permit(:description, :flavour)
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -28,7 +28,7 @@ class NotesController < ApplicationController
     @note = note_from_params
     if @note.update_attributes(note_params)
       flash[:success] = 'Notes updated'
-      redirect_to cluster_note_path(@note.cluster, flavour: @note.flavour)
+      redirect_to @note.path
     else
       flash[:error] = "Your notes were not updated: #{format_errors(@note)}"
       render :edit

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -25,7 +25,11 @@ class NotesController < ApplicationController
   def update
     @note = note_from_params
     authorize @note
-    if @note.update_attributes(note_params)
+    if note_params[:description].blank?
+      @note.destroy
+      flash[:success] = 'Notes removed'
+      redirect_to cluster_path(@note.cluster)
+    elsif @note.update_attributes(note_params)
       flash[:success] = 'Notes updated'
       redirect_to @note.decorate.path
     else

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -12,10 +12,12 @@ class NotesController < ApplicationController
 
   def edit
     @note = note_from_params
+    authorize @note
   end
 
   def create
     @note = note_from_params
+    authorize @note
     if @note.update_attributes(note_params)
       flash[:success] = 'Notes created'
     else
@@ -26,9 +28,10 @@ class NotesController < ApplicationController
 
   def update
     @note = note_from_params
+    authorize @note
     if @note.update_attributes(note_params)
       flash[:success] = 'Notes updated'
-      redirect_to @note.path
+      redirect_to @note.decorate.path
     else
       flash[:error] = "Your notes were not updated: #{format_errors(@note)}"
       render :edit
@@ -40,8 +43,7 @@ class NotesController < ApplicationController
   def note_from_params
     cluster = cluster_from_params
     flavour = params.require(:flavour)
-    note = cluster.notes.send(flavour).first || cluster.notes.new(flavour: flavour)
-    note.decorate
+    cluster.notes.send(flavour).first || cluster.notes.new(flavour: flavour)
   end
 
   def cluster_from_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,21 @@
+class NotesController < ApplicationController
+  decorates_assigned :note
+
+  def engineering
+    @note = note_from_params(:engineering)
+    render :show
+  end
+
+  def customer
+    @note = note_from_params(:customer)
+    render :show
+  end
+
+  private
+
+  def note_from_params(flavour)
+    cluster = Cluster.find(params.require(:cluster_id))
+    note = cluster.notes.send(flavour).first || cluster.notes.new(flavour: flavour)
+    @note = note.decorate
+  end
+end

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -59,18 +59,18 @@ class ClusterDecorator < ApplicationDecorator
         dropdown: [
           {
             text: 'Engineering',
-            path: h.engineering_cluster_notes_path(self),
+            path: h.cluster_note_path(self, flavour: :engineering),
           },
           {
             text: 'Customer',
-            path: h.customer_cluster_notes_path(self),
+            path: h.cluster_note_path(self, flavour: :customer),
           },
         ]
       }
     else
       {
         id: :notes,
-        path: h.customer_cluster_notes_path(self),
+        path: h.cluster_note_path(self, flavour: :customer),
       }
     end
   end

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -15,7 +15,7 @@ class ClusterDecorator < ApplicationDecorator
   def tabs
     [
       tabs_builder.overview,
-      documents.empty? ? nil :{ id: :documents, path: h.cluster_documents_path(self) },
+      documents.empty? ? nil : { id: :documents, path: h.cluster_documents_path(self) },
       tabs_builder.logs,
       tabs_builder.cases,
       tabs_builder.maintenance,
@@ -28,7 +28,8 @@ class ClusterDecorator < ApplicationDecorator
             path: h.cluster_components_path(self, type: t)
           }
         end.push(text: 'All', path: h.cluster_components_path(self))
-      }
+      },
+      notes_tab,
     ].compact
   end
 
@@ -47,5 +48,30 @@ class ClusterDecorator < ApplicationDecorator
       motd: motd,
       motdHtml: h.simple_format(motd),
     }
+  end
+
+  private
+
+  def notes_tab
+    if current_user.admin?
+      {
+        id: :notes,
+        dropdown: [
+          {
+            text: 'Engineering',
+            path: h.engineering_cluster_notes_path(self),
+          },
+          {
+            text: 'Customer',
+            path: h.customer_cluster_notes_path(self),
+          },
+        ]
+      }
+    else
+      {
+        id: :notes,
+        path: h.customer_cluster_notes_path(self),
+      }
+    end
   end
 end

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -2,20 +2,27 @@ class NoteDecorator < ApplicationDecorator
   delegate_all
 
   def subtitle
-    if !persisted?
-      not_found_message
-    elsif current_user.admin?
+    if current_user.admin?
       "#{flavour.capitalize} notes"
     else
-      "Notes"
+      "Cluster notes"
     end
   end
 
-  def not_found_message
+  def new_form_intro
     if current_user.admin?
-      "No #{flavour} notes have been added yet."
+      "No #{flavour} notes have been added for this cluster yet. You may add
+      them below."
     else
-      "No notes have been added yet."
+      "No cluster notes have been added yet. You may add them below."
+    end
+  end
+
+  def edit_form_intro
+    if current_user.admin?
+      "Edit the #{flavour} notes for this cluster below."
+    else
+      'Edit your cluster notes below.'
     end
   end
 

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -18,4 +18,8 @@ class NoteDecorator < ApplicationDecorator
       "No notes have been added yet."
     end
   end
+
+  def edit_path
+    h.edit_cluster_note_path(cluster, object)
+  end
 end

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -1,0 +1,21 @@
+class NoteDecorator < ApplicationDecorator
+  delegate_all
+
+  def subtitle
+    if !persisted?
+      not_found_message
+    elsif current_user.admin?
+      "#{flavour.capitalize} notes"
+    else
+      "Notes"
+    end
+  end
+
+  def not_found_message
+    if current_user.admin?
+      "No #{flavour} notes have been addded yet."
+    else
+      "No notes have been addded yet."
+    end
+  end
+end

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -20,6 +20,6 @@ class NoteDecorator < ApplicationDecorator
   end
 
   def edit_path
-    h.edit_cluster_note_path(cluster, object)
+    h.edit_cluster_note_path(cluster, object, flavour: flavour)
   end
 end

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -20,6 +20,10 @@ class NoteDecorator < ApplicationDecorator
   end
 
   def edit_path
-    h.edit_cluster_note_path(cluster, object, flavour: flavour)
+    h.edit_cluster_note_path(cluster, object)
+  end
+
+  def form_path
+    [note.cluster, note]
   end
 end

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -13,9 +13,9 @@ class NoteDecorator < ApplicationDecorator
 
   def not_found_message
     if current_user.admin?
-      "No #{flavour} notes have been addded yet."
+      "No #{flavour} notes have been added yet."
     else
-      "No notes have been addded yet."
+      "No notes have been added yet."
     end
   end
 end

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -26,8 +26,12 @@ class NoteDecorator < ApplicationDecorator
     end
   end
 
+  def path
+    h.cluster_note_path(cluster, self)
+  end
+
   def edit_path
-    h.edit_cluster_note_path(cluster, object)
+    h.edit_cluster_note_path(cluster, self)
   end
 
   def form_path

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -11,10 +11,10 @@ class NoteDecorator < ApplicationDecorator
 
   def new_form_intro
     if current_user.admin?
-      "No #{flavour} notes have been added for this cluster yet. You may add
+      "There are currently no #{flavour} notes for this cluster. You may add
       them below."
     else
-      "No cluster notes have been added yet. You may add them below."
+      "There are currently no notes for this cluster. You may add them below."
     end
   end
 

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -23,6 +23,7 @@ class Cluster < ApplicationRecord
   has_many :cases
   has_many :maintenance_windows
   has_many :logs, dependent: :destroy
+  has_many :notes, dependent: :destroy
 
   validates_associated :site
   validates :name, presence: true

--- a/app/models/concerns/admin_config/note.rb
+++ b/app/models/concerns/admin_config/note.rb
@@ -1,0 +1,20 @@
+module AdminConfig::Note
+  extend ActiveSupport::Concern
+
+  included do
+    rails_admin do
+      edit do
+        configure :description do
+          html_attributes rows: 10, cols: 100
+          help Constants::MARKDOWN_DESCRIPTION_EDIT_HELP
+        end
+
+        configure :flavour do
+          help <<~EOF
+            Valid flavours are #{Note::FLAVOURS.join(', ')}.
+          EOF
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/admin_config/note.rb
+++ b/app/models/concerns/admin_config/note.rb
@@ -8,12 +8,6 @@ module AdminConfig::Note
           html_attributes rows: 10, cols: 100
           help Constants::MARKDOWN_DESCRIPTION_EDIT_HELP
         end
-
-        configure :flavour do
-          help <<~EOF
-            Valid flavours are #{Note::FLAVOURS.join(', ')}.
-          EOF
-        end
       end
     end
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -18,4 +18,8 @@ class Note < ApplicationRecord
   def flavour_enum
     FLAVOURS
   end
+
+  def to_param
+    flavour
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,6 +1,7 @@
 class Note < ApplicationRecord
   include MarkdownDescription
   include BelongsToCluster
+  include AdminConfig::Note
 
   FLAVOURS = ['customer', 'engineering'].freeze
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -14,4 +14,8 @@ class Note < ApplicationRecord
   FLAVOURS.each do |flavour|
     scope flavour, ->{ where(flavour: flavour) }
   end
+
+  def flavour_enum
+    FLAVOURS
+  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,16 @@
+class Note < ApplicationRecord
+  include MarkdownDescription
+  include BelongsToCluster
+
+  FLAVOURS = ['customer', 'engineering'].freeze
+
+  belongs_to :cluster
+  has_one :site, through: :cluster
+
+  validates :description, presence: true
+  validates :flavour, inclusion: { in: FLAVOURS }, presence: true
+
+  FLAVOURS.each do |flavour|
+    scope flavour, ->{ where(flavour: flavour) }
+  end
+end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -1,0 +1,21 @@
+class NotePolicy < ApplicationPolicy
+
+  def permitted?
+    case @record.flavour
+    when 'engineering'
+      admin?
+    else
+      editor?
+    end
+  end
+
+  alias_method :create?, :permitted?
+  alias_method :edit?, :permitted?
+  alias_method :update?, :permitted?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,0 +1,13 @@
+<div class="card-body">
+    <p>
+    <%= intro_text %>
+    </p>
+    <%= form_for note.form_path do |f| %>
+        <div class="form-group">
+            <%= f.text_area :description, class: 'form-control', rows: 10 %>
+        </div>
+        <div class="form-group" style="overflow: hidden;">
+            <%= f.submit button_text, class: dark_button_classes %>
+        </div>
+    <% end %>
+</div>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -6,6 +6,9 @@
         <div class="form-group">
             <%= f.text_area :description, class: 'form-control', rows: 10 %>
         </div>
+        <p class="form-text text-muted">
+            Styling with markdown is supported
+        </p>
         <div class="form-group" style="overflow: hidden;">
             <%= f.submit button_text, class: dark_button_classes %>
         </div>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for(:subtitle) { note.subtitle } %>
+
+<%= render 'partials/tabs', activate: :notes do %>
+    <div class="card-body">
+        <%= form_for [note.cluster, note] do |f| %>
+            <%= f.hidden_field :flavour %>
+            <div class="form-group">
+                <%= f.label :description, 'Edit your notes for this cluster below.' %>
+                <span class="badge badge-light ml-1">Required</span>
+                <%= f.text_area :description, class: 'form-control', rows: 10 %>
+            </div>
+            <div class="form-group" style="overflow: hidden;">
+                <%= f.submit "Update notes", class: dark_button_classes %>
+            </div>
+        <% end %>
+    </div>
+<% end %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,17 +1,5 @@
 <% content_for(:subtitle) { note.subtitle } %>
 
 <%= render 'partials/tabs', activate: :notes do %>
-    <div class="card-body">
-        <p>
-        <%= note.edit_form_intro %>
-        </p>
-        <%= form_for note.form_path do |f| %>
-            <div class="form-group">
-                <%= f.text_area :description, class: 'form-control', rows: 10 %>
-            </div>
-            <div class="form-group" style="overflow: hidden;">
-                <%= f.submit "Update notes", class: dark_button_classes %>
-            </div>
-        <% end %>
-    </div>
+    <%= render 'form', intro_text: note.edit_form_intro, button_text: 'Update notes' %>
 <% end %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -2,8 +2,7 @@
 
 <%= render 'partials/tabs', activate: :notes do %>
     <div class="card-body">
-        <%= form_for [note.cluster, note] do |f| %>
-            <%= f.hidden_field :flavour %>
+        <%= form_for note, url: { action: 'update' } do |f| %>
             <div class="form-group">
                 <%= f.label :description, 'Edit your notes for this cluster below.' %>
                 <span class="badge badge-light ml-1">Required</span>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'partials/tabs', activate: :notes do %>
     <div class="card-body">
-        <%= form_for note, url: { action: 'update' } do |f| %>
+        <%= form_for note.form_path do |f| %>
             <div class="form-group">
                 <%= f.label :description, 'Edit your notes for this cluster below.' %>
                 <span class="badge badge-light ml-1">Required</span>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -2,10 +2,11 @@
 
 <%= render 'partials/tabs', activate: :notes do %>
     <div class="card-body">
+        <p>
+        <%= note.edit_form_intro %>
+        </p>
         <%= form_for note.form_path do |f| %>
             <div class="form-group">
-                <%= f.label :description, 'Edit your notes for this cluster below.' %>
-                <span class="badge badge-light ml-1">Required</span>
                 <%= f.text_area :description, class: 'form-control', rows: 10 %>
             </div>
             <div class="form-group" style="overflow: hidden;">

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:subtitle) { note.subtitle } %>
+
+<%= render 'partials/tabs', activate: :notes do %>
+    <div class="card-body">
+        <p>
+        <%= note.not_found_message %>
+        </p>
+        <%= form_for [note.cluster, note] do |f| %>
+            <%= f.hidden_field :flavour %>
+            <div class="form-group">
+                <%= f.label :description, 'You may create notes for this cluster below.' %>
+                <span class="badge badge-light ml-1">Required</span>
+                <%= f.text_area :description, class: 'form-control', rows: 10 %>
+            </div>
+            <div class="form-group" style="overflow: hidden;">
+                <%= f.submit "Create notes", class: dark_button_classes %>
+            </div>
+        <% end %>
+    </div>
+<% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,17 +1,5 @@
 <% content_for(:subtitle) { note.subtitle } %>
 
 <%= render 'partials/tabs', activate: :notes do %>
-    <div class="card-body">
-        <p>
-        <%= note.new_form_intro %>
-        </p>
-        <%= form_for note.form_path do |f| %>
-            <div class="form-group">
-                <%= f.text_area :description, class: 'form-control', rows: 10 %>
-            </div>
-            <div class="form-group" style="overflow: hidden;">
-                <%= f.submit "Create notes", class: dark_button_classes %>
-            </div>
-        <% end %>
-    </div>
+    <%= render 'form', intro_text: note.new_form_intro, button_text: 'Create notes' %>
 <% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -3,12 +3,10 @@
 <%= render 'partials/tabs', activate: :notes do %>
     <div class="card-body">
         <p>
-        <%= note.not_found_message %>
+        <%= note.new_form_intro %>
         </p>
         <%= form_for note.form_path do |f| %>
             <div class="form-group">
-                <%= f.label :description, 'You may create notes for this cluster below.' %>
-                <span class="badge badge-light ml-1">Required</span>
                 <%= f.text_area :description, class: 'form-control', rows: 10 %>
             </div>
             <div class="form-group" style="overflow: hidden;">

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -5,7 +5,7 @@
         <p>
         <%= note.not_found_message %>
         </p>
-        <%= form_for [note.cluster, note], url: { action: 'create' } do |f| %>
+        <%= form_for note.form_path do |f| %>
             <div class="form-group">
                 <%= f.label :description, 'You may create notes for this cluster below.' %>
                 <span class="badge badge-light ml-1">Required</span>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -5,8 +5,7 @@
         <p>
         <%= note.not_found_message %>
         </p>
-        <%= form_for [note.cluster, note] do |f| %>
-            <%= f.hidden_field :flavour %>
+        <%= form_for [note.cluster, note], url: { action: 'create' } do |f| %>
             <div class="form-group">
                 <%= f.label :description, 'You may create notes for this cluster below.' %>
                 <span class="badge badge-light ml-1">Required</span>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:subtitle) { note.subtitle } %>
+
+<%= render 'partials/tabs', activate: :notes do %>
+    <div class="card-body">
+        <% if note.persisted? %>
+            <%= note.rendered_description.html_safe %>
+        <% else %>
+            <% if current_user.admin? %>
+                No <%= note.flavour %> notes have been addded yet.
+            <% else %>
+                No notes have been addded yet.
+            <% end %>
+        <% end %>
+    </div>
+<% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -5,11 +5,7 @@
         <% if note.persisted? %>
             <%= note.rendered_description.html_safe %>
         <% else %>
-            <% if current_user.admin? %>
-                No <%= note.flavour %> notes have been addded yet.
-            <% else %>
-                No notes have been addded yet.
-            <% end %>
+            <%= note.not_found_message %>
         <% end %>
     </div>
 <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -2,10 +2,11 @@
 
 <%= render 'partials/tabs', activate: :notes do %>
     <div class="card-body">
-        <% if note.persisted? %>
-            <%= note.rendered_description.html_safe %>
-        <% else %>
-            <%= note.not_found_message %>
-        <% end %>
+        <%= note.rendered_description.html_safe %>
     </div>
+    <%= link_to 'Edit notes',
+        note.edit_path,
+        class: 'btn btn-secondary m-2 btn-sm',
+        role: 'button'
+    %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,12 @@ Rails.application.routes.draw do
     resources :clusters, only: []  do
       request_maintenance_form.call
       admin_logs.call
+      resource :notes, only: [] do
+        member do
+          get :engineering
+          get :customer
+        end
+      end
     end
 
     resources :components, only: []  do
@@ -140,6 +146,11 @@ Rails.application.routes.draw do
       logs.call
       confirm_maintenance_form.call
       get :documents
+      resource :notes, only: [] do
+        member do
+          get :customer
+        end
+      end
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,13 +41,9 @@ Rails.application.routes.draw do
   notes = Proc.new do |admin|
     constraints NoteFlavourConstraint.new(admin: admin) do
       prefix = admin ? '' : 'prevent_named_route_clash_'
-      resource :note, only: [] do
-        member do
-          get ':flavour' => 'notes#show', as: prefix
-          get ':flavour/edit' => 'notes#edit', as: "#{prefix}edit"
-          post ':flavour' => 'notes#create'
-          patch ':flavour' => 'notes#update'
-          put ':flavour' => 'notes#update'
+      resources :notes, param: :flavour, except: [:new, :create, :index] do
+        collection do
+          post ':flavour' => 'notes#create', as: prefix
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,6 @@ Rails.application.routes.draw do
       resource :notes, only: [] do
         member do
           get :engineering
-          get :customer
         end
       end
     end
@@ -146,11 +145,12 @@ Rails.application.routes.draw do
       logs.call
       confirm_maintenance_form.call
       get :documents
-      resource :notes, only: [] do
+      resource :notes, only: [:create] do
         member do
           get :customer
         end
       end
+      resources :notes, only: [:edit, :update]
     end
 
     resources :components, only: :show do

--- a/db/migrate/20180605135005_create_notes.rb
+++ b/db/migrate/20180605135005_create_notes.rb
@@ -1,0 +1,13 @@
+class CreateNotes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :notes do |t|
+      t.text :description, null: false
+      t.string :flavour, null: false, limit: 64
+
+      t.references :cluster, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :notes, [:flavour, :cluster_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_25_175459) do
+ActiveRecord::Schema.define(version: 2018_06_05_135005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -286,6 +286,16 @@ ActiveRecord::Schema.define(version: 2018_05_25_175459) do
     t.index ["service_id"], name: "index_maintenance_windows_on_service_id"
   end
 
+  create_table "notes", force: :cascade do |t|
+    t.text "description", null: false
+    t.string "flavour", limit: 64, null: false
+    t.bigint "cluster_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cluster_id"], name: "index_notes_on_cluster_id"
+    t.index ["flavour", "cluster_id"], name: "index_notes_on_flavour_and_cluster_id", unique: true
+  end
+
   create_table "service_types", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
@@ -374,6 +384,7 @@ ActiveRecord::Schema.define(version: 2018_05_25_175459) do
   add_foreign_key "maintenance_windows", "clusters"
   add_foreign_key "maintenance_windows", "components"
   add_foreign_key "maintenance_windows", "services"
+  add_foreign_key "notes", "clusters"
   add_foreign_key "services", "clusters"
   add_foreign_key "services", "service_types"
   add_foreign_key "users", "sites"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -67,12 +67,17 @@ namespace :alces do
         new_account_username = email_local_part.gsub(/[^0-9a-z]/i, '')
 
         <<~RUBY.strip_heredoc
-          Account.create!(
-            username: '#{new_account_username}',
-            email: '#{user.email}',
-            password: 'password',
-            terms: true
-          ).confirm unless Account.find_by_username('#{new_account_username}')
+          if Account.find_by_username('#{new_account_username}') || Account.find_by_email('#{user.email}')
+            puts "Skipping account #{new_account_username}"
+          else
+            puts "Creating account username: #{new_account_username}, email: #{user.email}"
+            Account.create!(
+              username: '#{new_account_username}',
+              email: '#{user.email}',
+              password: 'password',
+              terms: true
+            ).confirm
+          end
         RUBY
       end.join("\n")
     end

--- a/spec/factories/note.rb
+++ b/spec/factories/note.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :note do
+    cluster
+    description "# Description title\n\nDescription body\n"
+    flavour { Note::FLAVOURS[rand(Note::FLAVOURS.length)] }
+
+    factory :customer_note do
+      flavour :customer
+    end
+
+    factory :engineering_note do
+      flavour :engineering
+    end
+  end
+end

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'cluster tabs', type: :feature do
   let(:tabs) { page.find('ul.nav-tabs') }
   let(:maintenance_tab) { tabs.find('li', text: /Maintenance/) }
   let(:documents_tab) { tabs.find('li', text: /Documents/) }
+  let(:notes_tab) { tabs.find('li', text: /Notes/) }
   let(:user) { create(:contact, site: cluster.site) }
 
   context 'when visiting the cluster page' do
@@ -40,6 +41,22 @@ RSpec.describe 'cluster tabs', type: :feature do
           documents_tab
         end.to raise_error(Capybara::ElementNotFound)
       end
+
+      it 'has a dropdown menu for notes tab' do
+        expect(notes_tab).to match_css('.dropdown')
+        expect(notes_tab.first('div')).to match_css('.dropdown-menu')
+      end
+
+      it 'has a link to the engineering notes' do
+        path = cluster_note_path(cluster, flavour: 'engineering')
+        expect(notes_tab).to have_link(href: path)
+      end
+
+      it 'has a link to the customer notes' do
+        path = cluster_note_path(cluster, flavour: 'customer')
+        expect(notes_tab).to have_link(href: path)
+      end
+
     end
 
     context 'with a contact user' do
@@ -62,6 +79,15 @@ RSpec.describe 'cluster tabs', type: :feature do
         expect do
           documents_tab
         end.to raise_error(Capybara::ElementNotFound)
+      end
+
+      it 'does not have dropdown menu for notes tab' do
+        expect(notes_tab).not_to match_css('.dropdown')
+      end
+
+      it 'has a link to the customer notes' do
+        path = cluster_note_path(cluster, flavour: 'customer')
+        expect(notes_tab).to have_link(href: path)
       end
     end
 

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Note, type: :model do
+  describe '#valid?' do
+    shared_examples 'note validations' do
+      it { is_expected.to validate_presence_of(:flavour) }
+      it { is_expected.to validate_inclusion_of(:flavour).in_array(Note::FLAVOURS) }
+      it { is_expected.to validate_presence_of(:description) }
+      it { is_expected.to belong_to(:cluster) }
+      it { is_expected.to have_one(:site) }
+    end
+
+    context 'when customer note' do
+      subject { create(:customer_note) }
+      include_examples 'note validations'
+    end
+
+    context 'when engineering note' do
+      subject { create(:engineering_note) }
+      include_examples 'note validations'
+    end
+  end
+
+  describe 'markdown_description' do
+    # The shared markdown_description examples don't work for notes, so we'll
+    # define our own examples.
+
+    subject do
+      create(
+        :note,
+        description: '- some bullet point'
+      ).rendered_description
+    end
+
+    it { is_expected.to include('<li>some bullet point</li>') }
+
+  end
+
+  describe 'funky routing using `flavour` instead of `id`' do
+    subject { note.to_param }
+
+    context 'when customer note' do
+      let(:note) { create(:customer_note) }
+      it { is_expected.to eq('customer') }
+    end
+
+    context 'when engineering note' do
+      let(:note) { create(:engineering_note) }
+      it { is_expected.to eq('engineering') }
+    end
+  end
+
+  describe 'scope method for each flavour' do
+    let(:cluster) { create(:cluster) }
+
+    let(:notes) do
+      {
+        engineering: create_list(:engineering_note, 2),
+        customer: create_list(:customer_note, 2),
+      }
+    end
+
+    Note::FLAVOURS.each do |flavour|
+      it "Note::#{flavour} should return correct notes" do
+        expect(Note.send(flavour)).to eq(notes[flavour.to_sym])
+      end
+    end
+  end
+end

--- a/spec/policies/note_policy_spec.rb
+++ b/spec/policies/note_policy_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe NotePolicy do
+  include_context 'policy'
+
+  context 'when the note is an engineering note' do
+    let(:record) { build(:engineering_note) }
+
+    permissions :create?, :edit?, :update? do
+      it_behaves_like 'it is available only to admins'
+    end
+  end
+
+  context 'when the note is a customer note' do
+    let(:record) { build(:customer_note) }
+
+    permissions :create?, :edit?, :update? do
+      it_behaves_like 'it is available only to editors'
+    end
+  end
+end

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -82,6 +82,50 @@ RSpec.describe NotesController, type: :request do
     end
   end
 
+  describe 'creating a note' do
+    let(:flavour) { 'engineering' }
+    let(:params) { {note: {description: 'My description'}} }
+    let(:path) { cluster_note_path(cluster_without_notes, flavour: flavour, as: user) }
+    let(:user) { admin }
+
+    it 'creates the note' do
+      expect do
+        post path, params: params
+      end.to change { Note.count }.by(1)
+    end
+
+    it 'creates the note for the given cluster' do
+      expect(Note.count).to eq(0)
+      post path, params: params
+      expect(Note.first.cluster).to eq(cluster_without_notes)
+    end
+
+    it 'creates the note with the given description' do
+      expect(Note.count).to eq(0)
+      post path, params: params
+      expect(Note.first.description).to eq('My description')
+    end
+
+    it 'creates the note with the given flavour' do
+      expect(Note.count).to eq(0)
+      post path, params: params
+      expect(Note.first.flavour).to eq(flavour)
+    end
+  end
+
+  describe 'updating a note' do
+    let(:note) { engineering_note }
+    let(:params) { {note: {description: 'My new description'}} }
+    let(:path) { cluster_note_path(note.cluster, note, as: user) }
+    let(:user) { admin }
+
+    it 'updates the notes description' do
+      expect do
+        patch path, params: params
+      end.to change { Note.find(note.id).description }.to('My new description')
+    end
+  end
+
   describe 'deleting a note' do
     let(:user) { admin }
     it 'when the description is empty it deletes the note' do

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe NotesController, type: :request do
+  let(:contact) { create(:contact, site: site) }
+  let(:admin) { create(:admin) }
+  let(:site) { create(:site) }
+  let!(:cluster) { create(:cluster, site: site) }
+  let!(:cluster_without_notes) { create(:cluster, site: site) }
+  let(:engineering_note) { create(:engineering_note, cluster: cluster) }
+  let(:customer_note) { create(:customer_note, cluster: cluster) }
+
+  describe 'permitted routes' do
+    context 'when no user' do
+      let(:user) { nil }
+
+      it 'does not permit access to engineering notes' do
+        note = engineering_note
+        path = cluster_note_path(note.cluster, note, as: user)
+        expect{get(path)}.to raise_error(ActionController::RoutingError)
+      end
+
+      it 'does not permit access to customer notes' do
+        note = customer_note
+        path = cluster_note_path(note.cluster, note, as: user)
+        expect{get(path)}.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context 'when user is site contact' do
+      let(:user) { contact }
+
+      it 'does not permit access to engineering notes' do
+        note = engineering_note
+        path = cluster_note_path(note.cluster, note, as: user)
+        expect{get(path)}.to raise_error(ActionController::RoutingError)
+      end
+
+      it 'permits access to customer notes' do
+        note = customer_note
+        path = cluster_note_path(note.cluster, note, as: user)
+        get path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when user is admin' do
+      let(:user) { admin }
+
+      it 'permits access to engineering notes' do
+        note = engineering_note
+        path = cluster_note_path(note.cluster, note, as: user)
+        get path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'permits access to customer notes' do
+        note = customer_note
+        path = cluster_note_path(note.cluster, note, as: user)
+        get path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'show' do
+    let(:user) { admin }
+    context 'when note exists' do
+      it 'shows the note' do
+        note = engineering_note
+        path = cluster_note_path(note.cluster, note, as: user)
+        get path
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'when note does not exist' do
+      it 'shows a new note form' do
+        path = cluster_note_path(cluster_without_notes, flavour: 'engineering', as: user)
+        get path
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -81,4 +81,16 @@ RSpec.describe NotesController, type: :request do
       end
     end
   end
+
+  describe 'deleting a note' do
+    let(:user) { admin }
+    it 'when the description is empty it deletes the note' do
+      note = engineering_note
+      cluster = note.cluster
+      path = cluster_note_path(note.cluster, note, as: user)
+      expect do
+        patch path, params: {note: {description: nil}}
+      end.to change { cluster.reload.notes.length }.by(-1)
+    end
+  end
 end


### PR DESCRIPTION
This PR implements #232.  Currently, a cluster can have `engineering` and `customer` notes.  Admin users can view, create and update both kinds of notes, site contacts can view, create and update only `customer` notes.

@bobwhitelock I have a few questions:

 1. Is this along the lines of what you were expecting?
 2. I'm assuming that we want to add the ability for the `customer` notes to be edited created through the non-RailsAdmin UI.  Is that correct?
 3. Do we use the RailsAdmin UI in production for creating/editing/deleting admin content?
 4. Any other comments you have would be appreciated.