### PR TITLE
Fix auth failure when accessing RailsAdmin routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,8 @@
 require 'exceptions'
 
-class ApplicationController < ActionController::Base
-  include Clearance::Controller
+class ApplicationController < RootController
   include Pundit
 
-  protect_from_forgery with: :exception
   decorates_assigned :site
 
   before_action :set_sentry_raven_context

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,0 +1,10 @@
+
+# This controller exists so we have a common root controller which can be
+# shared between our app and other Rails engines used by the app, in particular
+# RailsAdmin. We can't just use ApplicationController for this as this contains
+# common app-specific behaviour which we do not want shared.
+class RootController < ActionController::Base
+  include Clearance::Controller
+
+  protect_from_forgery with: :exception
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,8 +1,9 @@
 
 RailsAdmin.config do |config|
-  # Required so ApplicationController methods, such as `current_user`,
-  # available within `authorize_with` block.
-  config.parent_controller = ApplicationController.to_s
+  # Inherit RailsAdmin controllers from a common root controller with our app;
+  # in particular required so methods from Clearance, like `current_user`, are
+  # available to RailsAdmin.
+  config.parent_controller = RootController.to_s
 
   # Prevent access to admin interface unless current user is an admin.
   config.authorize_with do


### PR DESCRIPTION
Following the introduction of app-wide authorisation using Pundit (done
in #338), the
RailsAdmin routes had accidentally become inaccessible as we now verify
most controller actions perform an authorisation check, and RailsAdmin
actions were not doing this.

A straightforward solution to this, since we want authorisation enforced
within our app but not in RailsAdmin, is to have one RootController
which will be inherited from both by the ApplicationController and by
other engines, while any app-specific behaviour can just be in the
ApplicationController which RailsAdmin controllers no longer inherit
from.
