### PR TITLE
Minor role tweaks

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -190,7 +190,7 @@ class Case < ApplicationRecord
   end
 
   def potential_assignees
-    User.where(site: site).order(:name) +
+    User.where(site: site).where.not(role: :viewer).order(:name) +
         User.where(role: :admin).order(:name)
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -190,8 +190,9 @@ class Case < ApplicationRecord
   end
 
   def potential_assignees
-    User.where(site: site).where.not(role: :viewer).order(:name) +
-        User.where(role: :admin).order(:name)
+    site.users.where.not(role: :viewer)
+      .or(User.where(role: :admin))
+      .order(:name)
   end
 
   def assignee=(new_assignee)

--- a/app/models/case_commenting.rb
+++ b/app/models/case_commenting.rb
@@ -10,7 +10,9 @@ class CaseCommenting
   end
 
   def disabled_text
-    if !kase.open?
+    if user.viewer?
+      viewer_cannot_comment_message
+    elsif !kase.open?
       not_open_message
     elsif user.contact? && !kase.consultancy?
       non_consultancy_message
@@ -22,6 +24,10 @@ class CaseCommenting
   private
 
   attr_reader :kase, :user
+
+  def viewer_cannot_comment_message
+    'As a viewer you cannot comment on cases.'
+  end
 
   def not_open_message
     "Commenting is disabled as this case is #{kase.state}."

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   validates :role, presence: true, inclusion: ROLES
 
   validates :site, {
-    presence: {if: :contact?},
+    presence: {unless: :admin?},
     absence: {if: :admin?}
   }
   validate :validates_primary_contact_assignment

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,12 @@ class User < ApplicationRecord
     primary_contact? || secondary_contact?
   end
 
+  # Anyone who isn't just a viewer, i.e. who can perform some edits, is
+  # considered an editor.
+  def editor?
+    !viewer?
+  end
+
   def validates_primary_contact_assignment
     return unless site_primary_contact
     if primary_contact? && site_primary_contact != self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,12 @@ class User < ApplicationRecord
     to: :role_inquiry,
     allow_nil: true
 
+  # Automatically picked up by rails_admin so only these options displayed when
+  # selecting role.
+  def role_enum
+    ROLES
+  end
+
   def contact?
     primary_contact? || secondary_contact?
   end

--- a/app/views/partials/_nav_bar.html.erb
+++ b/app/views/partials/_nav_bar.html.erb
@@ -30,7 +30,9 @@
         </ul>
       <% end %>
 
-      <span class="navbar-text text-light"><%= current_user.name %></span>
+      <span class="navbar-text text-light">
+        <%= current_user.name %> (<em><%= current_user.role.titlecase %></em>)
+      </span>
     <% end %>
   </div>
 </nav>

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     password 'definitely_encrypted'
     role :secondary_contact
 
+    factory :viewer do
+      role :viewer
+    end
+
     factory :contact do
       role :primary_contact
 

--- a/spec/models/case_commenting_spec.rb
+++ b/spec/models/case_commenting_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe CaseCommenting do
     end
   end
 
+  RSpec.shared_examples 'commenting disabled for viewer' do
+    context 'for viewer' do
+      let(:user) { create(:viewer) }
+
+      it 'should have commenting disabled' do
+        expect(subject).to be_disabled
+        expect(subject.disabled_text).to eq(
+          'As a viewer you cannot comment on cases.'
+        )
+      end
+    end
+  end
+
   context 'when Case is not open' do
     let(:state) { :resolved }
 
@@ -23,6 +36,8 @@ RSpec.describe CaseCommenting do
         )
       end
     end
+
+    include_examples 'commenting disabled for viewer'
 
     context 'for admin' do
       let(:user) { create(:admin) }
@@ -45,6 +60,8 @@ RSpec.describe CaseCommenting do
         allow(kase).to receive(:consultancy?).and_return(true)
       end
 
+      include_examples 'commenting disabled for viewer'
+
       context 'for admin' do
         let(:user) { create(:admin) }
 
@@ -62,6 +79,8 @@ RSpec.describe CaseCommenting do
       before :each do
         allow(kase).to receive(:consultancy?).and_return(false)
       end
+
+      include_examples 'commenting disabled for viewer'
 
       context 'for admin' do
         let(:user) { create(:admin) }

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -471,5 +471,11 @@ RSpec.describe Case, type: :model do
 
       expect(subject).not_to include('some_contact')
     end
+
+    it 'does not include viewer for site of Case' do
+      create(:viewer, name: 'some_viewer', site: kase.site)
+
+      expect(subject).not_to include('some_viewer')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,6 +82,36 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#editor?' do
+    subject do
+      build(:user, role: role).editor?
+    end
+
+    context "when role is 'primary_contact'" do
+      let (:role) { :primary_contact }
+
+      it { is_expected.to be true }
+    end
+
+    context "when role is 'secondary_contact'" do
+      let (:role) { :secondary_contact }
+
+      it { is_expected.to be true }
+    end
+
+    context "when role is 'admin'" do
+      let (:role) { :admin }
+
+      it { is_expected.to be true }
+    end
+
+    context "when role is 'viewer'" do
+      let (:role) { :viewer }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe '#validates_primary_contact_assignment' do
     subject do
       build(:user, role: 'primary_contact', site: site)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe User, type: :model do
 
       it { is_expected.to validate_presence_of(:site) }
     end
+
+    context 'as viewer' do
+      subject { create(:viewer) }
+
+      it { is_expected.to validate_presence_of(:site) }
+    end
   end
 
   roles = described_class::ROLES


### PR DESCRIPTION
This PR makes various tweaks following the addition of `viewer` Users, such as accounting for `viewer`s in a couple of places where we previously only considered contacts and admins, and indicating what the current User's `role` is in the app nav bar - see commits for full details. This is a step towards implementing https://trello.com/c/JvjCbEAh/339-prevent-viewers-from-interacting-with-things.