### PR TITLE
Misc post-roles/pre-authorization changes

### DIFF
--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -1,25 +1,24 @@
 class CaseCommentsController < ApplicationController
   def create
     my_case = Case.find_from_id!(params.require(:case_id))
-    fallback_location = @scope.dashboard_case_path(my_case)
 
-    new_comment = my_case.case_comments.create(
-        user: current_user,
-        text: params.require(:case_comment)
-                  .permit(:text)
-                  .require(:text)
-    )
+    new_comment = my_case.case_comments.new(comment_params)
 
-    if new_comment.persisted?
+    if new_comment.save
       flash[:notice] = 'New comment added.'
     else
       flash[:error] = "Your comment was not added. #{new_comment.errors.full_messages.join('; ').strip}"
     end
 
+    fallback_location = @scope.dashboard_case_path(my_case)
     redirect_back fallback_location: fallback_location
+  end
 
-  rescue ActionController::ParameterMissing
-    flash[:error] = 'Empty comments are not permitted.'
-    redirect_back fallback_location: fallback_location
+  private
+
+  def comment_params
+    params.require(:case_comment)
+      .permit(:text)
+      .merge(user: current_user)
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -1,13 +1,12 @@
 class CasesController < ApplicationController
   decorates_assigned :site
 
-  def index(show_resolved: false)
-    @show_resolved = show_resolved
+  def index
+    index_action(show_resolved: false)
   end
 
   def resolved
-    index(show_resolved: true)
-    render :index
+    index_action(show_resolved: true)
   end
 
   def show
@@ -122,6 +121,11 @@ class CasesController < ApplicationController
       fields: [:type, :name, :value, :optional, :help],
       tool_fields: {}
     )
+  end
+
+  def index_action(show_resolved:)
+    @show_resolved = show_resolved
+    render :index
   end
 
   def change_action(success_flash, &block)

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -1,8 +1,8 @@
 class ComponentExpansionsController < ApplicationController
   def create
     expansion = @cluster_part.component_expansions
-                             .create create_expansion_param
-    if expansion.valid?
+                             .new create_expansion_params
+    if expansion.save
       msg = "Successfully added the: #{expansion.expansion_type.name}"
       flash[:success] = msg
     else
@@ -14,7 +14,7 @@ class ComponentExpansionsController < ApplicationController
 
   def update
     @cluster_part.component_expansions.each do |expansion|
-      new_params = update_expansion_param expansion
+      new_params = update_expansion_params expansion
       unless expansion.update new_params
         expansion_errors.push expansion
       end
@@ -23,7 +23,7 @@ class ComponentExpansionsController < ApplicationController
   end
 
   def destroy
-    if component_expansion_param.destroy
+    if component_expansion_from_param.destroy
       flash[:success] = 'Successfully deleted expansion'
     else
       flash[:error] = 'Failed to delete expansion'
@@ -53,21 +53,21 @@ class ComponentExpansionsController < ApplicationController
     @errors_in_component_expansion_form_data ||= []
   end
 
-  def create_expansion_param
+  def create_expansion_params
     params.require(:component_expansion).permit([:slot, :ports]).tap do |x|
       type_id = params.require(:expansion_type).require(:id)
       x.merge!(expansion_type: ExpansionType.find_by_id(type_id))
     end
   end
 
-  def update_expansion_param(expansion)
+  def update_expansion_params(expansion)
     id = expansion.id
     params.permit([:"slot#{id}", :"ports#{id}"]).to_h.map do |k, v|
       [k.to_s.chomp(id.to_s).to_sym, v]
     end.to_h
   end
 
-  def component_expansion_param
+  def component_expansion_from_param
     ComponentExpansion.find_by_id params.require(:id)
   end
 end

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -36,18 +36,16 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def commenting_disabled?
-    commenting_disabled_text.present?
+    commenting.disabled?
   end
 
   def commenting_disabled_text
-    if !open?
-      "Commenting is disabled as this case is #{state}."
-    elsif current_user.contact? && !consultancy?
-      <<~TITLE.squish
-        Additional discussion is not available for cases in the current support
-        tier. If you wish to request additional support please either escalate
-        this case (which may incur a charge), or open a new support case.
-      TITLE
-    end
+    commenting.disabled_text
+  end
+
+  private
+
+  def commenting
+    @commenting ||= CaseCommenting.new(self, current_user)
   end
 end

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -44,10 +44,9 @@ class CaseDecorator < ApplicationDecorator
       "Commenting is disabled as this case is #{state}."
     elsif current_user.contact? && !consultancy?
       <<~TITLE.squish
-            Additional discussion is not available for cases in the current
-            support tier. If you wish to request additional support please either
-            escalate this case (which may incur a charge), or open a
-            new support case.
+        Additional discussion is not available for cases in the current support
+        tier. If you wish to request additional support please either escalate
+        this case (which may incur a charge), or open a new support case.
       TITLE
     end
   end

--- a/app/models/case_comment.rb
+++ b/app/models/case_comment.rb
@@ -7,7 +7,9 @@ class CaseComment < ApplicationRecord
   validates :user, presence: true
   validates :case, presence: true
 
-  validates :text, length: { minimum: 2}
+  validates :text,
+    presence: {message: 'Empty comments are not permitted'},
+    length: { minimum: 2}
 
   validate :valid_user, on: :create
 

--- a/app/models/case_commenting.rb
+++ b/app/models/case_commenting.rb
@@ -1,0 +1,37 @@
+
+class CaseCommenting
+  def initialize(kase, user)
+    @kase = kase
+    @user = user
+  end
+
+  def disabled?
+    disabled_text.present?
+  end
+
+  def disabled_text
+    if !kase.open?
+      not_open_message
+    elsif user.contact? && !kase.consultancy?
+      non_consultancy_message
+    else
+      ''
+    end
+  end
+
+  private
+
+  attr_reader :kase, :user
+
+  def not_open_message
+    "Commenting is disabled as this case is #{kase.state}."
+  end
+
+  def non_consultancy_message
+    <<~MESSAGE.squish
+      Additional discussion is not available for cases in the current support
+      tier. If you wish to request additional support please either escalate
+      this case (which may incur a charge), or open a new support case.
+    MESSAGE
+  end
+end

--- a/app/models/concerns/admin_config/user.rb
+++ b/app/models/concerns/admin_config/user.rb
@@ -5,6 +5,9 @@ module AdminConfig::User
   included do
     rails_admin do
       edit do
+        configure :password do
+          hide
+        end
         configure :password_confirmation do
           hide
         end

--- a/spec/models/case_commenting_spec.rb
+++ b/spec/models/case_commenting_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe CaseCommenting do
+  subject { CaseCommenting.new(kase, user) }
+  let(:kase) { create(:case, state: state) }
+  let(:user) { create(:user) }
+
+  RSpec.shared_examples 'commenting enabled' do
+    it 'should have commenting enabled' do
+      expect(subject).not_to be_disabled
+      expect(subject.disabled_text).to eq('')
+    end
+  end
+
+  context 'when Case is not open' do
+    let(:state) { :resolved }
+
+    RSpec.shared_examples 'commenting disabled as not open' do
+      it 'should have commenting disabled' do
+        expect(subject).to be_disabled
+        expect(subject.disabled_text).to eq(
+          "Commenting is disabled as this case is #{state}."
+        )
+      end
+    end
+
+    context 'for admin' do
+      let(:user) { create(:admin) }
+
+      include_examples 'commenting disabled as not open'
+    end
+
+    context 'for contact' do
+      let(:user) { create(:contact) }
+
+      include_examples 'commenting disabled as not open'
+    end
+  end
+
+  context 'when Case is open' do
+    let(:state) { :open }
+
+    context 'when Case is consultancy' do
+      before :each do
+        allow(kase).to receive(:consultancy?).and_return(true)
+      end
+
+      context 'for admin' do
+        let(:user) { create(:admin) }
+
+        include_examples 'commenting enabled'
+      end
+
+      context 'for contact' do
+        let(:user) { create(:contact) }
+
+        include_examples 'commenting enabled'
+      end
+    end
+
+    context 'when Case is not consultancy' do
+      before :each do
+        allow(kase).to receive(:consultancy?).and_return(false)
+      end
+
+      context 'for admin' do
+        let(:user) { create(:admin) }
+
+        include_examples 'commenting enabled'
+      end
+
+      context 'for contact' do
+        let(:user) { create(:contact) }
+
+        it 'should have commenting disabled' do
+          expect(subject).to be_disabled
+          expect(subject.disabled_text).to include(
+            'Additional discussion is not available'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe User, type: :model do
   ])
   end
 
+  describe '#valid?' do
+    context 'as admin' do
+      subject { create(:admin) }
+
+      it { is_expected.to validate_absence_of(:site) }
+    end
+
+    context 'as contact' do
+      subject { create(:contact) }
+
+      it { is_expected.to validate_presence_of(:site) }
+    end
+  end
+
   roles = described_class::ROLES
   roles.each do |role|
     role_query_method = role + '?'


### PR DESCRIPTION
This PR adds various changes made following the switch to distinguishing types of Users by `role`, and prior to adding full authorisation based on `role`s, using [Pundit](https://github.com/varvet/pundit). This largely consists of various refactoring, adding some tests, and an admin interface tweak - see commits for details, and the reasons for making these changes should become clear in the subsequent PRs (submitting these changes on their own here for clarity, to keep them distinct from the actual behaviour changes to come in the next PRs).