### PR TITLE
Controller action authorisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'state_machines-audit_trail'
 gem 'business_time'
 gem "audited", "~> 4.7"
 gem 'jwt'
+gem 'pundit'
 
 gem 'bootstrap', '~> 4.0.0'
 gem 'jquery-rails' # Required for Bootstrap.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,8 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
+    pundit (1.1.0)
+      activesupport (>= 3.0.0)
     rack (2.0.5)
     rack-pjax (1.0.0)
       nokogiri (~> 1.5)
@@ -466,6 +468,7 @@ DEPENDENCIES
   pg (~> 0.18)
   pry-rails
   puma (~> 3.7)
+  pundit
   rails (~> 5.2)
   rails-controller-testing
   rails_admin (~> 1.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,13 @@ class ApplicationController < ActionController::Base
   before_action :assign_scope
   before_action :assign_title
 
+  # Ensure actions authorize the resource they operate on (using Pundit). These
+  # read-only actions are skipped as, for now at least, whether a User is able
+  # to read a record is checked at the model level, and handled as a 404 if
+  # they are forbidden; see `ApplicationRecord#check_read_permissions`.
+  NO_AUTH_ACTIONS = [:show, :index]
+  after_action :verify_authorized, except: NO_AUTH_ACTIONS
+
   rescue_from ReadPermissionsError, with: :not_found
   rescue_from JWT::DecodeError, with: :not_found
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ require 'exceptions'
 
 class ApplicationController < ActionController::Base
   include Clearance::Controller
+  include Pundit
+
   protect_from_forgery with: :exception
   decorates_assigned :site
 

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -1,9 +1,17 @@
 class AssetRecordsController < ApplicationController
+
+  # Ensure actions authorize the resource they operate on (using Pundit).
+  after_action :verify_authorized
+
   def edit
+    authorize :asset_record, :edit?
+
     @asset = asset
   end
 
   def update
+    authorize :asset_record, :update?
+
     update_component_make if asset.is_a? ComponentGroup
     failed_updates = update_asset_record.reject(&:nil?)
                                         .reject(&:valid?)

--- a/app/controllers/asset_records_controller.rb
+++ b/app/controllers/asset_records_controller.rb
@@ -1,8 +1,4 @@
 class AssetRecordsController < ApplicationController
-
-  # Ensure actions authorize the resource they operate on (using Pundit).
-  after_action :verify_authorized
-
   def edit
     authorize :asset_record, :edit?
 

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -1,8 +1,12 @@
 class CaseCommentsController < ApplicationController
+  # Ensure actions authorize the resource they operate on (using Pundit).
+  after_action :verify_authorized
+
   def create
     my_case = Case.find_from_id!(params.require(:case_id))
 
     new_comment = my_case.case_comments.new(comment_params)
+    authorize new_comment
 
     if new_comment.save
       flash[:notice] = 'New comment added.'

--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -1,7 +1,4 @@
 class CaseCommentsController < ApplicationController
-  # Ensure actions authorize the resource they operate on (using Pundit).
-  after_action :verify_authorized
-
   def create
     my_case = Case.find_from_id!(params.require(:case_id))
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -1,6 +1,9 @@
 class CasesController < ApplicationController
   decorates_assigned :site
 
+  # Ensure actions authorize the resource they operate on (using Pundit).
+  after_action :verify_authorized
+
   def index
     index_action(show_resolved: false)
   end
@@ -20,6 +23,7 @@ class CasesController < ApplicationController
   end
 
   def new
+    authorize Case
     cluster_id = params[:cluster_id]
     component_id = params[:component_id]
     service_id = params[:service_id]
@@ -38,6 +42,7 @@ class CasesController < ApplicationController
 
   def create
     @case = Case.new(case_params.merge(user: current_user))
+    authorize @case
 
     respond_to do |format|
       if @case.save
@@ -124,6 +129,7 @@ class CasesController < ApplicationController
   end
 
   def index_action(show_resolved:)
+    authorize Case
     @show_resolved = show_resolved
     render :index
   end
@@ -141,6 +147,8 @@ class CasesController < ApplicationController
   end
 
   def case_from_params
-    Case.find_from_id!(params.require(:id)).decorate
+    Case.find_from_id!(params.require(:id))
+      .tap { |c| authorize c }
+      .decorate
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -1,8 +1,9 @@
 class CasesController < ApplicationController
   decorates_assigned :site
 
-  # Ensure actions authorize the resource they operate on (using Pundit).
-  after_action :verify_authorized
+  # Authorization also not required for `resolved` here, since this is
+  # effectively the same as `index` just with different Cases listed.
+  after_action :verify_authorized, except: NO_AUTH_ACTIONS + [:resolved]
 
   def index
     index_action(show_resolved: false)
@@ -129,7 +130,6 @@ class CasesController < ApplicationController
   end
 
   def index_action(show_resolved:)
-    authorize Case
     @show_resolved = show_resolved
     render :index
   end

--- a/app/controllers/change_motd_requests_controller.rb
+++ b/app/controllers/change_motd_requests_controller.rb
@@ -1,7 +1,4 @@
 class ChangeMotdRequestsController < ApplicationController
-  # Ensure actions authorize the resource they operate on (using Pundit).
-  after_action :verify_authorized
-
   def apply
     change_motd_request = ChangeMotdRequest.find(params[:id])
     authorize change_motd_request

--- a/app/controllers/change_motd_requests_controller.rb
+++ b/app/controllers/change_motd_requests_controller.rb
@@ -1,6 +1,10 @@
 class ChangeMotdRequestsController < ApplicationController
+  # Ensure actions authorize the resource they operate on (using Pundit).
+  after_action :verify_authorized
+
   def apply
     change_motd_request = ChangeMotdRequest.find(params[:id])
+    authorize change_motd_request
     change_motd_request.apply!(current_user)
     redirect_back fallback_location: change_motd_request.case
     flash[:success] = 'The cluster has been updated to reflect this change.'

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -1,11 +1,4 @@
 class ComponentExpansionsController < ApplicationController
-  # Ensure actions authorize the resource they operate on (using Pundit).
-  after_action :verify_authorized
-
-  def index
-    authorize ComponentExpansion
-  end
-
   def edit
     authorize ComponentExpansion
   end

--- a/app/controllers/component_expansions_controller.rb
+++ b/app/controllers/component_expansions_controller.rb
@@ -1,7 +1,19 @@
 class ComponentExpansionsController < ApplicationController
+  # Ensure actions authorize the resource they operate on (using Pundit).
+  after_action :verify_authorized
+
+  def index
+    authorize ComponentExpansion
+  end
+
+  def edit
+    authorize ComponentExpansion
+  end
+
   def create
     expansion = @cluster_part.component_expansions
                              .new create_expansion_params
+    authorize expansion
     if expansion.save
       msg = "Successfully added the: #{expansion.expansion_type.name}"
       flash[:success] = msg
@@ -14,6 +26,7 @@ class ComponentExpansionsController < ApplicationController
 
   def update
     @cluster_part.component_expansions.each do |expansion|
+      authorize expansion
       new_params = update_expansion_params expansion
       unless expansion.update new_params
         expansion_errors.push expansion
@@ -23,7 +36,9 @@ class ComponentExpansionsController < ApplicationController
   end
 
   def destroy
-    if component_expansion_from_param.destroy
+    expansion = component_expansion_from_param
+    authorize expansion
+    if expansion.destroy
       flash[:success] = 'Successfully deleted expansion'
     else
       flash[:error] = 'Failed to delete expansion'

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,11 +1,7 @@
 require 'slack-notifier'
 class LogsController < ApplicationController
-  # Ensure actions authorize the resource they operate on (using Pundit).
-  after_action :verify_authorized
-
   def index
     @new_log = Log.new
-    authorize @new_log
     @scope = @component || @cluster
     @logs = @scope.logs
     @cases = @scope.cases

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,7 +1,11 @@
 require 'slack-notifier'
 class LogsController < ApplicationController
+  # Ensure actions authorize the resource they operate on (using Pundit).
+  after_action :verify_authorized
+
   def index
     @new_log = Log.new
+    authorize @new_log
     @scope = @component || @cluster
     @logs = @scope.logs
     @cases = @scope.cases
@@ -11,6 +15,7 @@ class LogsController < ApplicationController
   def create
     @scope = @component || @cluster # TODO: Generalise this
     new_log = @scope.logs.build(log_params)
+    authorize new_log
     if new_log.save
       flash[:success] = 'Added new log entry'
     else

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,7 +1,4 @@
 class MaintenanceWindowsController < ApplicationController
-  # Ensure actions authorize the resource they operate on (using Pundit).
-  after_action :verify_authorized, except: :index
-
   decorates_assigned :maintenance_window
 
   def new

--- a/app/controllers/sso_sessions_controller.rb
+++ b/app/controllers/sso_sessions_controller.rb
@@ -1,4 +1,8 @@
 class SsoSessionsController < Clearance::SessionsController
+  # No need to do authorization in this controller, want to just let any User
+  # access actions and Clearance appropriately handle things as normal.
+  after_action :verify_authorized, only: []
+
   def url_after_destroy
     '/'
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -227,6 +227,10 @@ class Case < ApplicationRecord
     handle_tool(tool_type, fields: tool_hash)
   end
 
+  def commenting_enabled_for?(user)
+    !CaseCommenting.new(self, user).disabled?
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(:id => record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,7 +1,7 @@
 class ApplicationPolicy
   attr_reader :user, :record
 
-  delegate :admin?, :editor?, to: :user
+  delegate :admin?, :contact?, :editor?, to: :user
 
   def initialize(user, record)
     @user = user

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,12 +8,6 @@ class ApplicationPolicy
     @record = record
   end
 
-  # Method analogous to `admin?` and `editor?`, but to use when any User can
-  # perform the action.
-  def anyone?
-    true
-  end
-
   def index?
     false
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,6 +8,12 @@ class ApplicationPolicy
     @record = record
   end
 
+  # Method analogous to `admin?` and `editor?`, but to use when any User can
+  # perform the action.
+  def anyone?
+    true
+  end
+
   def index?
     false
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,6 +1,8 @@
 class ApplicationPolicy
   attr_reader :user, :record
 
+  delegate :admin?, :editor?, to: :user
+
   def initialize(user, record)
     @user = user
     @record = record

--- a/app/policies/asset_record_policy.rb
+++ b/app/policies/asset_record_policy.rb
@@ -1,0 +1,9 @@
+class AssetRecordPolicy < ApplicationPolicy
+  alias_method :update?, :admin?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/case_comment_policy.rb
+++ b/app/policies/case_comment_policy.rb
@@ -1,0 +1,11 @@
+class CaseCommentPolicy < ApplicationPolicy
+  def create?
+    record.case.commenting_enabled_for?(user)
+  end
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -1,8 +1,6 @@
 class CasePolicy < ApplicationPolicy
-  def index?
-    true
-  end
-  alias_method :resolved?, :index?
+  alias_method :index?, :anyone?
+  alias_method :resolved?, :anyone?
 
   alias_method :create?, :editor?
   alias_method :escalate?, :editor?

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -1,0 +1,20 @@
+class CasePolicy < ApplicationPolicy
+  def index?
+    true
+  end
+  alias_method :resolved?, :index?
+
+  alias_method :create?, :editor?
+  alias_method :escalate?, :editor?
+
+  alias_method :close?, :admin?
+  alias_method :assign?, :admin?
+  alias_method :resolve?, :admin?
+  alias_method :set_time?, :admin?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -1,7 +1,4 @@
 class CasePolicy < ApplicationPolicy
-  alias_method :index?, :anyone?
-  alias_method :resolved?, :anyone?
-
   alias_method :create?, :editor?
   alias_method :escalate?, :editor?
 

--- a/app/policies/change_motd_request_policy.rb
+++ b/app/policies/change_motd_request_policy.rb
@@ -1,0 +1,9 @@
+class ChangeMotdRequestPolicy < ApplicationPolicy
+  alias_method :apply?, :admin?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/component_expansion_policy.rb
+++ b/app/policies/component_expansion_policy.rb
@@ -1,0 +1,12 @@
+class ComponentExpansionPolicy < ApplicationPolicy
+  alias_method :index?, :anyone?
+  alias_method :create?, :admin?
+  alias_method :update?, :admin?
+  alias_method :destroy?, :admin?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/component_expansion_policy.rb
+++ b/app/policies/component_expansion_policy.rb
@@ -1,5 +1,4 @@
 class ComponentExpansionPolicy < ApplicationPolicy
-  alias_method :index?, :anyone?
   alias_method :create?, :admin?
   alias_method :update?, :admin?
   alias_method :destroy?, :admin?

--- a/app/policies/log_policy.rb
+++ b/app/policies/log_policy.rb
@@ -1,0 +1,11 @@
+class LogPolicy < ApplicationPolicy
+  alias_method :index?, :anyone?
+
+  alias_method :create?, :admin?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/log_policy.rb
+++ b/app/policies/log_policy.rb
@@ -1,6 +1,4 @@
 class LogPolicy < ApplicationPolicy
-  alias_method :index?, :anyone?
-
   alias_method :create?, :admin?
 
   class Scope < Scope

--- a/app/policies/maintenance_window_policy.rb
+++ b/app/policies/maintenance_window_policy.rb
@@ -1,0 +1,16 @@
+class MaintenanceWindowPolicy < ApplicationPolicy
+  alias_method :create?, :admin?
+  alias_method :cancel?, :admin?
+  alias_method :end?, :admin?
+  alias_method :extend?, :admin?
+
+  alias_method :confirm?, :contact?
+  alias_method :confirm_submit?, :confirm?
+  alias_method :reject?, :contact?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,10 @@ module AlcesFlightCenter
                           'Alces Flight Center <center@alces-flight.com>'
                         end
 
+    # Handle Pundit authorization failure as 403 (forbidden) - see
+    # https://github.com/varvet/pundit/blob/dc7095118c47faca1fbea213f8b82d4d0b2616a0/README.md#rescuing-a-denied-authorization-in-rails.
+    config.action_dispatch.rescue_responses['Pundit::NotAuthorizedError'] = :forbidden
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/lib/templates/rspec/policy/policy_spec.rb
+++ b/lib/templates/rspec/policy/policy_spec.rb
@@ -1,0 +1,11 @@
+require '<%= File.exists?('spec/rails_helper.rb') ? 'rails_helper' : 'spec_helper' %>'
+
+RSpec.describe <%= class_name %>Policy do
+  include_context 'policy'
+
+  let(:record) { nil }
+
+  permissions :some_action? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -478,4 +478,18 @@ RSpec.describe Case, type: :model do
       expect(subject).not_to include('some_viewer')
     end
   end
+
+  describe '#commenting_enabled_for?' do
+    it 'returns inverse of what CaseCommenting#disabled? would give' do
+      user = build_stubbed(:user)
+      kase = build_stubbed(:case)
+      stub_case_commenting = CaseCommenting.new(kase, user)
+      allow(stub_case_commenting).to receive(:disabled?).and_return true
+      allow(
+        CaseCommenting
+      ).to receive(:new).with(kase, user).and_return(stub_case_commenting)
+
+      expect(kase.commenting_enabled_for?(user)).to eq(false)
+    end
+  end
 end

--- a/spec/policies/asset_record_policy_spec.rb
+++ b/spec/policies/asset_record_policy_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe AssetRecordPolicy do
+  include_context 'policy'
+
+  let(:record) { nil }
+
+  permissions :edit?, :update? do
+    it_behaves_like 'it is available only to admins'
+  end
+end

--- a/spec/policies/case_comment_policy_spec.rb
+++ b/spec/policies/case_comment_policy_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe CaseCommentPolicy do
+  include_context 'policy'
+
+  permissions :create? do
+    let(:user) { build_stubbed(:user) }
+    let(:comment) { build_stubbed(:case_comment, case: kase) }
+    let(:kase) { build_stubbed(:case) }
+
+    it 'denies access when commenting is disabled on the Case' do
+      allow(kase).to receive(:commenting_enabled_for?).with(user).and_return(false)
+
+      expect(subject).not_to permit(user, comment)
+    end
+
+    it 'grants access when commenting is enabled on the Case' do
+      allow(kase).to receive(:commenting_enabled_for?).with(user).and_return(true)
+
+      expect(subject).to permit(user, comment)
+    end
+  end
+end

--- a/spec/policies/case_policy_spec.rb
+++ b/spec/policies/case_policy_spec.rb
@@ -1,53 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe CasePolicy do
-  subject { described_class }
+  include_context 'policy'
 
-  let(:admin) { create(:admin) }
-  let(:site_contact) { create(:contact, site: site) }
-  let(:site_viewer) { create(:viewer, site: site) }
-  let(:kase) { create(:case, cluster: create(:cluster, site: site)) }
-  let(:site) { create(:site) }
+  let(:record) { create(:case, cluster: create(:cluster, site: site)) }
 
   permissions :index?, :resolved? do
-    it 'grants access to admin' do
-      expect(subject).to permit(admin, kase)
-    end
-
-    it 'grants access to site contact' do
-      expect(subject).to permit(site_contact, kase)
-    end
-
-    it 'grants access to site viewer' do
-      expect(subject).to permit(site_viewer, kase)
-    end
+    it_behaves_like 'it is available to anyone'
   end
 
   permissions :create?, :new?, :escalate? do
-    it 'grants access to admin' do
-      expect(subject).to permit(admin, kase)
-    end
-
-    it 'grants access to site contact' do
-      expect(subject).to permit(site_contact, kase)
-    end
-
-    it 'denies access to site viewer' do
-      expect(subject).not_to permit(site_viewer, kase)
-    end
+    it_behaves_like 'it is available only to editors'
   end
 
   permissions :close?, :assign?, :resolve?, :set_time? do
-    it 'grants access to admin' do
-      expect(subject).to permit(admin, kase)
-    end
-
-    it 'denies access to site contact' do
-      expect(subject).not_to permit(site_contact, kase)
-    end
-
-    it 'denies access to site viewer' do
-      expect(subject).not_to permit(site_viewer, kase)
-    end
+    it_behaves_like 'it is available only to admins'
   end
 end

--- a/spec/policies/case_policy_spec.rb
+++ b/spec/policies/case_policy_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe CasePolicy do
 
   let(:record) { create(:case, cluster: create(:cluster, site: site)) }
 
-  permissions :index?, :resolved? do
-    it_behaves_like 'it is available to anyone'
-  end
-
   permissions :create?, :new?, :escalate? do
     it_behaves_like 'it is available only to editors'
   end

--- a/spec/policies/case_policy_spec.rb
+++ b/spec/policies/case_policy_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe CasePolicy do
+  subject { described_class }
+
+  let(:admin) { create(:admin) }
+  let(:site_contact) { create(:contact, site: site) }
+  let(:site_viewer) { create(:viewer, site: site) }
+  let(:kase) { create(:case, cluster: create(:cluster, site: site)) }
+  let(:site) { create(:site) }
+
+  permissions :index?, :resolved? do
+    it 'grants access to admin' do
+      expect(subject).to permit(admin, kase)
+    end
+
+    it 'grants access to site contact' do
+      expect(subject).to permit(site_contact, kase)
+    end
+
+    it 'grants access to site viewer' do
+      expect(subject).to permit(site_viewer, kase)
+    end
+  end
+
+  permissions :create?, :new?, :escalate? do
+    it 'grants access to admin' do
+      expect(subject).to permit(admin, kase)
+    end
+
+    it 'grants access to site contact' do
+      expect(subject).to permit(site_contact, kase)
+    end
+
+    it 'denies access to site viewer' do
+      expect(subject).not_to permit(site_viewer, kase)
+    end
+  end
+
+  permissions :close?, :assign?, :resolve?, :set_time? do
+    it 'grants access to admin' do
+      expect(subject).to permit(admin, kase)
+    end
+
+    it 'denies access to site contact' do
+      expect(subject).not_to permit(site_contact, kase)
+    end
+
+    it 'denies access to site viewer' do
+      expect(subject).not_to permit(site_viewer, kase)
+    end
+  end
+end

--- a/spec/policies/change_motd_request_policy_spec.rb
+++ b/spec/policies/change_motd_request_policy_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ChangeMotdRequestPolicy do
+  include_context 'policy'
+
+  let(:record) { nil }
+
+  permissions :apply? do
+    it_behaves_like 'it is available only to admins'
+  end
+end

--- a/spec/policies/component_expansion_policy_spec.rb
+++ b/spec/policies/component_expansion_policy_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe ComponentExpansionPolicy do
 
   let(:record) { nil }
 
-  permissions :index? do
-    it_behaves_like 'it is available to anyone'
-  end
-
   permissions :create?, :update?, :destroy? do
     it_behaves_like 'it is available only to admins'
   end

--- a/spec/policies/component_expansion_policy_spec.rb
+++ b/spec/policies/component_expansion_policy_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ComponentExpansionPolicy do
+  include_context 'policy'
+
+  let(:record) { nil }
+
+  permissions :index? do
+    it_behaves_like 'it is available to anyone'
+  end
+
+  permissions :create?, :update?, :destroy? do
+    it_behaves_like 'it is available only to admins'
+  end
+end

--- a/spec/policies/log_policy_spec.rb
+++ b/spec/policies/log_policy_spec.rb
@@ -5,10 +5,6 @@ RSpec.describe LogPolicy do
 
   let(:record) { nil }
 
-  permissions :index? do
-    it_behaves_like 'it is available to anyone'
-  end
-
   permissions :create?, :new? do
     it_behaves_like 'it is available only to admins'
   end

--- a/spec/policies/log_policy_spec.rb
+++ b/spec/policies/log_policy_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe LogPolicy do
+  include_context 'policy'
+
+  let(:record) { nil }
+
+  permissions :index? do
+    it_behaves_like 'it is available to anyone'
+  end
+
+  permissions :create?, :new? do
+    it_behaves_like 'it is available only to admins'
+  end
+end

--- a/spec/policies/maintenance_window_policy_spec.rb
+++ b/spec/policies/maintenance_window_policy_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe MaintenanceWindowPolicy do
+  include_context 'policy'
+
+  let(:record) { nil }
+
+  permissions :new?, :create?, :cancel?, :end?, :extend? do
+    it_behaves_like 'it is available only to admins'
+  end
+
+  permissions :confirm?, :confirm_submit?, :reject? do
+    it_behaves_like 'it is available only to contacts'
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ require 'email_spec/rspec'
 Dir[Rails.root.join('spec/support/**/*.rb')].each {|f| require f}
 
 require 'clearance/rspec'
+require 'pundit/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/shared_contexts/policy.rb
+++ b/spec/support/shared_contexts/policy.rb
@@ -49,3 +49,17 @@ RSpec.shared_examples 'it is available only to admins' do
     expect(subject).not_to permit(site_viewer, record)
   end
 end
+
+RSpec.shared_examples 'it is available only to contacts' do
+  it 'denies access to admin' do
+    expect(subject).not_to permit(admin, record)
+  end
+
+  it 'grants access to site contact' do
+    expect(subject).to permit(site_contact, record)
+  end
+
+  it 'denies access to site viewer' do
+    expect(subject).not_to permit(site_viewer, record)
+  end
+end

--- a/spec/support/shared_contexts/policy.rb
+++ b/spec/support/shared_contexts/policy.rb
@@ -1,0 +1,51 @@
+
+RSpec.shared_context 'policy' do
+  subject { described_class }
+
+  let(:admin) { create(:admin) }
+  let(:site_contact) { create(:contact, site: site) }
+  let(:site_viewer) { create(:viewer, site: site) }
+  let(:site) { create(:site) }
+end
+
+RSpec.shared_examples 'it is available to anyone' do
+  it 'grants access to admin' do
+    expect(subject).to permit(admin, record)
+  end
+
+  it 'grants access to site contact' do
+    expect(subject).to permit(site_contact, record)
+  end
+
+  it 'grants access to site viewer' do
+    expect(subject).to permit(site_viewer, record)
+  end
+end
+
+RSpec.shared_examples 'it is available only to editors' do
+  it 'grants access to admin' do
+    expect(subject).to permit(admin, record)
+  end
+
+  it 'grants access to site contact' do
+    expect(subject).to permit(site_contact, record)
+  end
+
+  it 'denies access to site viewer' do
+    expect(subject).not_to permit(site_viewer, record)
+  end
+end
+
+RSpec.shared_examples 'it is available only to admins' do
+  it 'grants access to admin' do
+    expect(subject).to permit(admin, record)
+  end
+
+  it 'denies access to site contact' do
+    expect(subject).not_to permit(site_contact, record)
+  end
+
+  it 'denies access to site viewer' do
+    expect(subject).not_to permit(site_viewer, record)
+  end
+end

--- a/spec/support/shared_contexts/policy.rb
+++ b/spec/support/shared_contexts/policy.rb
@@ -8,20 +8,6 @@ RSpec.shared_context 'policy' do
   let(:site) { create(:site) }
 end
 
-RSpec.shared_examples 'it is available to anyone' do
-  it 'grants access to admin' do
-    expect(subject).to permit(admin, record)
-  end
-
-  it 'grants access to site contact' do
-    expect(subject).to permit(site_contact, record)
-  end
-
-  it 'grants access to site viewer' do
-    expect(subject).to permit(site_viewer, record)
-  end
-end
-
 RSpec.shared_examples 'it is available only to editors' do
   it 'grants access to admin' do
     expect(subject).to permit(admin, record)


### PR DESCRIPTION
This PR adds authorisation for all non-read-only controller actions using [Pundit](https://github.com/varvet/pundit) (see https://github.com/alces-software/alces-flight-center/commit/19ee270f1b3643cef07c3679fa51b83f9a3bfd6a for details of why I've decided we do not need/want authorisation for read-only actions at the moment). Pundit policies have been implemented which handle all our current non-read-only controller actions, and these should appropriately handle authorisation for all our current possible User roles.

This should mostly implement the server-side handling of https://trello.com/c/JvjCbEAh/339-prevent-viewers-from-interacting-with-things, as viewers should be forbidden from accessing actions they shouldn't have access to; actually hiding/disabling buttons they shouldn't have access to is still to come (and I still need to go through and check we're appropriately handling viewers in all situations).