### PR TITLE
Support tier 4 cases (change requests)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -122,3 +122,7 @@ table {
 [onclick] {
   cursor: pointer;
 }
+
+.alert a.btn {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -64,3 +64,13 @@
     }
   }
 }
+
+.alert-cr-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  span {
+    flex: 1 1 33%;
+  }
+}

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -1,0 +1,11 @@
+class ChangeRequestsController < ApplicationController
+
+  before_action :assign_case
+
+  private
+
+  def assign_case
+    @case = Case.find_from_id!(params.require(:case_id)).decorate
+  end
+
+end

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -32,6 +32,12 @@ class ChangeRequestsController < ApplicationController
     end
   end
 
+  def authorise
+    change_action 'Change request %s authorised.' do |cr|
+      cr.authorise!(current_user)
+    end
+  end
+
   private
 
   def assign_case

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -9,10 +9,13 @@ class ChangeRequestsController < ApplicationController
   end
 
   def create
-    cr = @case.build_change_request(cr_params)
+    authorize @case
+    @case.tier_level = 4
+
+    cr = @case.create_change_request(cr_params)
     authorize cr
 
-    if cr.save
+    if @case.save
       flash[:success] = "Created change request for case #{@case.display_id}."
       redirect_to case_path(@case.display_id)
     else

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -26,6 +26,16 @@ class ChangeRequestsController < ApplicationController
     @cr = @case.change_request.decorate
   end
 
+  def edit
+    @cr = @case.change_request.decorate
+  end
+
+  def update
+    change_action 'Change request %s updated.' do |cr|
+      cr.assign_attributes(cr_params)
+    end
+  end
+
   def propose
     change_action 'Change request %s has been submitted for customer authorisation.' do |cr|
       cr.propose!(current_user)

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -7,13 +7,18 @@ class ChangeRequestsController < ApplicationController
   end
 
   def create
-    p params
+    @case.create_change_request!(cr_params)
+    redirect_to case_path(@case.display_id)
   end
 
   private
 
   def assign_case
     @case = Case.find_from_id!(params.require(:case_id)).decorate
+  end
+
+  def cr_params
+    params.require(:change_request).permit(:details, :credit_charge)
   end
 
 end

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -19,7 +19,7 @@ class ChangeRequestsController < ApplicationController
       flash[:error] = "Error creating change request: #{errors}." if errors
       # Show the form again, with the data previously entered.
       @cr = cr
-      render 'change_requests/new'
+      render :new
     end
 
   end

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -2,6 +2,14 @@ class ChangeRequestsController < ApplicationController
 
   before_action :assign_case
 
+  def new
+    @cr = ChangeRequest.new
+  end
+
+  def create
+    p params
+  end
+
   private
 
   def assign_case

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -1,6 +1,7 @@
 class ChangeRequestsController < ApplicationController
 
   before_action :assign_case
+  decorates_assigned :cr
 
   def new
     authorize ChangeRequest
@@ -25,11 +26,11 @@ class ChangeRequestsController < ApplicationController
   end
 
   def show
-    @cr = @case.change_request.decorate
+    assign_cr
   end
 
   def edit
-    @cr = @case.change_request.decorate
+    assign_cr
     authorize @cr
   end
 
@@ -73,6 +74,10 @@ class ChangeRequestsController < ApplicationController
 
   def assign_case
     @case = Case.find_from_id!(params.require(:case_id)).decorate
+  end
+
+  def assign_cr
+    @cr = @case.change_request || not_found
   end
 
   def cr_params

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -89,7 +89,7 @@ class ChangeRequestsController < ApplicationController
     rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
       flash[:error] = "Error updating change request: #{format_errors(cr)}"
     end
-    redirect_to cluster_case_change_request_path(@case.cluster, @case, cr)
+    redirect_to cluster_case_change_request_path(@case.cluster, @case)
   end
 
   def change_action_and_email(success_flash)

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -27,7 +27,7 @@ class ChangeRequestsController < ApplicationController
   end
 
   def propose
-    change_action 'Change request %s has been submitted for customer authorization' do |cr|
+    change_action 'Change request %s has been submitted for customer authorisation.' do |cr|
       cr.propose!(current_user)
     end
   end

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -30,6 +30,7 @@ class ChangeRequestsController < ApplicationController
 
   def edit
     @cr = @case.change_request.decorate
+    authorize @cr
   end
 
   def update

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -22,6 +22,10 @@ class ChangeRequestsController < ApplicationController
 
   end
 
+  def show
+    @cr = @case.change_request.decorate
+  end
+
   private
 
   def assign_case

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -38,6 +38,12 @@ class ChangeRequestsController < ApplicationController
     end
   end
 
+  def handover
+    change_action 'Change request %s handed over for customer approval.' do |cr|
+      cr.handover!(current_user)
+    end
+  end
+
   private
 
   def assign_case

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -37,31 +37,31 @@ class ChangeRequestsController < ApplicationController
   end
 
   def propose
-    change_action 'Change request %s has been submitted for customer authorisation.' do |cr|
+    change_action_and_email 'Change request %s has been submitted for customer authorisation.' do |cr|
       cr.propose!(current_user)
     end
   end
 
   def decline
-    change_action 'Change request %s declined.' do |cr|
+    change_action_and_email 'Change request %s declined.' do |cr|
       cr.decline!(current_user)
     end
   end
 
   def authorise
-    change_action 'Change request %s authorised.' do |cr|
+    change_action_and_email 'Change request %s authorised.' do |cr|
       cr.authorise!(current_user)
     end
   end
 
   def handover
-    change_action 'Change request %s handed over for customer approval.' do |cr|
+    change_action_and_email 'Change request %s handed over for customer approval.' do |cr|
       cr.handover!(current_user)
     end
   end
 
   def complete
-    change_action 'Change request %s completed.' do |cr|
+    change_action_and_email 'Change request %s completed.' do |cr|
       cr.complete!(current_user)
     end
   end
@@ -86,6 +86,19 @@ class ChangeRequestsController < ApplicationController
       flash[:error] = "Error updating change request: #{format_errors(cr)}"
     end
     redirect_to cluster_case_change_request_path(@case.cluster, @case, cr)
+  end
+
+  def change_action_and_email(success_flash)
+    change_action success_flash do |cr|
+      yield cr
+      # A note on the order in which things are done:
+      # Although the call to cr.save! doesn't happen until after this block
+      # returns, the #event! methods on ChangeRequest will already have saved
+      # the record to the database (or raised an exception). Hence we can be
+      # certain that, if we reach this point, the model is saved and valid, so
+      # it's safe to send the email.
+      CaseMailer.change_request(cr.case, cr.transitions.last.decorate.text_for_event).deliver_later
+    end
   end
 
 end

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -3,11 +3,13 @@ class ChangeRequestsController < ApplicationController
   before_action :assign_case
 
   def new
+    authorize ChangeRequest
     @cr = ChangeRequest.new
   end
 
   def create
     cr = @case.build_change_request(cr_params)
+    authorize cr
 
     if cr.save
       flash[:success] = "Created change request for case #{@case.display_id}."
@@ -79,6 +81,7 @@ class ChangeRequestsController < ApplicationController
   def change_action(success_flash)
     cr = @case.change_request
     begin
+      authorize cr
       yield(cr)
       cr.save!
       flash[:success] = success_flash % cr.case.display_id

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -63,7 +63,7 @@ class ChangeRequestsController < ApplicationController
   end
 
   def cr_params
-    params.require(:change_request).permit(:details, :credit_charge)
+    params.require(:change_request).permit(:description, :credit_charge)
   end
 
   def change_action(success_flash)

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -7,8 +7,19 @@ class ChangeRequestsController < ApplicationController
   end
 
   def create
-    @case.create_change_request!(cr_params)
-    redirect_to case_path(@case.display_id)
+    cr = @case.build_change_request(cr_params)
+
+    if cr.save
+      flash[:success] = "Created change request for case #{@case.display_id}."
+      redirect_to case_path(@case.display_id)
+    else
+      errors = format_errors(cr)
+      flash[:error] = "Error creating change request: #{errors}." if errors
+      # Show the form again, with the data previously entered.
+      @cr = cr
+      render 'change_requests/new'
+    end
+
   end
 
   private

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -32,6 +32,12 @@ class ChangeRequestsController < ApplicationController
     end
   end
 
+  def decline
+    change_action 'Change request %s declined.' do |cr|
+      cr.decline!(current_user)
+    end
+  end
+
   def authorise
     change_action 'Change request %s authorised.' do |cr|
       cr.authorise!(current_user)
@@ -41,6 +47,12 @@ class ChangeRequestsController < ApplicationController
   def handover
     change_action 'Change request %s handed over for customer approval.' do |cr|
       cr.handover!(current_user)
+    end
+  end
+
+  def complete
+    change_action 'Change request %s completed.' do |cr|
+      cr.complete!(current_user)
     end
   end
 

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -12,7 +12,7 @@ class ChangeRequestsController < ApplicationController
     authorize @case
     @case.tier_level = 4
 
-    cr = @case.create_change_request(cr_params)
+    cr = @case.build_change_request(cr_params)
     authorize cr
 
     if @case.save

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -82,7 +82,7 @@ module Audited
     end
 
     def tier_level_text(from, to)
-      if to == 3 && from < 3
+      if to >= 3 && from <= 3
         "Escalated this case to tier #{h.tier_description(to)}."
       elsif from.nil?  # Hide initial transitions caused by data migration
         nil

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -1,5 +1,6 @@
 class CaseDecorator < ApplicationDecorator
   delegate_all
+  decorates_association :change_request
 
   def user_facing_state
     model.state.to_s.titlecase

--- a/app/decorators/change_request_decorator.rb
+++ b/app/decorators/change_request_decorator.rb
@@ -1,0 +1,7 @@
+class ChangeRequestDecorator < ApplicationDecorator
+  delegate_all
+
+  def user_facing_state
+    state.tr('_', ' ').titleize
+  end
+end

--- a/app/decorators/change_request_decorator.rb
+++ b/app/decorators/change_request_decorator.rb
@@ -2,6 +2,6 @@ class ChangeRequestDecorator < ApplicationDecorator
   delegate_all
 
   def user_facing_state
-    state.tr('_', ' ').titleize
+    state.titleize
   end
 end

--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -1,6 +1,6 @@
 class ChangeRequestStateTransitionDecorator < ApplicationDecorator
   def event_card
-    text = text_for_event(object.event)
+    text = "#{text_for_event(object.event)} #{cr_link(object)}"
     h.render 'cases/event',
              name: object.user.name,
              date: object.created_at,
@@ -12,17 +12,30 @@ class ChangeRequestStateTransitionDecorator < ApplicationDecorator
 
   def text_for_event(event)
     case event
-    # TODO this is placeholder text
     when 'propose'
-      'Propose.'
+      'Change request has been proposed and is awaiting customer authorisation.'
     when 'decline'
-      'Decline.'
+      'Change request has been declined.'
     when 'authorise'
-      'Authorise.'
+      'Change request has been authorised.'
     when 'handover'
-      'Handover.'
+      'Change request is ready for handover.'
     when 'complete'
-      'Complete.'
+      'Change request is now complete.'
     end
+  end
+
+  def cr_link(crst)
+    kase = crst.change_request.case
+
+    h.link_to(
+       'View change request',
+       h.cluster_case_change_request_path(
+         kase.cluster,
+         kase,
+         crst.change_request
+       ),
+       class: 'btn btn-secondary float-right'
+    )
   end
 end

--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -1,0 +1,28 @@
+class ChangeRequestStateTransitionDecorator < ApplicationDecorator
+  def event_card
+    text = text_for_event(object.event)
+    h.render 'cases/event',
+             name: object.user.name,
+             date: object.created_at,
+             text: text,
+             type: 'cog'
+  end
+
+  private
+
+  def text_for_event(event)
+    case event
+    # TODO this is placeholder text
+    when 'propose'
+      'Propose.'
+    when 'decline'
+      'Decline.'
+    when 'authorise'
+      'Authorise.'
+    when 'handover'
+      'Handover.'
+    when 'complete'
+      'Complete.'
+    end
+  end
+end

--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -32,8 +32,7 @@ class ChangeRequestStateTransitionDecorator < ApplicationDecorator
        'View change request',
        h.cluster_case_change_request_path(
          kase.cluster,
-         kase,
-         object.change_request
+         kase
        ),
        class: 'btn btn-secondary float-right'
     )

--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -1,6 +1,6 @@
 class ChangeRequestStateTransitionDecorator < ApplicationDecorator
   def event_card
-    text = "#{text_for_event(object.event)} #{cr_link(object)}"
+    text = "Change request #{text_for_event} #{cr_link}"
     h.render 'cases/event',
              name: object.user.name,
              date: object.created_at,
@@ -8,32 +8,32 @@ class ChangeRequestStateTransitionDecorator < ApplicationDecorator
              type: 'cog'
   end
 
-  private
-
-  def text_for_event(event)
-    case event
+  def text_for_event
+    case object.event
     when 'propose'
-      'Change request has been proposed and is awaiting customer authorisation.'
+      'has been proposed and is awaiting customer authorisation.'
     when 'decline'
-      'Change request has been declined.'
+      'has been declined.'
     when 'authorise'
-      'Change request has been authorised.'
+      'has been authorised.'
     when 'handover'
-      'Change request is ready for handover.'
+      'is ready for handover.'
     when 'complete'
-      'Change request is now complete.'
+      'is now complete.'
     end
   end
 
-  def cr_link(crst)
-    kase = crst.change_request.case
+  private
+
+  def cr_link
+    kase = object.change_request.case
 
     h.link_to(
        'View change request',
        h.cluster_case_change_request_path(
          kase.cluster,
          kase,
-         crst.change_request
+         object.change_request
        ),
        class: 'btn btn-secondary float-right'
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,7 @@ module ApplicationHelper
       1 => 'Tool',
       2 => 'Routine Maintenance',
       3 => 'General Support',
+      4 => 'Change request'
   }.freeze
 
   def icon(name, interactive: false, inline: false, **args)

--- a/app/mailer_previews/case_mailer_preview.rb
+++ b/app/mailer_previews/case_mailer_preview.rb
@@ -20,6 +20,13 @@ class CaseMailerPreview < ApplicationMailerPreview
     )
   end
 
+  def change_request
+    CaseMailer.change_request(
+      get_case,
+      'has text to be replaced with the text from ChangeRequestStateTransitionDecorator.'
+    )
+  end
+
   private
 
   def get_case

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -56,4 +56,13 @@ class CaseMailer < ApplicationMailer
     SlackNotifier.maintenance_ending_soon_notification(@case, @text)
     window.set_maintenance_ending_soon_email_flag
   end
+
+  def change_request(my_case, text)
+    @case = my_case
+    @text = text
+    mail(
+      cc: @case.email_recipients,
+      subject: @case.email_reply_subject
+    )
+  end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -137,7 +137,7 @@ class Case < ApplicationRecord
       audits +
       logs +
       [ credit_charge ] +
-      change_request&.transitions
+      (change_request&.transitions || [])
     ).compact.sort_by(&:created_at).reverse!
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -208,7 +208,7 @@ class Case < ApplicationRecord
 
   def resolvable?
     state_transitions.map(&:to_name).include?(:resolved) &&
-        (!change_request.present? || change_request.finalised?)
+      !cr_in_progress?
   end
 
   def potential_assignees

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -61,7 +61,7 @@ class Case < ApplicationRecord
       # providing access to documentation without any action needing to be
       # taken by Alces admins.
       greater_than_or_equal_to: 1,
-      less_than_or_equal_to: 3,
+      less_than_or_equal_to: 4,
     }
   validate :validate_tier_level_changes
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -15,6 +15,7 @@ class Case < ApplicationRecord
   has_and_belongs_to_many :logs
   has_many :case_comments
   has_one :change_motd_request, required: false, autosave: true
+  has_one :change_request, required: false
 
   has_many :case_state_transitions
   alias_attribute :transitions, :case_state_transitions

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -136,8 +136,9 @@ class Case < ApplicationRecord
       case_state_transitions +
       audits +
       logs +
-      [ credit_charge ].compact
-    ).sort_by(&:created_at).reverse!
+      [ credit_charge ] +
+      change_request&.transitions
+    ).compact.sort_by(&:created_at).reverse!
   end
 
   def email_subject

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -88,6 +88,7 @@ class Case < ApplicationRecord
   validate :validates_user_assignment
 
   validate :validate_not_resolved_with_open_cr
+  validate :validate_cr_iff_tier_4
 
   after_initialize :assign_cluster_if_necessary
   after_initialize :generate_token, on: :create
@@ -342,6 +343,11 @@ class Case < ApplicationRecord
   def validate_not_resolved_with_open_cr
     error_condition = resolved? && change_request.present? && !change_request.finalised?
     errors.add(:state, 'cannot be resolved with an open change request') if error_condition
+  end
+
+  def validate_cr_iff_tier_4
+    error_condition = (tier_level == 4) != (change_request.present?)
+    errors.add(:change_request, 'must be present if and only if case is tier 4') if error_condition
   end
 
   def validate_minimum_credit_charge

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -88,7 +88,9 @@ class Case < ApplicationRecord
   validate :validates_user_assignment
 
   validate :validate_not_resolved_with_open_cr
-  validate :validate_cr_iff_tier_4
+  validates :change_request,
+            presence: { if: proc { |k| k.tier_level == 4 } },
+            absence: { unless: proc { |k| k.tier_level == 4 } }
 
   after_initialize :assign_cluster_if_necessary
   after_initialize :generate_token, on: :create
@@ -355,11 +357,6 @@ class Case < ApplicationRecord
   def validate_not_resolved_with_open_cr
     error_condition = resolved? && cr_in_progress?
     errors.add(:state, 'cannot be resolved with an open change request') if error_condition
-  end
-
-  def validate_cr_iff_tier_4
-    error_condition = (tier_level == 4) != (change_request.present?)
-    errors.add(:change_request, 'must be present if and only if case is tier 4') if error_condition
   end
 
   def validate_minimum_credit_charge

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -195,6 +195,10 @@ class Case < ApplicationRecord
     open? && !consultancy?
   end
 
+  def can_create_change_request
+    tier_level == 3 && change_request.nil?
+  end
+
   def potential_assignees
     site.users.where.not(role: :viewer)
       .or(User.where(role: :admin))

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -74,6 +74,7 @@ class Case < ApplicationRecord
 
   validates :credit_charge, presence: true,  if: :closed?
   validates_associated :credit_charge
+  validate :validate_minimum_credit_charge
 
   # Only validate this type of support is available on create, as this is the
   # only point at which we should prevent users accessing support they are not
@@ -341,6 +342,14 @@ class Case < ApplicationRecord
   def validate_not_resolved_with_open_cr
     error_condition = resolved? && change_request.present? && !change_request.finalised?
     errors.add(:state, 'cannot be resolved with an open change request') if error_condition
+  end
+
+  def validate_minimum_credit_charge
+    error_condition = closed? && change_request.present? && (
+      credit_charge.nil? || credit_charge < change_request.credit_charge
+    )
+
+    errors.add(:credit_charge, "cannot be less than attached CR charge of #{change_request.credit_charge}") if error_condition
   end
 
   def field_hash

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -251,6 +251,14 @@ class Case < ApplicationRecord
     !CaseCommenting.new(self, user).disabled?
   end
 
+  def cr_charge_applies?
+    change_request.present? && change_request.completed?
+  end
+
+  def minimum_credit_charge
+    cr_charge_applies? ? change_request.credit_charge : 0
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and
@@ -352,8 +360,7 @@ class Case < ApplicationRecord
 
   def validate_minimum_credit_charge
     error_condition = closed? &&
-                      change_request.present? &&
-                      change_request.completed? &&
+                      cr_charge_applies? &&
                       (
                         credit_charge.nil? ||
                         credit_charge.amount < change_request.credit_charge

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -200,7 +200,7 @@ class Case < ApplicationRecord
     open? && !consultancy?
   end
 
-  def can_create_change_request
+  def can_create_change_request?
     tier_level == 3 && change_request.nil?
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -15,7 +15,7 @@ class Case < ApplicationRecord
   has_and_belongs_to_many :logs
   has_many :case_comments
   has_one :change_motd_request, required: false, autosave: true
-  has_one :change_request, required: false
+  has_one :change_request, required: false, validate: true
 
   has_many :case_state_transitions
   alias_attribute :transitions, :case_state_transitions

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -351,9 +351,13 @@ class Case < ApplicationRecord
   end
 
   def validate_minimum_credit_charge
-    error_condition = closed? && change_request.present? && (
-      credit_charge.nil? || credit_charge.amount < change_request.credit_charge
-    )
+    error_condition = closed? &&
+                      change_request.present? &&
+                      change_request.completed? &&
+                      (
+                        credit_charge.nil? ||
+                        credit_charge.amount < change_request.credit_charge
+                      )
 
     errors.add(:credit_charge, "cannot be less than attached CR charge of #{change_request.credit_charge}") if error_condition
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -346,7 +346,7 @@ class Case < ApplicationRecord
 
   def validate_minimum_credit_charge
     error_condition = closed? && change_request.present? && (
-      credit_charge.nil? || credit_charge < change_request.credit_charge
+      credit_charge.nil? || credit_charge.amount < change_request.credit_charge
     )
 
     errors.add(:credit_charge, "cannot be less than attached CR charge of #{change_request.credit_charge}") if error_condition

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -259,6 +259,10 @@ class Case < ApplicationRecord
     cr_charge_applies? ? change_request.credit_charge : 0
   end
 
+  def cr_in_progress?
+    change_request.present? && !change_request.finalised?
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and
@@ -349,7 +353,7 @@ class Case < ApplicationRecord
   end
 
   def validate_not_resolved_with_open_cr
-    error_condition = resolved? && change_request.present? && !change_request.finalised?
+    error_condition = resolved? && cr_in_progress?
     errors.add(:state, 'cannot be resolved with an open change request') if error_condition
   end
 

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -1,6 +1,8 @@
 class ChangeRequest < ApplicationRecord
   belongs_to :case
 
+  delegate :site, to: :case
+
   state_machine initial: :draft do
     state :draft
     state :awaiting_authorisation

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -1,6 +1,9 @@
 class ChangeRequest < ApplicationRecord
   belongs_to :case
 
+  has_many :change_request_state_transitions
+  alias_attribute :transitions, :change_request_state_transitions
+
   delegate :site, to: :case
 
   after_create :ensure_case_is_tier_4

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -8,8 +8,6 @@ class ChangeRequest < ApplicationRecord
 
   delegate :site, to: :case
 
-  after_create :ensure_case_is_tier_4
-
   state_machine initial: :draft do
     audit_trail context: [:requesting_user], initial: false
 
@@ -45,11 +43,6 @@ class ChangeRequest < ApplicationRecord
 
   def requesting_user(transition)
     transition.args&.first
-  end
-
-  def ensure_case_is_tier_4
-    self.case.tier_level = 4
-    self.case.save!
   end
 
 end

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -3,6 +3,8 @@ class ChangeRequest < ApplicationRecord
 
   delegate :site, to: :case
 
+  after_create :ensure_case_is_tier_4
+
   state_machine initial: :draft do
     state :draft
     state :awaiting_authorisation
@@ -17,6 +19,13 @@ class ChangeRequest < ApplicationRecord
     event(:handover) { transition in_progress: :in_handover }
     event(:complete) { transition in_handover: :completed }
 
+  end
+
+  private
+
+  def ensure_case_is_tier_4
+    self.case.tier_level = 4
+    self.case.save!
   end
 
 end

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -37,6 +37,10 @@ class ChangeRequest < ApplicationRecord
 
   validates :description, presence: true
 
+  def finalised?
+    completed? || declined?
+  end
+
   private
 
   def requesting_user(transition)

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -1,0 +1,20 @@
+class ChangeRequest < ApplicationRecord
+  belongs_to :case
+
+  state_machine initial: :draft do
+    state :draft
+    state :awaiting_authorisation
+    state :declined
+    state :in_progress
+    state :in_handover
+    state :completed
+
+    event(:propose) { transition draft: :awaiting_authorisation }
+    event(:decline) { transition awaiting_authorisation: :declined }
+    event(:authorise) { transition awaiting_authorisation: :in_progress }
+    event(:handover) { transition in_progress: :in_handover }
+    event(:complete) { transition in_handover: :completed }
+
+  end
+
+end

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -28,6 +28,8 @@ class ChangeRequest < ApplicationRecord
                 minimum: 0
             }
 
+  validates :details, presence: true
+
   private
 
   def ensure_case_is_tier_4

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -1,4 +1,6 @@
 class ChangeRequest < ApplicationRecord
+  include MarkdownDescription
+
   belongs_to :case
 
   has_many :change_request_state_transitions
@@ -33,7 +35,7 @@ class ChangeRequest < ApplicationRecord
                 minimum: 0
             }
 
-  validates :details, presence: true
+  validates :description, presence: true
 
   private
 

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -6,6 +6,8 @@ class ChangeRequest < ApplicationRecord
   after_create :ensure_case_is_tier_4
 
   state_machine initial: :draft do
+    audit_trail context: [:requesting_user], initial: false
+
     state :draft
     state :awaiting_authorisation
     state :declined
@@ -31,6 +33,10 @@ class ChangeRequest < ApplicationRecord
   validates :details, presence: true
 
   private
+
+  def requesting_user(transition)
+    transition.args&.first
+  end
 
   def ensure_case_is_tier_4
     self.case.tier_level = 4

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -21,6 +21,13 @@ class ChangeRequest < ApplicationRecord
 
   end
 
+  validates :credit_charge,
+            presence: true,
+            numericality: {
+                only_integer: true,
+                minimum: 0
+            }
+
   private
 
   def ensure_case_is_tier_4

--- a/app/models/change_request_state_transition.rb
+++ b/app/models/change_request_state_transition.rb
@@ -5,4 +5,18 @@ class ChangeRequestStateTransition < ApplicationRecord
   delegate :site, to: :change_request
 
   alias_attribute :requesting_user, :user
+
+  validates_presence_of :user
+  validate :validate_user_can_initiate
+
+  private
+
+  def validate_user_can_initiate
+    case event&.to_sym
+    when :propose, :handover
+      errors.add(:user, 'must be an admin') unless user&.admin?
+    when :authorise, :decline, :complete
+      errors.add(:user, 'must not be an admin') if user&.admin?
+    end
+  end
 end

--- a/app/models/change_request_state_transition.rb
+++ b/app/models/change_request_state_transition.rb
@@ -2,5 +2,7 @@ class ChangeRequestStateTransition < ApplicationRecord
   belongs_to :change_request
   belongs_to :user
 
+  delegate :site, to: :change_request
+
   alias_attribute :requesting_user, :user
 end

--- a/app/models/change_request_state_transition.rb
+++ b/app/models/change_request_state_transition.rb
@@ -16,7 +16,7 @@ class ChangeRequestStateTransition < ApplicationRecord
     when :propose, :handover
       errors.add(:user, 'must be an admin') unless user&.admin?
     when :authorise, :decline, :complete
-      errors.add(:user, 'must not be an admin') if user&.admin?
+      errors.add(:user, 'must be a contact') unless user&.contact?
     end
   end
 end

--- a/app/models/change_request_state_transition.rb
+++ b/app/models/change_request_state_transition.rb
@@ -1,0 +1,6 @@
+class ChangeRequestStateTransition < ApplicationRecord
+  belongs_to :change_request
+  belongs_to :user
+
+  alias_attribute :requesting_user, :user
+end

--- a/app/policies/change_request_policy.rb
+++ b/app/policies/change_request_policy.rb
@@ -1,0 +1,15 @@
+class ChangeRequestPolicy < ApplicationPolicy
+
+  alias_method :propose?, :admin?
+  alias_method :handover?, :admin?
+
+  alias_method :authorise?, :contact?
+  alias_method :decline?, :contact?
+  alias_method :complete?, :contact?
+
+  class Scope < Scope
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/change_request_policy.rb
+++ b/app/policies/change_request_policy.rb
@@ -1,5 +1,8 @@
 class ChangeRequestPolicy < ApplicationPolicy
 
+  alias_method :create?, :admin?
+  alias_method :edit?, :admin?
+  alias_method :update?, :admin?
   alias_method :propose?, :admin?
   alias_method :handover?, :admin?
 

--- a/app/views/case_mailer/change_request.html.erb
+++ b/app/views/case_mailer/change_request.html.erb
@@ -1,0 +1,3 @@
+<h3><%= @case.display_id %> <%= @case.ticket_subject %></h3>
+
+<p>The change request for this case <%= @text %></p>

--- a/app/views/case_mailer/change_request.text.erb
+++ b/app/views/case_mailer/change_request.text.erb
@@ -1,0 +1,3 @@
+<%= @case.display_id %> <%= @case.ticket_subject %>
+
+The change request for this case <%= @text %>

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -11,7 +11,7 @@
                     confirm: 'Are you sure you want to resolve this support case?'
                 }
     %>
-  <% elsif @case.open? && !@case.change_request&.finalised? %>
+  <% elsif @case.open? && @case.cr_in_progress? %>
     <p class="small">This case cannot be resolved as the change request is incomplete.</p>
   <% end %>
 <% end %>

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -1,16 +1,21 @@
 
-<% if policy(@case).resolve? && @case.can_resolve? %>
-  <%= link_to 'Resolve this case',
-              resolve_case_path(@case.id),
-              class: 'btn btn-secondary ml-2 btn-sm',
-              method: :post,
-              role: 'button',
-              title: 'Resolve this support case if it has been completed or is no longer relevant',
-              data: {
-                  confirm: 'Are you sure you want to resolve this support case?'
-              }
-  %>
+<% if policy(@case).resolve? %>
+  <% if @case.resolvable? %>
+    <%= link_to 'Resolve this case',
+                resolve_case_path(@case.id),
+                class: 'btn btn-secondary ml-2 btn-sm',
+                method: :post,
+                role: 'button',
+                title: 'Resolve this support case if it has been completed or is no longer relevant',
+                data: {
+                    confirm: 'Are you sure you want to resolve this support case?'
+                }
+    %>
+  <% elsif @case.open? && !@case.change_request&.finalised? %>
+    <p class="small">This case cannot be resolved as the change request is incomplete.</p>
+  <% end %>
 <% end %>
+
 <% if policy(@case).close? && @case.can_close? %>
   <%= form_tag({controller: 'cases', action: 'close'},
                method: :post,

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -22,7 +22,7 @@
                class: 'form-inline',
                id: 'case-close-form'
       ) do %>
-      <% if @case.change_request.present? %>
+      <% if @case.cr_charge_applies? %>
         <p class="small">
           Charge below should include <%= pluralize(@case.change_request.credit_charge, 'credit') %> from attached CR
         </p>
@@ -32,9 +32,9 @@
           <%= number_field :credit_charge,
                            :amount,
                            class: 'form-control',
-                           min: 0,
+                           min: @case.minimum_credit_charge,
                            required: 'required',
-                           value: @case.change_request&.credit_charge
+                           value: @case.minimum_credit_charge
         %>
         <div class="input-group-append">
           <%= submit_tag 'Set charge and close case',

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -22,14 +22,19 @@
                class: 'form-inline',
                id: 'case-close-form'
       ) do %>
-    <div class="form-group">
-      <div class="input-group">
-        <%= number_field :credit_charge,
-                         :amount,
-                         class: 'form-control',
-                         min: 0,
-                         value: 0,
-                         required: 'required'
+      <% if @case.change_request.present? %>
+        <p class="small">
+          Charge below should include <%= pluralize(@case.change_request.credit_charge, 'credit') %> from attached CR
+        </p>
+      <% end %>
+      <div class="form-group">
+        <div class="input-group">
+          <%= number_field :credit_charge,
+                           :amount,
+                           class: 'form-control',
+                           min: 0,
+                           required: 'required',
+                           value: @case.change_request&.credit_charge
         %>
         <div class="input-group-append">
           <%= submit_tag 'Set charge and close case',

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -1,11 +1,4 @@
 
-<%#
-  This is the same logic as `Case#comments_could_be_enabled?` although the
-  purpose is different - possibly there's some underlying shared concept for
-  when both these should be toggled that we should extract? Not sure if this is
-  just conincidental though and they could later independently change, which is
-  why I've not done this yet.
-%>
 <% if @case.open? %>
   <% if @case.tier_level < 3 %>
     <%

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -64,7 +64,7 @@
         </div>
       </div>
     </div>
-  <% elsif @case.can_create_change_request && current_user.admin? %>
+  <% elsif @case.can_create_change_request? && current_user.admin? %>
     <%= link_to 'Create change request',
                 new_cluster_case_change_request_path(@case.cluster.id, @case.display_id),
                 class: 'btn btn-sm btn-warning',

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -66,7 +66,7 @@
     </div>
   <% elsif @case.can_create_change_request && current_user.admin? %>
     <%= link_to 'Create change request',
-                new_case_change_request_path(@case.id),
+                new_cluster_case_change_request_path(@case.cluster.id, @case.display_id),
                 class: 'btn btn-sm btn-warning',
                 id: 'create-cr-button',
                 role: 'button'

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -6,62 +6,70 @@
   just conincidental though and they could later independently change, which is
   why I've not done this yet.
 %>
-<% if @case.open? && !@case.consultancy? %>
-  <%
-      modal_id = 'escalateModal'
-      modal_label = 'escalateModalLabel'
-  %>
+<% if @case.open? %>
+  <% if @case.tier_level < 3 %>
+    <%
+        modal_id = 'escalateModal'
+        modal_label = 'escalateModalLabel'
+    %>
 
-  <%= button_tag 'Escalate',
-    PolicyDependentOptions.wrap(
-      {
-        class: "btn btn-warning btn-sm ml-2",
-        data: {
-          toggle: 'modal',
-          target: "##{modal_id}",
+    <%= button_tag 'Escalate',
+      PolicyDependentOptions.wrap(
+        {
+          class: "btn btn-warning btn-sm ml-2",
+          data: {
+            toggle: 'modal',
+            target: "##{modal_id}",
+          },
         },
-      },
-      policy: policy(@case).escalate?,
-      action_description: 'escalate a case',
-      user: current_user
-  )
-  %>
+        policy: policy(@case).escalate?,
+        action_description: 'escalate a case',
+        user: current_user
+    )
+    %>
 
-  <div
-    class="modal fade"
-    id="<%= modal_id %>"
-    tabindex="-1"
-    role="dialog"
-    aria-labelledby="<%= modal_label %>"
-    aria-hidden="true"
-  >
-    <div class="modal-dialog modal-dialog-centered" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="<%= modal_label %>">
-            Escalating this support case may incur charges
-          </h5>
-          <button class="close" data-dismiss="modal">×</button>
-        </div>
-        <div class="modal-body">
-          <p>Escalating a support case means that the case becomes potentially
-            chargeable, and may incur a charge of support credits.</p>
-          <p>Do you wish to continue?</p>
-        </div>
-        <div class="modal-footer">
-          <button class="btn btn-outline-primary" data-dismiss="modal">
-            Cancel
-          </button>
-          <%= link_to 'Escalate',
-                      escalate_case_path(@case.id),
-                      class: 'btn btn-outline-warning',
-                      id: 'confirm-escalate-button',
-                      method: :post,
-                      role: 'button'
-          %>
+    <div
+      class="modal fade"
+      id="<%= modal_id %>"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="<%= modal_label %>"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="<%= modal_label %>">
+              Escalating this support case may incur charges
+            </h5>
+            <button class="close" data-dismiss="modal">×</button>
+          </div>
+          <div class="modal-body">
+            <p>Escalating a support case means that the case becomes potentially
+              chargeable, and may incur a charge of support credits.</p>
+            <p>Do you wish to continue?</p>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-outline-primary" data-dismiss="modal">
+              Cancel
+            </button>
+            <%= link_to 'Escalate',
+                        escalate_case_path(@case.id),
+                        class: 'btn btn-outline-warning',
+                        id: 'confirm-escalate-button',
+                        method: :post,
+                        role: 'button'
+            %>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
+  <% elsif @case.can_create_change_request && current_user.admin? %>
+    <%= link_to 'Create change request',
+                new_case_change_request_path(@case.id),
+                class: 'btn btn-sm btn-warning',
+                id: 'create-cr-button',
+                role: 'button'
+    %>
+  <% end %>
 <% end %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -3,6 +3,28 @@
 <%= render 'partials/tabs', activate: :cases do %>
   <div class='table-responsive'>
     <table class="table case-table">
+      <% if @case.change_request.present? %>
+        <% verb = @case.change_request.draft? && current_user.admin? ? 'View / Edit' : 'View' %>
+        <tr>
+          <td colspan="4">
+            <div class="alert alert-info alert-cr-info">
+              <span>
+                This case has an attached change request.
+              </span>
+
+              <span>
+                CR state: <b><%= @case.change_request.state.titleize %></b>
+              </span>
+
+              <%= link_to verb,
+                          case_change_request_path(@case.change_request),
+                          class: 'btn btn-primary',
+                          role: 'button'
+              %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
       <tr style="width: 100%;">
         <th>Created</th>
         <td>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -8,6 +8,7 @@
         <tr>
           <td colspan="4">
             <div class="alert alert-info alert-cr-info">
+              <i class="fa fa-2x fa-paperclip mr-2" aria-hidden="true"></i>
               <span>
                 This case has an attached change request.
               </span>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -14,7 +14,7 @@
               </span>
 
               <span>
-                CR state: <b><%= @case.change_request.state.titleize %></b>
+                CR state: <b><%= @case.change_request.user_facing_state %></b>
               </span>
 
               <%= link_to verb,

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -18,7 +18,7 @@
               </span>
 
               <%= link_to verb,
-                          cluster_case_change_request_path(@case.cluster, @case, @case.change_request),
+                          cluster_case_change_request_path(@case.cluster, @case),
                           class: 'btn btn-primary',
                           role: 'button'
               %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -17,7 +17,7 @@
               </span>
 
               <%= link_to verb,
-                          case_change_request_path(@case.change_request),
+                          cluster_case_change_request_path(@case.cluster, @case, @case.change_request),
                           class: 'btn btn-primary',
                           role: 'button'
               %>

--- a/app/views/change_requests/_form.html.erb
+++ b/app/views/change_requests/_form.html.erb
@@ -2,7 +2,8 @@
   <div class="form-group row">
     <label class="col-sm-3 col-form-label" for="change_request_details">
       Describe this change in as much detail as possible. Include proposed changes,
-      prerequisites, dependencies and relevant technical information.
+      prerequisites, dependencies and relevant technical information. You can
+      use Markdown to format your text.
     </label>
     <div class="col-sm-9">
       <%= f.text_area :description, rows: 15, class: 'form-control' %>

--- a/app/views/change_requests/_form.html.erb
+++ b/app/views/change_requests/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_for @cr, url: {action: action}, html: {class: 'form'} do |f| %>
+  <div class="form-group row">
+    <label class="col-sm-3 col-form-label" for="change_request_details">
+      Describe this change in as much detail as possible. Include proposed changes,
+      prerequisites, dependencies and relevant technical information.
+    </label>
+    <div class="col-sm-9">
+      <%= f.text_area :description, rows: 15, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <label class="col-sm-3 col-form-label" for="change_request_credit_charge">
+      Credit charge for this CR:
+    </label>
+    <div class="col-sm-9">
+      <%= f.number_field :credit_charge, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <%= yield %>
+    <div class="col-sm-3">
+      <%= f.submit submit_text, class: 'btn btn-primary form-control' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/change_requests/_form.html.erb
+++ b/app/views/change_requests/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @cr, url: {action: action}, html: {class: 'form'} do |f| %>
+<%= form_for cr, url: {action: action}, html: {class: 'form'} do |f| %>
   <div class="form-group row">
     <label class="col-sm-3 col-form-label" for="change_request_details">
       Describe this change in as much detail as possible. Include proposed changes,

--- a/app/views/change_requests/edit.html.erb
+++ b/app/views/change_requests/edit.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:subtitle) { "Edit change request for case #{@case.display_id}" } %>
+
+<h2>Editing change request for <%= @case.display_id %>: <%= @case.subject %></h2>
+
+<%= render 'change_requests/form', action: :update, submit_text: 'Save' %>

--- a/app/views/change_requests/edit.html.erb
+++ b/app/views/change_requests/edit.html.erb
@@ -2,4 +2,4 @@
 
 <h2>Editing change request for <%= @case.display_id %>: <%= @case.subject %></h2>
 
-<%= render 'change_requests/form', action: :update, submit_text: 'Save' %>
+<%= render 'change_requests/form', action: :update, cr: cr, submit_text: 'Save' %>

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -2,7 +2,7 @@
 
 <h2>New change request for <%= @case.display_id %>: <%= @case.subject %></h2>
 
-<%= render 'change_requests/form', action: :create, submit_text: 'Create' do %>
+<%= render 'change_requests/form', action: :create, cr: cr, submit_text: 'Create' do %>
   <div class="alert alert-info col-sm-9">
     <i class="fa fa-info-circle fa-2x float-left mr-2" aria-hidden="true"></i>
     Creating this CR will escalate the associated case to support tier 4.

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -26,11 +26,11 @@
     <div class="alert alert-info col-sm-9">
       <i class="fa fa-info-circle fa-2x float-left mr-2" aria-hidden="true"></i>
       Creating this CR will escalate the associated case to support tier 4.
-      You'll be able to edit this CR further once it has been created, before it
-      is sent to the customer for authorisation.
+      Once created, you will have the opportunity to edit these details again
+      before the CR is sent to the customer for authorisation.
     </div>
     <div class="col-sm-3">
-      <%= f.submit "Create", class: 'btn btn-primary' %>
+      <%= f.submit "Create", class: 'btn btn-primary form-control' %>
     </div>
   </div>
 <% end %>

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -1,1 +1,25 @@
 <% content_for(:subtitle) { "Create new change request for case #{@case.display_id}" } %>
+
+<h2>New change request for <%= @case.display_id %>: <%= @case.subject %></h2>
+
+<%= form_for @cr, url: {action: :create}, html: {class: 'form'} do |f| %>
+  <div class="form-group row">
+    <label class="col-sm-3 col-form-label" for="change_request_details">
+      Describe this change in as much detail as possible. Include proposed changes,
+      prerequisites, dependencies and relevant technical information.
+    </label>
+    <div class="col-sm-9">
+      <%= f.text_area :details, rows: 15, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <label class="col-sm-3 col-form-label" for="change_request_credit_charge">
+      Credit charge for this CR:
+    </label>
+    <div class="col-sm-9">
+      <%= f.number_field :credit_charge, class: 'form-control' %>
+    </div>
+  </div>
+  <%= f.submit "Create", class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -21,5 +21,16 @@
       <%= f.number_field :credit_charge, class: 'form-control' %>
     </div>
   </div>
-  <%= f.submit "Create", class: 'btn btn-primary' %>
+
+  <div class="form-group row">
+    <div class="alert alert-info col-sm-9">
+      <i class="fa fa-info-circle fa-2x float-left mr-2" aria-hidden="true"></i>
+      Creating this CR will escalate the associated case to support tier 4.
+      You'll be able to edit this CR further once it has been created, before it
+      is sent to the customer for authorisation.
+    </div>
+    <div class="col-sm-3">
+      <%= f.submit "Create", class: 'btn btn-primary' %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -9,7 +9,7 @@
       prerequisites, dependencies and relevant technical information.
     </label>
     <div class="col-sm-9">
-      <%= f.text_area :details, rows: 15, class: 'form-control' %>
+      <%= f.text_area :description, rows: 15, class: 'form-control' %>
     </div>
   </div>
 

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -1,0 +1,1 @@
+<% content_for(:subtitle) { "Create new change request for case #{@case.display_id}" } %>

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -2,35 +2,11 @@
 
 <h2>New change request for <%= @case.display_id %>: <%= @case.subject %></h2>
 
-<%= form_for @cr, url: {action: :create}, html: {class: 'form'} do |f| %>
-  <div class="form-group row">
-    <label class="col-sm-3 col-form-label" for="change_request_details">
-      Describe this change in as much detail as possible. Include proposed changes,
-      prerequisites, dependencies and relevant technical information.
-    </label>
-    <div class="col-sm-9">
-      <%= f.text_area :description, rows: 15, class: 'form-control' %>
-    </div>
-  </div>
-
-  <div class="form-group row">
-    <label class="col-sm-3 col-form-label" for="change_request_credit_charge">
-      Credit charge for this CR:
-    </label>
-    <div class="col-sm-9">
-      <%= f.number_field :credit_charge, class: 'form-control' %>
-    </div>
-  </div>
-
-  <div class="form-group row">
-    <div class="alert alert-info col-sm-9">
-      <i class="fa fa-info-circle fa-2x float-left mr-2" aria-hidden="true"></i>
-      Creating this CR will escalate the associated case to support tier 4.
-      Once created, you will have the opportunity to edit these details again
-      before the CR is sent to the customer for authorisation.
-    </div>
-    <div class="col-sm-3">
-      <%= f.submit "Create", class: 'btn btn-primary form-control' %>
-    </div>
+<%= render 'change_requests/form', action: :create, submit_text: 'Create' do %>
+  <div class="alert alert-info col-sm-9">
+    <i class="fa fa-info-circle fa-2x float-left mr-2" aria-hidden="true"></i>
+    Creating this CR will escalate the associated case to support tier 4.
+    Once created, you will have the opportunity to edit these details again
+    before the CR is sent to the customer for authorisation.
   </div>
 <% end %>

--- a/app/views/change_requests/show.html.erb
+++ b/app/views/change_requests/show.html.erb
@@ -1,0 +1,45 @@
+<% content_for(:subtitle) { "Change request for #{@case.display_id}: #{@case.subject}" } %>
+<div class="card">
+  <div class="card-body row">
+    <div class="col-12">
+      <a name="cr-top"></a>
+      <h2>Change request <%= @case.display_id %>: <%= @case.subject %></h2>
+    </div>
+    <div class="col-sm-12">
+      <div class="card-deck mb-2">
+        <div class="card">
+          <div class="card-body">
+            <table class="table">
+              <tr>
+                <th>State</th>
+                <td><%= @cr.user_facing_state %></td>
+              </tr>
+              <tr>
+                <th>Credit charge</th>
+                <td><%= pluralize(@cr.credit_charge, 'credit') %></td>
+              </tr>
+            </table>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-body">
+            <%= render "change_requests/state_controls/#{@cr.state}", cr: @cr %>
+            <hr />
+            <%=
+              link_to 'Return to case',
+                      cluster_case_path(@case.cluster, @case),
+                      class: 'btn btn-primary form-control',
+                      role: 'button'
+            %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-12">
+      <h3>Details</h3>
+      <%= @cr.details %>
+      <hr />
+      <a href="#cr-top">Back to top</a>
+    </div>
+  </div>
+</div>

--- a/app/views/change_requests/show.html.erb
+++ b/app/views/change_requests/show.html.erb
@@ -12,18 +12,18 @@
             <table class="table">
               <tr>
                 <th>State</th>
-                <td><%= @cr.user_facing_state %></td>
+                <td><%= cr.user_facing_state %></td>
               </tr>
               <tr>
                 <th>Credit charge</th>
-                <td><%= pluralize(@cr.credit_charge, 'credit') %></td>
+                <td><%= pluralize(cr.credit_charge, 'credit') %></td>
               </tr>
             </table>
           </div>
         </div>
         <div class="card">
           <div class="card-body state-controls">
-            <%= render "change_requests/state_controls/#{@cr.state}", cr: @cr %>
+            <%= render "change_requests/state_controls/#{cr.state}", cr: cr %>
             <hr />
             <%=
               link_to 'Return to case',
@@ -37,7 +37,7 @@
     </div>
     <div class="col-12">
       <h3>Details</h3>
-      <%= @cr.rendered_description.html_safe %>
+      <%= cr.rendered_description.html_safe %>
       <hr />
       <a href="#cr-top">Back to top</a>
     </div>

--- a/app/views/change_requests/show.html.erb
+++ b/app/views/change_requests/show.html.erb
@@ -37,7 +37,7 @@
     </div>
     <div class="col-12">
       <h3>Details</h3>
-      <%= @cr.details %>
+      <%= @cr.rendered_description.html_safe %>
       <hr />
       <a href="#cr-top">Back to top</a>
     </div>

--- a/app/views/change_requests/show.html.erb
+++ b/app/views/change_requests/show.html.erb
@@ -22,7 +22,7 @@
           </div>
         </div>
         <div class="card">
-          <div class="card-body">
+          <div class="card-body state-controls">
             <%= render "change_requests/state_controls/#{@cr.state}", cr: @cr %>
             <hr />
             <%=

--- a/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
+++ b/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
@@ -1,0 +1,26 @@
+<% if current_user.admin? %>
+  <p>
+    This change request is awaiting authorisation from the customer.
+  </p>
+<% else %>
+  <%= link_to 'Authorise',
+              authorise_case_change_request_path(cr.case, cr),
+              class: 'btn btn-success form-control mb-2',
+              data: {
+                  confirm: 'Are you sure you want to authorise this change request?'
+              },
+              method: 'post',
+              role: 'button'
+  %>
+  <%= link_to 'Decline',
+              decline_case_change_request_path(cr.case, cr),
+              class: 'btn btn-danger form-control',
+              data: {
+                  confirm: 'Are you sure you want to decline this change
+                            request? You may still be charged for work carried
+                            out up to this point.'.squish
+              },
+              method: 'post',
+              role: 'button'
+  %>
+<% end %>

--- a/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
+++ b/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
@@ -4,7 +4,7 @@
   </p>
 <% else %>
   <%= link_to 'Authorise',
-              authorise_case_change_request_path(cr.case, cr),
+              authorise_case_change_request_path(cr.case),
               class: 'btn btn-success form-control mb-2',
               data: {
                   confirm: 'Are you sure you want to authorise this change request?'
@@ -13,7 +13,7 @@
               role: 'button'
   %>
   <%= link_to 'Decline',
-              decline_case_change_request_path(cr.case, cr),
+              decline_case_change_request_path(cr.case),
               class: 'btn btn-danger form-control',
               data: {
                   confirm: 'Are you sure you want to decline this change

--- a/app/views/change_requests/state_controls/_completed.html.erb
+++ b/app/views/change_requests/state_controls/_completed.html.erb
@@ -1,0 +1,3 @@
+<p>
+  This change request has been completed.
+</p>

--- a/app/views/change_requests/state_controls/_declined.html.erb
+++ b/app/views/change_requests/state_controls/_declined.html.erb
@@ -1,0 +1,3 @@
+<p>
+  This change request has been declined.
+</p>

--- a/app/views/change_requests/state_controls/_draft.html.erb
+++ b/app/views/change_requests/state_controls/_draft.html.erb
@@ -1,11 +1,11 @@
 <% if current_user.admin? %>
   <%= link_to 'Edit',
-              edit_cluster_case_change_request_path(cr.case.cluster, cr.case, cr),
+              edit_cluster_case_change_request_path(cr.case.cluster, cr.case),
               class: 'btn btn-primary form-control mb-2',
               role: 'button'
   %>
   <%= link_to 'Submit for authorisation',
-              propose_case_change_request_path(cr.case, cr),
+              propose_case_change_request_path(cr.case),
               class: 'btn btn-danger form-control',
               data: {
                   confirm: 'Are you sure you want to finalise this CR and submit

--- a/app/views/change_requests/state_controls/_draft.html.erb
+++ b/app/views/change_requests/state_controls/_draft.html.erb
@@ -1,0 +1,22 @@
+<% if current_user.admin? %>
+  <%= link_to 'Edit',
+              edit_cluster_case_change_request_path(cr.case.cluster, cr.case, cr),
+              class: 'btn btn-primary form-control mb-2',
+              role: 'button'
+  %>
+  <%= link_to 'Submit for authorisation',
+              edit_cluster_case_change_request_path(cr.case.cluster, cr.case, cr),
+              class: 'btn btn-danger form-control',
+              role: 'button',
+              data: {
+                  confirm: 'Are you sure you want to finalise this CR and submit
+                  it for customer authorization? You will not be able to make
+                  further changes once you have done so.'.squish
+              }
+  %>
+<% else %>
+<p>
+  This CR is in draft. When it has been completed you will be able to authorize or
+  decline it.
+</p>
+<% end %>

--- a/app/views/change_requests/state_controls/_draft.html.erb
+++ b/app/views/change_requests/state_controls/_draft.html.erb
@@ -5,14 +5,15 @@
               role: 'button'
   %>
   <%= link_to 'Submit for authorisation',
-              edit_cluster_case_change_request_path(cr.case.cluster, cr.case, cr),
+              propose_case_change_request_path(cr.case, cr),
               class: 'btn btn-danger form-control',
-              role: 'button',
               data: {
                   confirm: 'Are you sure you want to finalise this CR and submit
                   it for customer authorization? You will not be able to make
                   further changes once you have done so.'.squish
-              }
+              },
+              method: 'post',
+              role: 'button'
   %>
 <% else %>
 <p>

--- a/app/views/change_requests/state_controls/_in_handover.html.erb
+++ b/app/views/change_requests/state_controls/_in_handover.html.erb
@@ -1,0 +1,15 @@
+<% if current_user.admin? %>
+  <p>
+    This change request is awaiting customer approval.
+  </p>
+<% else %>
+  <%= link_to 'Approve work and close CR',
+              complete_case_change_request_path(cr.case, cr),
+              class: 'btn btn-success form-control mb-2',
+              data: {
+                  confirm: 'Are you sure you want to approve and close this change request?'
+              },
+              method: 'post',
+              role: 'button'
+  %>
+<% end %>

--- a/app/views/change_requests/state_controls/_in_handover.html.erb
+++ b/app/views/change_requests/state_controls/_in_handover.html.erb
@@ -4,7 +4,7 @@
   </p>
 <% else %>
   <%= link_to 'Approve work and close CR',
-              complete_case_change_request_path(cr.case, cr),
+              complete_case_change_request_path(cr.case),
               class: 'btn btn-success form-control mb-2',
               data: {
                   confirm: 'Are you sure you want to approve and close this change request?'

--- a/app/views/change_requests/state_controls/_in_progress.html.erb
+++ b/app/views/change_requests/state_controls/_in_progress.html.erb
@@ -1,6 +1,6 @@
 <% if current_user.admin? %>
   <%= link_to 'Begin handover',
-              handover_case_change_request_path(cr.case, cr),
+              handover_case_change_request_path(cr.case),
               class: 'btn btn-danger form-control mb-2',
               data: {
                   confirm: 'Are you sure you want to mark work on this CR as complete?'

--- a/app/views/change_requests/state_controls/_in_progress.html.erb
+++ b/app/views/change_requests/state_controls/_in_progress.html.erb
@@ -1,0 +1,16 @@
+<% if current_user.admin? %>
+  <%= link_to 'Begin handover',
+              handover_case_change_request_path(cr.case, cr),
+              class: 'btn btn-danger form-control mb-2',
+              data: {
+                  confirm: 'Are you sure you want to mark work on this CR as complete?'
+              },
+              method: 'post',
+              role: 'button'
+  %>
+<% else %>
+  <p>
+    This change request is in progress. When work is complete you will be able
+    to complete the handover process.
+  </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,9 @@ Rails.application.routes.draw do
       collection do
         get :resolved
       end
+      resource :change_request, only: [:show] do
+        # We'll want some more routes here soon™
+      end
       block.call if block
     end
   end
@@ -105,6 +108,7 @@ Rails.application.routes.draw do
         post :set_time
         post :set_commenting
       end
+      resource :change_request, only: [:new, :create, :edit]
     end
 
     resources :change_motd_requests, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,17 @@ Rails.application.routes.draw do
     delete :logout, to: 'sso_sessions#destroy'
   end
 
+  constraints(Clearance::Constraints::SignedIn.new { |user| !user.admin? }) do
+    resources :cases, only: [] do
+      resource :change_request, only: [] do
+        member do
+          post :authorise
+          post :decline
+        end
+      end
+    end
+  end
+
   constraints Clearance::Constraints::SignedIn.new do
     root 'sites#show'
     delete '/sign_out' => 'sso_sessions#destroy', as: 'sign_out'  # Keeping this one around as it's correctly coupled to SSO
@@ -172,13 +183,6 @@ Rails.application.routes.draw do
       resources :case_comments, only: :create
       member do
         post :escalate
-      end
-
-      resource :change_request, only: [] do
-        member do
-          post :authorise
-          post :decline
-        end
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,7 @@ Rails.application.routes.draw do
         post :set_time
         post :set_commenting
       end
-      resource :change_request, only: [:new, :create, :edit, :update] do
+      resource :change_request, only: [:new, :create, :edit, :update], path: 'change-request' do
         member do
           post :propose
           post :handover
@@ -125,7 +125,7 @@ Rails.application.routes.draw do
       notes.call(true)
       post :deposit
       cases.call do
-        resource :change_request, only: [:new, :create, :edit]
+        resource :change_request, only: [:new, :create, :edit], path: 'change-request'
       end
     end
 
@@ -171,7 +171,7 @@ Rails.application.routes.draw do
       member do
         post :escalate
       end
-      resource :change_request, only: [:show] do
+      resource :change_request, only: [:show], path: 'change-request' do
         member do
           post :authorise
           post :decline
@@ -182,7 +182,7 @@ Rails.application.routes.draw do
 
     resources :clusters, only: :show do
       cases.call do
-        resource :change_request, only: [:show]
+        resource :change_request, only: [:show], path: 'change-request'
       end
       resources :services, only: :index
       maintenance_windows.call

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,9 @@ Rails.application.routes.draw do
       admin_logs.call
       notes.call(true)
       post :deposit
+      cases.call do
+        resource :change_request, only: [:new, :create, :edit]
+      end
     end
 
     resources :components, only: []  do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,7 @@ Rails.application.routes.draw do
         member do
           post :authorise
           post :decline
+          post :complete
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,7 @@ Rails.application.routes.draw do
         post :set_time
         post :set_commenting
       end
-      resource :change_request, only: [:new, :create, :edit] do
+      resource :change_request, only: [:new, :create, :edit, :update] do
         member do
           post :propose
           post :handover

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,6 +173,13 @@ Rails.application.routes.draw do
       member do
         post :escalate
       end
+
+      resource :change_request, only: [] do
+        member do
+          post :authorise
+          post :decline
+        end
+      end
     end
 
     resources :clusters, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,9 +84,6 @@ Rails.application.routes.draw do
       collection do
         get :resolved
       end
-      resource :change_request, only: [:show] do
-        # We'll want some more routes here soon™
-      end
       block.call if block
     end
   end
@@ -167,7 +164,7 @@ Rails.application.routes.draw do
 
   constraints(Clearance::Constraints::SignedIn.new { |user| !user.admin? }) do
     resources :cases, only: [] do
-      resource :change_request, only: [] do
+      resource :change_request, only: [:show] do
         member do
           post :authorise
           post :decline
@@ -189,7 +186,9 @@ Rails.application.routes.draw do
     end
 
     resources :clusters, only: :show do
-      cases.call
+      cases.call do
+        resource :change_request, only: [:show]
+      end
       resources :services, only: :index
       maintenance_windows.call
       resources :components, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,18 +162,6 @@ Rails.application.routes.draw do
     delete :logout, to: 'sso_sessions#destroy'
   end
 
-  constraints(Clearance::Constraints::SignedIn.new { |user| !user.admin? }) do
-    resources :cases, only: [] do
-      resource :change_request, only: [:show] do
-        member do
-          post :authorise
-          post :decline
-          post :complete
-        end
-      end
-    end
-  end
-
   constraints Clearance::Constraints::SignedIn.new do
     root 'sites#show'
     delete '/sign_out' => 'sso_sessions#destroy', as: 'sign_out'  # Keeping this one around as it's correctly coupled to SSO
@@ -182,6 +170,13 @@ Rails.application.routes.draw do
       resources :case_comments, only: :create
       member do
         post :escalate
+      end
+      resource :change_request, only: [:show] do
+        member do
+          post :authorise
+          post :decline
+          post :complete
+        end
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
       resource :change_request, only: [:new, :create, :edit] do
         member do
           post :propose
+          post :handover
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,11 @@ Rails.application.routes.draw do
         post :set_time
         post :set_commenting
       end
-      resource :change_request, only: [:new, :create, :edit]
+      resource :change_request, only: [:new, :create, :edit] do
+        member do
+          post :propose
+        end
+      end
     end
 
     resources :change_motd_requests, only: [] do

--- a/db/migrate/20180605163528_create_change_requests.rb
+++ b/db/migrate/20180605163528_create_change_requests.rb
@@ -1,0 +1,12 @@
+class CreateChangeRequests < ActiveRecord::Migration[5.2]
+  def change
+    create_table :change_requests do |t|
+      t.references :case, foreign_key: true
+      t.string :state, default: 'draft', null: false
+      t.string :details, null: false
+      t.integer :credit_charge, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180605163528_create_change_requests.rb
+++ b/db/migrate/20180605163528_create_change_requests.rb
@@ -3,7 +3,7 @@ class CreateChangeRequests < ActiveRecord::Migration[5.2]
     create_table :change_requests do |t|
       t.references :case, foreign_key: true
       t.string :state, default: 'draft', null: false
-      t.string :details, null: false
+      t.string :description, null: false
       t.integer :credit_charge, null: false
 
       t.timestamps

--- a/db/migrate/20180606172635_create_change_request_state_transitions.rb
+++ b/db/migrate/20180606172635_create_change_request_state_transitions.rb
@@ -1,0 +1,15 @@
+class CreateChangeRequestStateTransitions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :change_request_state_transitions do |t|
+      t.references :change_request, foreign_key: true
+      t.string :namespace
+      t.string :event
+      t.string :from
+      t.string :to
+      t.timestamp :created_at
+
+      # Custom field not required by state_machines-audit_trail Gem.
+      t.references :user, foreign_key: true, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -156,6 +156,18 @@ ActiveRecord::Schema.define(version: 2018_06_12_161101) do
     t.index ["case_id"], name: "index_change_motd_requests_on_case_id"
   end
 
+  create_table "change_request_state_transitions", force: :cascade do |t|
+    t.bigint "change_request_id"
+    t.string "namespace"
+    t.string "event"
+    t.string "from"
+    t.string "to"
+    t.datetime "created_at"
+    t.bigint "user_id", null: false
+    t.index ["change_request_id"], name: "index_change_request_state_transitions_on_change_request_id"
+    t.index ["user_id"], name: "index_change_request_state_transitions_on_user_id"
+  end
+
   create_table "change_requests", force: :cascade do |t|
     t.bigint "case_id"
     t.string "state", default: "draft", null: false
@@ -398,6 +410,8 @@ ActiveRecord::Schema.define(version: 2018_06_12_161101) do
   add_foreign_key "cases", "users", column: "assignee_id"
   add_foreign_key "change_motd_request_state_transitions", "change_motd_requests"
   add_foreign_key "change_motd_request_state_transitions", "users"
+  add_foreign_key "change_request_state_transitions", "change_requests"
+  add_foreign_key "change_request_state_transitions", "users"
   add_foreign_key "change_requests", "cases"
   add_foreign_key "clusters", "sites"
   add_foreign_key "component_groups", "clusters"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -171,7 +171,7 @@ ActiveRecord::Schema.define(version: 2018_06_12_161101) do
   create_table "change_requests", force: :cascade do |t|
     t.bigint "case_id"
     t.string "state", default: "draft", null: false
-    t.string "details", null: false
+    t.string "description", null: false
     t.integer "credit_charge", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -156,6 +156,16 @@ ActiveRecord::Schema.define(version: 2018_06_12_161101) do
     t.index ["case_id"], name: "index_change_motd_requests_on_case_id"
   end
 
+  create_table "change_requests", force: :cascade do |t|
+    t.bigint "case_id"
+    t.string "state", default: "draft", null: false
+    t.string "details", null: false
+    t.integer "credit_charge", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["case_id"], name: "index_change_requests_on_case_id"
+  end
+
   create_table "clusters", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
@@ -388,6 +398,7 @@ ActiveRecord::Schema.define(version: 2018_06_12_161101) do
   add_foreign_key "cases", "users", column: "assignee_id"
   add_foreign_key "change_motd_request_state_transitions", "change_motd_requests"
   add_foreign_key "change_motd_request_state_transitions", "users"
+  add_foreign_key "change_requests", "cases"
   add_foreign_key "clusters", "sites"
   add_foreign_key "component_groups", "clusters"
   add_foreign_key "component_groups", "component_makes"

--- a/spec/controllers/change_requests_controller_spec.rb
+++ b/spec/controllers/change_requests_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ChangeRequestsController, type: :controller do
   let(:cluster) { create(:cluster, site: site) }
   let(:admin) { create(:admin) }
   let(:contact) { create(:contact, site: site) }
-  let(:kase) { create(:open_case, tier_level: 4, cluster: cluster)}
+  let(:kase) { build(:open_case, tier_level: 4, cluster: cluster)}
 
   EXPECTED_BEHAVIOURS = [ # initial_state, action, user, message, next_state
     [:draft, :propose, :admin, 'has been proposed and is awaiting customer authorisation.', :awaiting_authorisation],

--- a/spec/controllers/change_requests_controller_spec.rb
+++ b/spec/controllers/change_requests_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe ChangeRequestsController, type: :controller do
+  let :stub_mail do
+    obj = double
+    expect(obj).to receive(:deliver_later)
+    obj
+  end
+
+  let(:site) { create(:site) }
+  let(:cluster) { create(:cluster, site: site) }
+  let(:admin) { create(:admin) }
+  let(:contact) { create(:contact, site: site) }
+  let(:kase) { create(:open_case, tier_level: 4, cluster: cluster)}
+
+  EXPECTED_BEHAVIOURS = [ # initial_state, action, message, next_state
+    [:draft, :propose, 'has been proposed and is awaiting customer authorisation.', :awaiting_authorisation],
+    [:awaiting_authorisation, :authorise, 'has been authorised.', :in_progress],
+    [:awaiting_authorisation, :decline, 'has been declined.', :declined],
+    [:in_progress, :handover, 'is ready for handover.', :in_handover],
+    [:in_handover, :complete, 'is now complete.', :completed],
+  ].freeze
+
+  describe 'state transition methods' do
+
+    EXPECTED_BEHAVIOURS.each do |initial_state, action, message, next_state|
+      it "transitions from #{initial_state} to #{next_state}" do
+
+        cr = create(:change_request, case: kase, state: initial_state)
+
+        expect(CaseMailer).to receive(:change_request).with(
+          kase,
+          message
+        ).and_return(stub_mail)
+
+        post action, params: { case_id: kase.id }
+
+        cr.reload
+
+        expect(cr.state).to eq next_state.to_s
+      end
+    end
+
+    it 'does not allow illegal state transitions' do
+      cr = create(:change_request, case: kase, state: :draft)
+
+      post :complete, params: { case_id: kase.id }
+
+      cr.reload
+      expect(cr.state).to eq 'draft'
+      expect(flash[:error]).to eq 'Error updating change request: state cannot transition via "complete"'
+    end
+
+  end
+end

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe CaseDecorator do
       4 => 'Change request',
     }.each do |level, expected_description|
       it "gives correct text for level #{level} Tier" do
-        kase = create(:case, tier_level: level).decorate
+        kase = build(:case, tier_level: level).decorate
 
         expect(kase.tier_description).to eq("#{level} (#{expected_description})")
       end

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe CaseDecorator do
       1 => 'Tool',
       2 => 'Routine Maintenance',
       3 => 'General Support',
+      4 => 'Change request',
     }.each do |level, expected_description|
       it "gives correct text for level #{level} Tier" do
         kase = create(:case, tier_level: level).decorate
@@ -90,11 +91,11 @@ RSpec.describe CaseDecorator do
 
     it 'raises for unhandled tier_level' do
       # Use `build` as Case with this `tier_level` is currently invalid.
-      kase = build(:case, tier_level: 4).decorate
+      kase = build(:case, tier_level: 5).decorate
 
       expect do
         kase.tier_description
-      end.to raise_error(RuntimeError, "Unhandled tier_level: 4")
+      end.to raise_error(RuntimeError, "Unhandled tier_level: 5")
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -105,7 +105,7 @@ FactoryBot.define do
 
   factory :change_request do
     association :case
-    details 'Change request details text'
+    description 'Change request details text'
     credit_charge 1
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -102,4 +102,10 @@ FactoryBot.define do
     amount 1
     association :user, factory: :admin
   end
+
+  factory :change_request do
+    association :case
+    details 'Change request details text'
+    credit_charge 1
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -108,4 +108,11 @@ FactoryBot.define do
     details 'Change request details text'
     credit_charge 1
   end
+
+  factory :change_request_state_transition do
+    association :change_request
+    event 'propose'
+    from 'draft'
+    to 'awaiting_authorisation'
+  end
 end

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -231,6 +231,43 @@ RSpec.describe 'Case page', type: :feature do
       expect(resolved_case.state).to eq 'resolved'
       expect(find('.alert')).to have_text 'Error updating support case: credit_charge is invalid'
     end
+
+    let(:cr_case) {
+      create(:resolved_case, tier_level: 4, change_request: cr)
+    }
+
+    context 'with a declined change request' do
+      let(:cr) {
+        build(
+          :change_request,
+          credit_charge: 42,
+          state: 'declined'
+        )
+      }
+
+      it 'does not use CR charge as a minimum' do
+        visit case_path(cr_case, as: admin)
+
+        expect(find('#credit_charge_amount').value).to eq "0"
+      end
+    end
+
+    context 'with a completed change request' do
+      let!(:cr) {
+        build(
+          :change_request,
+          credit_charge: 42,
+          state: 'completed'
+        )
+      }
+
+      it 'uses CR charge as a minimum' do
+        visit case_path(cr_case, as: admin)
+
+        expect(find('#credit_charge_amount').value).to eq "42"
+        expect(find('#case-state-controls')).to have_text 'Charge below should include 42 credits from attached CR'
+      end
+    end
   end
 
   describe 'case assignment' do

--- a/spec/features/change_request/create_spec.rb
+++ b/spec/features/change_request/create_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Change requests #create', type: :feature do
+
+  let(:cluster) { create(:cluster) }
+  let(:kase) { create(:open_case, cluster: cluster, tier_level: 3) }
+  let(:admin) { create(:admin) }
+
+  it 'creates a valid CR and moves the case to tier 4' do
+    visit new_cluster_case_change_request_path(cluster, kase, as: admin)
+
+    fill_in 'change_request_description', with: 'Description of change request'
+    fill_in 'change_request_credit_charge', with: '42'
+
+    click_button 'Create'
+
+    expect(find('.alert-success').text).to have_text "Created change request for case #{kase.display_id}"
+
+    kase.reload
+
+    expect(kase.tier_level).to eq 4
+    expect(kase.change_request.present?).to eq true
+    expect(kase.change_request.description).to eq 'Description of change request'
+    expect(kase.cr_in_progress?).to eq true
+  end
+
+  it 'ensures the created CR has a description' do
+    visit new_cluster_case_change_request_path(cluster, kase, as: admin)
+
+    fill_in 'change_request_description', with: ''
+    fill_in 'change_request_credit_charge', with: '42'
+
+    click_button 'Create'
+
+    expect(find('.alert-danger').text).to have_text 'Error creating change request: description can\'t be blank'
+
+    kase.reload
+
+    expect(kase.tier_level).to eq 3
+    expect(kase.change_request.present?).to eq false
+  end
+
+  it 'ensures the created CR has a charge' do
+    visit new_cluster_case_change_request_path(cluster, kase, as: admin)
+
+    fill_in 'change_request_description', with: 'Description of change request'
+    fill_in 'change_request_credit_charge', with: ''
+
+    click_button 'Create'
+
+    expect(find('.alert-danger').text).to have_text 'Error creating change request: credit_charge can\'t be blank'
+
+    kase.reload
+
+    expect(kase.tier_level).to eq 3
+    expect(kase.change_request.present?).to eq false
+  end
+
+end

--- a/spec/features/change_request/show_spec.rb
+++ b/spec/features/change_request/show_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Change request view', type: :feature do
   let(:admin) { create(:admin) }
   let(:contact) { create(:contact, site: site) }
   let(:cluster) { create(:cluster, site: site) }
-  let(:kase) { create(:open_case, tier_level: 4, cluster: cluster) }
+  let(:kase) { build(:open_case, tier_level: 4, cluster: cluster) }
 
 
   EXPECTED_BUTTONS.keys.each do |state|

--- a/spec/features/change_request/show_spec.rb
+++ b/spec/features/change_request/show_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Change request view', type: :feature do
+
+  EXPECTED_BUTTONS = {
+    draft: {
+      admin: ['Edit', 'Submit for authorisation'],
+      contact: [],
+    },
+    awaiting_authorisation: {
+      admin: [],
+      contact: ['Authorise', 'Decline'],
+    },
+    declined: {
+      admin: [],
+      contact: [],
+    },
+    in_progress: {
+      admin: ['Begin handover'],
+      contact: [],
+    },
+    in_handover: {
+      admin: [],
+      contact: ['Approve work and close CR'],
+    },
+    completed: {
+      admin: [],
+      contact: [],
+    }
+  }.freeze
+
+  let(:site) { create(:site) }
+  let(:admin) { create(:admin) }
+  let(:contact) { create(:contact, site: site) }
+  let(:cluster) { create(:cluster, site: site) }
+  let(:kase) { create(:open_case, tier_level: 4, cluster: cluster) }
+
+
+  EXPECTED_BUTTONS.keys.each do |state|
+    context "for #{state} CR" do
+
+      subject { create(:change_request, state: state, case: kase) }
+
+      EXPECTED_BUTTONS[state].keys.each do |user_type|
+
+        it "shows #{user_type} expected buttons" do
+          visit cluster_case_change_request_path(
+            cluster, kase, subject,
+            as: send(user_type)
+          )
+
+          buttons = find('.state-controls').find_all('a.btn').map(&:text)
+          expect(buttons).to eq( EXPECTED_BUTTONS[state][user_type] << 'Return to case' )
+        end
+
+      end
+
+    end
+  end
+
+  it 'has test coverage for all possible CR states' do
+    cr = create(:change_request)
+    states = cr.state_paths(from: :draft).flatten.map(&:to_name).uniq << :draft
+
+    expect(states.sort).to eq EXPECTED_BUTTONS.keys.sort
+  end
+
+end

--- a/spec/features/change_request/show_spec.rb
+++ b/spec/features/change_request/show_spec.rb
@@ -39,13 +39,15 @@ RSpec.describe 'Change request view', type: :feature do
   EXPECTED_BUTTONS.keys.each do |state|
     context "for #{state} CR" do
 
-      subject { create(:change_request, state: state, case: kase) }
+      before(:each) do
+        create(:change_request, state: state, case: kase)
+      end
 
       EXPECTED_BUTTONS[state].keys.each do |user_type|
 
         it "shows #{user_type} expected buttons" do
           visit cluster_case_change_request_path(
-            cluster, kase, subject,
+            cluster, kase,
             as: send(user_type)
           )
 
@@ -59,7 +61,7 @@ RSpec.describe 'Change request view', type: :feature do
   end
 
   it 'has test coverage for all possible CR states' do
-    cr = create(:change_request)
+    cr = create(:change_request, case: kase)
     states = cr.state_paths(from: :draft).flatten.map(&:to_name).uniq << :draft
 
     expect(states.sort).to eq EXPECTED_BUTTONS.keys.sort
@@ -67,7 +69,7 @@ RSpec.describe 'Change request view', type: :feature do
 
   def as(whom)
     visit cluster_case_change_request_path(
-              cluster, kase, subject,
+              cluster, kase,
               as: whom
           )
     yield

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -492,4 +492,24 @@ RSpec.describe Case, type: :model do
       expect(kase.commenting_enabled_for?(user)).to eq(false)
     end
   end
+
+  describe '#resolve!' do
+    let(:kase) { create(:open_case, tier_level: 4) }
+
+    it 'is unresolvable with an outstanding change request' do
+      create(:change_request, case: kase, state: :awaiting_authorisation)
+
+      expect(kase.resolvable?).to eq false
+
+      expect do
+        kase.resolve!
+      end.to raise_error StateMachines::InvalidTransition
+
+      expect(kase.errors.messages).to eq(
+        state: ['cannot be resolved with an open change request']
+      )
+    end
+
+
+  end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -543,7 +543,7 @@ RSpec.describe Case, type: :model do
         kase.save!
       end.to raise_error ActiveRecord::RecordInvalid
       expect(kase.errors.messages).to include(
-        change_request: ['must be present if and only if case is tier 4']
+        change_request: ['must be blank']
       )
     end
     it 'must be present if tier_level is 4' do
@@ -553,7 +553,7 @@ RSpec.describe Case, type: :model do
         kase.save!
       end.to raise_error ActiveRecord::RecordInvalid
       expect(kase.errors.messages).to include(
-        change_request: ['must be present if and only if case is tier 4']
+        change_request: ['can\'t be blank']
       )
     end
   end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe Case, type: :model do
 
   describe '#credit_charge' do
     it 'cannot have a charge less than that of an attached change request' do
-      kase = build(:closed_case, tier_level: 4, credit_charge: 41)
+      kase = build(:closed_case, tier_level: 4, credit_charge: build(:credit_charge, amount: 41))
       build(:change_request, case: kase, credit_charge: 42)
 
       expect do

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Case, type: :model do
       is_expected.to validate_numericality_of(:tier_level)
         .only_integer
         .is_greater_than_or_equal_to(1)
-        .is_less_than_or_equal_to(3)
+        .is_less_than_or_equal_to(4)
     end
 
     describe 'fields validation' do

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -494,7 +494,7 @@ RSpec.describe Case, type: :model do
   end
 
   describe '#resolve!' do
-    let(:kase) { create(:open_case, tier_level: 4) }
+    let(:kase) { build(:open_case, tier_level: 4) }
 
     it 'is unresolvable with an outstanding change request' do
       create(:change_request, case: kase, state: :awaiting_authorisation)
@@ -521,6 +521,30 @@ RSpec.describe Case, type: :model do
       end.to raise_error ActiveRecord::RecordInvalid
       expect(kase.errors.messages).to include(
         credit_charge: ['cannot be less than attached CR charge of 42']
+      )
+    end
+  end
+
+  describe '#change_request' do
+    it 'cannot be present if tier_level is less than 4' do
+      kase = build(:open_case, tier_level: 3)
+      build(:change_request, case: kase)
+
+      expect do
+        kase.save!
+      end.to raise_error ActiveRecord::RecordInvalid
+      expect(kase.errors.messages).to include(
+        change_request: ['must be present if and only if case is tier 4']
+      )
+    end
+    it 'must be present if tier_level is 4' do
+      kase = build(:open_case, tier_level: 4)
+
+      expect do
+        kase.save!
+      end.to raise_error ActiveRecord::RecordInvalid
+      expect(kase.errors.messages).to include(
+        change_request: ['must be present if and only if case is tier 4']
       )
     end
   end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -505,11 +505,23 @@ RSpec.describe Case, type: :model do
         kase.resolve!
       end.to raise_error StateMachines::InvalidTransition
 
-      expect(kase.errors.messages).to eq(
+      expect(kase.errors.messages).to include(
         state: ['cannot be resolved with an open change request']
       )
     end
+  end
 
+  describe '#credit_charge' do
+    it 'cannot have a charge less than that of an attached change request' do
+      kase = build(:closed_case, tier_level: 4, credit_charge: 41)
+      build(:change_request, case: kase, credit_charge: 42)
 
+      expect do
+        kase.save!
+      end.to raise_error ActiveRecord::RecordInvalid
+      expect(kase.errors.messages).to include(
+        credit_charge: ['cannot be less than attached CR charge of 42']
+      )
+    end
   end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -512,9 +512,9 @@ RSpec.describe Case, type: :model do
   end
 
   describe '#credit_charge' do
-    it 'cannot have a charge less than that of an attached change request' do
+    it 'cannot have a charge less than that of an attached completed change request' do
       kase = build(:closed_case, tier_level: 4, credit_charge: build(:credit_charge, amount: 41))
-      build(:change_request, case: kase, credit_charge: 42)
+      build(:change_request, case: kase, credit_charge: 42, state: 'completed')
 
       expect do
         kase.save!
@@ -522,6 +522,15 @@ RSpec.describe Case, type: :model do
       expect(kase.errors.messages).to include(
         credit_charge: ['cannot be less than attached CR charge of 42']
       )
+    end
+
+    it 'does not restrict charge of attached declined change request' do
+      kase = build(:closed_case, tier_level: 4, credit_charge: build(:credit_charge, amount: 41))
+      build(:change_request, case: kase, credit_charge: 42, state: 'declined')
+
+      expect do
+        kase.save!
+      end.not_to raise_error
     end
   end
 

--- a/spec/models/change_request_spec.rb
+++ b/spec/models/change_request_spec.rb
@@ -2,15 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ChangeRequest, type: :model do
 
-  let(:my_case) { create(:open_case, tier_level: 3) }
-
-  it 'sets case tier to 4 on creation' do
-    create(:change_request, case: my_case)
-
-    my_case.reload
-    expect(my_case.tier_level).to eq 4
-  end
-
   describe '#finalised?' do
 
     FINAL_STATES = %w(declined completed).freeze

--- a/spec/models/change_request_spec.rb
+++ b/spec/models/change_request_spec.rb
@@ -11,4 +11,17 @@ RSpec.describe ChangeRequest, type: :model do
     expect(my_case.tier_level).to eq 4
   end
 
+  describe '#finalised?' do
+
+    FINAL_STATES = %w(declined completed).freeze
+
+    it 'reports final states as finalised' do
+
+      ChangeRequest.state_machine.states.map(&:name).each do |state|
+        cr = create(:change_request, state: state)
+        expect(cr.finalised?).to eq(FINAL_STATES.include?(state.to_s))
+      end
+    end
+  end
+
 end

--- a/spec/models/change_request_spec.rb
+++ b/spec/models/change_request_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe ChangeRequest, type: :model do
+
+  let(:my_case) { create(:open_case, tier_level: 3) }
+
+  it 'sets case tier to 4 on creation' do
+    create(:change_request, case: my_case)
+
+    my_case.reload
+    expect(my_case.tier_level).to eq 4
+  end
+
+end

--- a/spec/models/change_request_state_transition_spec.rb
+++ b/spec/models/change_request_state_transition_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.shared_examples 'it must be initiated by a non-admin' do
-  it 'can be initiated by non-admin' do
+RSpec.shared_examples 'it must be initiated by a contact' do
+  it 'can be initiated by contact' do
     subject.user = create(:contact)
 
     expect(subject).to be_valid
@@ -11,7 +11,14 @@ RSpec.shared_examples 'it must be initiated by a non-admin' do
     subject.user = create(:admin)
 
     expect(subject).not_to be_valid
-    expect(subject.errors.messages).to include user: [/must not be an admin/]
+    expect(subject.errors.messages).to include user: [/must be a contact/]
+  end
+
+  it 'cannot be initiated by viewer' do
+    subject.user = create(:viewer)
+
+    expect(subject).not_to be_valid
+    expect(subject.errors.messages).to include user: [/must be a contact/]
   end
 end
 
@@ -41,7 +48,7 @@ RSpec.describe ChangeRequestStateTransition, type: :model do
     context "when `#{event}` event" do
       let(:event) { event }
 
-      it_behaves_like 'it must be initiated by a non-admin'
+      it_behaves_like 'it must be initiated by a contact'
     end
   end
 

--- a/spec/models/change_request_state_transition_spec.rb
+++ b/spec/models/change_request_state_transition_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'it must be initiated by a non-admin' do
+  it 'can be initiated by non-admin' do
+    subject.user = create(:contact)
+
+    expect(subject).to be_valid
+  end
+
+  it 'cannot be initiated by admin' do
+    subject.user = create(:admin)
+
+    expect(subject).not_to be_valid
+    expect(subject.errors.messages).to include user: [/must not be an admin/]
+  end
+end
+
+
+RSpec.describe ChangeRequestStateTransition, type: :model do
+
+  subject do
+    build(:change_request_state_transition, event: event, user: user)
+  end
+
+  ADMIN_EVENTS = %w(propose handover).freeze
+  NON_ADMIN_EVENTS = %w(authorise decline complete).freeze
+
+  let(:event) { 'propose' }
+  let(:user) { create(:admin) }
+  it { is_expected.to validate_presence_of(:user) }
+
+  ADMIN_EVENTS.each do |event|
+    context "when `#{event}` event" do
+      let(:event) { event }
+
+      it_behaves_like 'it must be initiated by an admin'
+    end
+  end
+
+  NON_ADMIN_EVENTS.each do |event|
+    context "when `#{event}` event" do
+      let(:event) { event }
+
+      it_behaves_like 'it must be initiated by a non-admin'
+    end
+  end
+
+  it 'has no events not covered by these tests' do
+    states = subject.change_request.state_paths(from: :draft).flatten.map(&:event).map(&:to_s).uniq.sort
+
+    expect(states).to eq( (ADMIN_EVENTS + NON_ADMIN_EVENTS).sort )
+  end
+end

--- a/spec/policies/change_request_policy_spec.rb
+++ b/spec/policies/change_request_policy_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ChangeRequestPolicy do
+  include_context 'policy'
+
+  let(:record) { nil }
+
+  permissions :new?, :create?, :edit?, :update?, :propose?, :handover? do
+    it_behaves_like 'it is available only to admins'
+  end
+
+  permissions :authorise?, :decline?, :complete? do
+    it_behaves_like 'it is available only to contacts'
+  end
+end


### PR DESCRIPTION
This PR adds support for change requests - that is, tier 4 cases - to Flight Center.

A tier-3 case may be escalated by an admin to become a tier 4 case with an attached draft change request. A change request consists of a Markdown-text description and an integer credit charge amount. Admins may continue to edit the change request until it is ready for customer authorisation. Site contacts can then either authorise or decline the change request. If declined, then no further action may be taken - the case should be resolved manually by an admin.

Once work has been completed, admins can mark a change request as being ready for handover, after which site contacts can confirm the CR as complete. The case may then be resolved by an admin - cases are prevented from being resolved while a CR is in progress.

For each state transition described above (excluding the initial creation), an email is sent to the standard list of site recipients, and an entry generated in the case's events feed.

When a case with attached CR is ready to be closed, the default credit charge is now set to the value of the CR's credit charge. This can be overridden by the admin closing the case if necessary. The CR's charge is displayed alongside the input field for the case's charge. A case is forbidden from having a credit charge less than that associated with an attached CR.

Note that I've only included routes for CRs under `/cases/:case_id/change_request` and `/clusters/:cluster_id/cases/:case_id/change_request`; I can't decide whether that's sensible and keeps things simpler or not, but I'm erring on the side of that being the case.

Further note: the test around credit charges will need changing when #333 gets merged (since that changes how credit charges work).

Trello: https://trello.com/c/JxI8jNe3/183-add-change-request-tracking-tier-4
Closes #52.