### PR TITLE
Display site viewers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ group :test do
   gem 'email_spec'
   gem 'rails-controller-testing'
   gem 'shoulda-matchers'
+  gem 'rspec-retry'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,8 @@ GEM
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
+    rspec-retry (0.6.0)
+      rspec-core (> 3.3)
     rspec-support (3.7.1)
     rubocop (0.56.0)
       parallel (~> 1.10)
@@ -479,6 +481,7 @@ DEPENDENCIES
   resque_mailer
   roadie-rails
   rspec-rails
+  rspec-retry
   rubocop
   sass
   sass-rails (~> 5.0)

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -7,8 +7,16 @@ class SiteDecorator < ApplicationDecorator
   end
 
   def secondary_contacts_list
-    h.raw(
-      [secondary_contacts_title, secondary_contacts_ul].join
+    users_list(
+      users.secondary_contacts,
+      title: 'Secondary site contact'
+    )
+  end
+
+  def viewers_list
+    users_list(
+      users.viewers,
+      title: 'Site viewer'
     )
   end
 
@@ -30,22 +38,23 @@ class SiteDecorator < ApplicationDecorator
     end
   end
 
-  def secondary_contacts_title
-    "<h4>Secondary site #{'contact'.pluralize(secondary_contacts.length)}</h4>"
+  def users_list(users, title:)
+    h.raw(
+      [
+        "<h4>#{title.pluralize(users.length)}</h4>",
+        users_ul(users),
+      ].join
+    )
   end
 
-  def secondary_contacts_ul
-    if secondary_contacts.present?
-      items = secondary_contacts.map(&:decorate).map do |contact|
-        "<li>#{contact.info}</li>"
+  def users_ul(users)
+    if users.present?
+      items = users.map(&:decorate).map do |user|
+        "<li>#{user.info}</li>"
       end.join
       "<ul>#{items}</ul>"
     else
       "<em>None</em>"
     end
-  end
-
-  def secondary_contacts
-    @secondary_contacts ||= users.secondary_contacts
   end
 end

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -6,6 +6,12 @@ class SiteDecorator < ApplicationDecorator
     [tabs_builder.overview, all_cases_tab]
   end
 
+  def secondary_contacts_list
+    h.raw(
+      [secondary_contacts_title, secondary_contacts_ul].join
+    )
+  end
+
   private
 
   # Handles the dynamic naming of paths when a contact is logged in
@@ -21,6 +27,21 @@ class SiteDecorator < ApplicationDecorator
   def all_cases_tab
     tabs_builder.cases.tap do |tab|
       tab[:text] = 'All site cases'
+    end
+  end
+
+  def secondary_contacts_title
+    "<h4>Secondary site #{'contact'.pluralize(secondary_contacts.length)}</h4>"
+  end
+
+  def secondary_contacts_ul
+    if secondary_contacts.present?
+      items = secondary_contacts.map(&:decorate).map do |contact|
+        "<li>#{contact.info}</li>"
+      end.join
+      "<ul>#{items}</ul>"
+    else
+      "<em>None</em>"
     end
   end
 end

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -44,4 +44,8 @@ class SiteDecorator < ApplicationDecorator
       "<em>None</em>"
     end
   end
+
+  def secondary_contacts
+    @secondary_contacts ||= users.secondary_contacts
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,8 +25,4 @@ class Site < ApplicationRecord
   def primary_contact
     users.find_by(role: 'primary_contact')
   end
-
-  def secondary_contacts
-    users.where(role: 'secondary_contact')
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,10 @@ class User < ApplicationRecord
 
   ROLES = %w{admin primary_contact secondary_contact viewer}
 
+  ROLES.each do |role|
+    scope role.pluralize, -> { where(role: role) }
+  end
+
   belongs_to :site, required: false
 
   validates_associated :site

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -9,16 +9,7 @@
       <h4>Primary site contact</h4>
       <ul><li><%= site.primary_contact&.decorate&.info || raw('<em>Unset</em>') %></li></ul>
 
-      <h4>Secondary site <%= 'contact'.pluralize(site.secondary_contacts.length) %></h4>
-      <% if site.secondary_contacts.present? %>
-        <ul>
-          <% site.secondary_contacts.map(&:decorate).each do |contact| %>
-            <li><%= contact.info %></li>
-          <% end %>
-        </ul>
-      <% else %>
-        <em>None</em>
-      <% end %>
+      <%= site.secondary_contacts_list %>
 
       <% if site.additional_contacts.present? %>
 

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -11,6 +11,8 @@
 
       <%= site.secondary_contacts_list %>
 
+      <%= site.viewers_list %>
+
       <% if site.additional_contacts.present? %>
 
         <h4>Additional site contacts</h4>

--- a/spec/decorators/site_decorator_spec.rb
+++ b/spec/decorators/site_decorator_spec.rb
@@ -1,42 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe SiteDecorator do
-  describe '#secondary_contacts_list' do
+  let(:site) { create(:site) }
+
+  RSpec.shared_examples 'Site users list' do |args|
+    role = args.fetch(:role)
+    title = args.fetch(:title)
+
     it 'indicates what is displayed' do
-      site = create(:site)
-
-      expect(
-        site.decorate.secondary_contacts_list
-      ).to include(
-        '<h4>Secondary site contacts</h4>'
+      expect(subject).to include(
+        "<h4>#{title}s</h4>"
       )
     end
 
-    it 'indicates when only single contact to display' do
-      site = create(:site, users: [create(:secondary_contact)])
+    it 'indicates when only single user to display' do
+      site.users = [create(role)]
 
-      expect(
-        site.decorate.secondary_contacts_list
-      ).to include(
-        '<h4>Secondary site contact</h4>'
+      expect(subject).to include(
+        "<h4>#{title}</h4>"
       )
     end
 
-    it 'gives list including each secondary contact' do
-      secondary_contact = create(:secondary_contact, name: 'Some User')
-      site = create(:site, users: [secondary_contact])
+    it 'gives list including each applicable user' do
+      user = create(role, name: 'Some User')
+      site.users = [user]
 
-      expect(
-        site.decorate.secondary_contacts_list
-      ).to match(/<ul><li>#{secondary_contact.name}.*<\/li><\/ul>/)
+      expect(subject).to match(
+        /<ul><li>#{user.name}.*<\/li><\/ul>/
+      )
     end
 
-    it 'indicates when no secondary contacts' do
-      site = create(:site)
-
-      expect(
-        site.decorate.secondary_contacts_list
-      ).to include('<em>None</em>')
+    it 'indicates when no applicable users' do
+      expect(subject).to include('<em>None</em>')
     end
+  end
+
+  describe '#secondary_contacts_list' do
+    subject do
+      site.decorate.secondary_contacts_list
+    end
+
+    it_behaves_like 'Site users list',
+      role: :secondary_contact,
+      title: 'Secondary site contact'
   end
 end

--- a/spec/decorators/site_decorator_spec.rb
+++ b/spec/decorators/site_decorator_spec.rb
@@ -44,4 +44,14 @@ RSpec.describe SiteDecorator do
       role: :secondary_contact,
       title: 'Secondary site contact'
   end
+
+  describe '#viewers_list' do
+    subject do
+      site.decorate.viewers_list
+    end
+
+    it_behaves_like 'Site users list',
+      role: :viewer,
+      title: 'Site viewer'
+  end
 end

--- a/spec/decorators/site_decorator_spec.rb
+++ b/spec/decorators/site_decorator_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe SiteDecorator do
+  describe '#secondary_contacts_list' do
+    it 'indicates what is displayed' do
+      site = create(:site)
+
+      expect(
+        site.decorate.secondary_contacts_list
+      ).to include(
+        '<h4>Secondary site contacts</h4>'
+      )
+    end
+
+    it 'indicates when only single contact to display' do
+      site = create(:site, users: [create(:secondary_contact)])
+
+      expect(
+        site.decorate.secondary_contacts_list
+      ).to include(
+        '<h4>Secondary site contact</h4>'
+      )
+    end
+
+    it 'gives list including each secondary contact' do
+      secondary_contact = create(:secondary_contact, name: 'Some User')
+      site = create(:site, users: [secondary_contact])
+
+      expect(
+        site.decorate.secondary_contacts_list
+      ).to match(/<ul><li>#{secondary_contact.name}.*<\/li><\/ul>/)
+    end
+
+    it 'indicates when no secondary contacts' do
+      site = create(:site)
+
+      expect(
+        site.decorate.secondary_contacts_list
+      ).to include('<em>None</em>')
+    end
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -41,12 +41,4 @@ RSpec.describe Site, type: :model do
       expect(subject).to eq(primary_contact)
     end
   end
-
-  describe '#secondary_contacts' do
-    subject { site.secondary_contacts }
-
-    it 'gives Site secondary contacts' do
-      expect(subject).to match_array([secondary_contact])
-    end
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require 'rspec/retry'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -94,6 +97,19 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # `rspec-retry` settings.
+  # Show retry status in spec process.
+  config.verbose_retry = true
+  # Show exception that triggers a retry (if `verbose_retry` is also true).
+  config.display_try_failure_messages = true
+
+  # Feature tests which run JS are always going to be flaky for reasons
+  # unrelated to the actual correctness of the test, so retry these a few times
+  # if they fail.
+  config.around :each, :js do |example|
+    example.run_with_retry retry: 3
+  end
 
   config.before :example do
     # Prevent attempting to retrieve documents from S3 when Cluster page


### PR DESCRIPTION
This PR makes Site viewers be displayed on the Site dashboard overview page, in a similar way to the secondary contacts, along with some related refactoring and addition of tests.