### PR TITLE
Allow access to confirm MWs for admins

### DIFF
--- a/app/policies/maintenance_window_policy.rb
+++ b/app/policies/maintenance_window_policy.rb
@@ -4,8 +4,9 @@ class MaintenanceWindowPolicy < ApplicationPolicy
   alias_method :end?, :admin?
   alias_method :extend?, :admin?
 
-  alias_method :confirm?, :contact?
-  alias_method :confirm_submit?, :confirm?
+  alias_method :confirm?, :editor?
+  alias_method :confirm_submit?, :editor?
+
   alias_method :reject?, :contact?
 
   class Scope < Scope

--- a/spec/policies/maintenance_window_policy_spec.rb
+++ b/spec/policies/maintenance_window_policy_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe MaintenanceWindowPolicy do
     it_behaves_like 'it is available only to admins'
   end
 
-  permissions :confirm?, :confirm_submit?, :reject? do
+  permissions :confirm?, :confirm_submit? do
+    it_behaves_like 'it is available only to editors'
+  end
+
+  permissions :reject? do
     it_behaves_like 'it is available only to contacts'
   end
 end


### PR DESCRIPTION
This was previously allowed at the model level, but I hadn't accounted
for admins also being able to confirm maintenance when implementing this
policy. This commit corrects this so both admins and contacts can
confirm maintenance.