### PR TITLE
motd change request button

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -39,6 +39,15 @@ class CasesController < ApplicationController
                 else
                   current_site.clusters
                 end
+    @selected = if params[:tool].present?
+                  tool = Tier.find_by(tool: params[:tool])
+                  {
+                    issue: tool.issue_id,
+                    category: tool.issue.category_id
+                  }
+                else
+                  {}
+                end
   end
 
   def create

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -49,7 +49,7 @@ class CasesController < ApplicationController
                     {
                       category: issue.category_id,
                       issue: issue.id,
-                      service: service.id,
+                      service: service.present? ? service.id : nil,
                       tier: tool.level,
                     }
                   end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -41,12 +41,18 @@ class CasesController < ApplicationController
                 end
     @selected = if params[:tool].present?
                   tool = Tier.find_by(tool: params[:tool])
-                  tool.nil? ?
-                    {} :
+                  if tool.nil?
+                    {}
+                  else
+                    issue = tool.issue
+                    service = issue.service_type.services.find_by(cluster_id: cluster_id)
                     {
-                      issue: tool.issue_id,
-                      category: tool.issue.category_id
+                      category: issue.category_id,
+                      issue: issue.id,
+                      service: service.id,
+                      tier: tool.level,
                     }
+                  end
                 else
                   {}
                 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -39,24 +39,7 @@ class CasesController < ApplicationController
                 else
                   current_site.clusters
                 end
-    @selected = if params[:tool].present?
-                  tool = Tier.find_by(tool: params[:tool])
-                  if tool.nil?
-                    {}
-                  else
-                    # issue = tool.issue
-                    # service = issue.service_type.services.find_by(cluster_id: cluster_id)
-                    {
-                      # category: issue.category_id,
-                      # issue: issue.id,
-                      # service: service.present? ? service.id : nil,
-                      # tier: tool.level,
-                      tool: params[:tool],
-                    }
-                  end
-                else
-                  {}
-                end
+    @pre_selected = get_pre_selections
   end
 
   def create
@@ -180,5 +163,60 @@ class CasesController < ApplicationController
     Case.find_from_id!(params.require(:id))
       .tap { |c| authorize c }
       .decorate
+  end
+
+  def get_pre_selections
+    if params[:tool].present?
+      {
+        tool: params[:tool],
+      }
+
+    elsif params[:issue].present?
+      issue_name = params[:issue]
+      issue = Issue.find_by(name: issue_name)
+      tier = if issue.present? && !issue.tiers.empty?
+               issue.tiers.order(:level).first
+             end
+      category = issue.category
+      service = if issue.service_type.present?
+                  Service.find_by(service_type: issue.service_type, cluster: @clusters.first)
+                elsif params[:service].present?
+                  Service.find_by(name: params[:service], cluster: @clusters.first)
+                end
+
+      {}.tap do |h|
+        h[:category] = category.id if category.present?
+        h[:issue] = issue.id if issue.present?
+        h[:service] = service.id if service.present?
+        h[:tier] = tier.id if tier.present?
+      end
+
+    elsif params[:category].present?
+      category_name = params[:category]
+      category = Category.find_by(name: category_name)
+      if category.present?
+        issue = category.issues.first
+        service = if issue.present? && issue.service_type.present?
+                    Service.find_by(service_type: issue.service_type, cluster: @clusters.first)
+                  elsif params[:service].present?
+                    Service.find_by(name: params[:service], cluster: @clusters.first)
+                  end
+      end
+
+      {}.tap do |h|
+        h[:category] = category.id if category.present?
+        h[:service] = service.id if service.present?
+      end
+
+    elsif params[:service].present?
+      service_name = params[:service]
+      service = Service.find_by(name: service_name, cluster: @clusters.first)
+
+      {}.tap do |h|
+        h[:service] = service.id if service.present?
+      end
+    else
+      {}
+    end
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -44,13 +44,14 @@ class CasesController < ApplicationController
                   if tool.nil?
                     {}
                   else
-                    issue = tool.issue
-                    service = issue.service_type.services.find_by(cluster_id: cluster_id)
+                    # issue = tool.issue
+                    # service = issue.service_type.services.find_by(cluster_id: cluster_id)
                     {
-                      category: issue.category_id,
-                      issue: issue.id,
-                      service: service.present? ? service.id : nil,
-                      tier: tool.level,
+                      # category: issue.category_id,
+                      # issue: issue.id,
+                      # service: service.present? ? service.id : nil,
+                      # tier: tool.level,
+                      tool: params[:tool],
                     }
                   end
                 else

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -41,10 +41,12 @@ class CasesController < ApplicationController
                 end
     @selected = if params[:tool].present?
                   tool = Tier.find_by(tool: params[:tool])
-                  {
-                    issue: tool.issue_id,
-                    category: tool.issue.category_id
-                  }
+                  tool.nil? ?
+                    {} :
+                    {
+                      issue: tool.issue_id,
+                      category: tool.issue.category_id
+                    }
                 else
                   {}
                 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,6 +33,7 @@ module ApplicationHelper
           #{selected_data_attr(:issue, selected)}
           #{selected_data_attr(:service, selected)}
           #{selected_data_attr(:tier, selected)}
+          #{selected_data_attr(:tool, selected)}
         ></div>
       EOF
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
     raw(condition ? '&check;' : '&cross;')
   end
 
-  def new_case_form(clusters:, single_part: nil)
+  def new_case_form(clusters:, single_part: nil, selected: {})
     clusters_json = json_map(clusters.map(&:decorate), :case_form_json)
     raw(
       <<~EOF
@@ -29,6 +29,8 @@ module ApplicationHelper
           id='new-case-form'
           data-clusters='#{clusters_json}'
           #{single_part_data_attr(single_part)}
+          #{selected_data_attr(:category, selected)}
+          #{selected_data_attr(:issue, selected)}
         ></div>
       EOF
     )
@@ -91,4 +93,12 @@ module ApplicationHelper
 
     "data-single-part=#{single_part_json}"
   end
+
+  def selected_data_attr(item_name, selected_items)
+    item = selected_items.fetch(item_name, nil)
+    return nil if item.nil?
+
+    return "data-selected-#{item_name}='\"#{item}\"'"
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,8 @@ module ApplicationHelper
           #{single_part_data_attr(single_part)}
           #{selected_data_attr(:category, selected)}
           #{selected_data_attr(:issue, selected)}
+          #{selected_data_attr(:service, selected)}
+          #{selected_data_attr(:tier, selected)}
         ></div>
       EOF
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
     raw(condition ? '&check;' : '&cross;')
   end
 
-  def new_case_form(clusters:, single_part: nil, selected: {})
+  def new_case_form(clusters:, single_part: nil, pre_selected: {})
     clusters_json = json_map(clusters.map(&:decorate), :case_form_json)
     raw(
       <<~EOF
@@ -29,11 +29,11 @@ module ApplicationHelper
           id='new-case-form'
           data-clusters='#{clusters_json}'
           #{single_part_data_attr(single_part)}
-          #{selected_data_attr(:category, selected)}
-          #{selected_data_attr(:issue, selected)}
-          #{selected_data_attr(:service, selected)}
-          #{selected_data_attr(:tier, selected)}
-          #{selected_data_attr(:tool, selected)}
+          #{selected_data_attr(:category, pre_selected)}
+          #{selected_data_attr(:issue, pre_selected)}
+          #{selected_data_attr(:service, pre_selected)}
+          #{selected_data_attr(:tier, pre_selected)}
+          #{selected_data_attr(:tool, pre_selected)}
         ></div>
       EOF
     )
@@ -103,5 +103,4 @@ module ApplicationHelper
 
     return "data-selected-#{item_name}='\"#{item}\"'"
   end
-
 end

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -2,10 +2,10 @@ module Issue
     exposing
         ( Id(..)
         , Issue
-        , data
         , decoder
         , extractId
         , findTier
+        , id
         , name
         , requiresComponent
         , sameId
@@ -86,6 +86,11 @@ requiresComponent issue =
 
         StandardIssue _ ->
             False
+
+
+id : Issue -> Id
+id issue =
+    data issue |> .id
 
 
 name : Issue -> String

--- a/app/javascript/packs/Issue.elm
+++ b/app/javascript/packs/Issue.elm
@@ -2,8 +2,10 @@ module Issue
     exposing
         ( Id(..)
         , Issue
+        , data
         , decoder
         , extractId
+        , findTier
         , name
         , requiresComponent
         , sameId
@@ -158,3 +160,8 @@ data issue =
 sameId : Id -> Issue -> Bool
 sameId id issue =
     data issue |> Utils.sameId id
+
+
+findTier : (Tier -> Bool) -> Issue -> Maybe Tier
+findTier predicate issue =
+    SelectList.Extra.find predicate (issue |> data |> .tiers)

--- a/app/javascript/packs/Issues.elm
+++ b/app/javascript/packs/Issues.elm
@@ -1,6 +1,6 @@
 module Issues
     exposing
-        ( Issues
+        ( Issues(..)
         , availableIssues
         , categories
         , decoder

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -2,14 +2,14 @@ module Main exposing (..)
 
 import Html exposing (Html)
 import Json.Decode as D
+import List
+import Maybe
 import Msg exposing (..)
+import Result
 import State exposing (State)
 import State.Update
 import State.View
 import View.Utils
-import Maybe
-import Result
-import List
 
 
 -- MODEL
@@ -41,23 +41,27 @@ decodeInitialModel value =
 init : D.Value -> ( Model, Cmd Msg )
 init flags =
     let
-        model = decodeInitialModel flags
+        model =
+            decodeInitialModel flags
 
-        mmsgs = [
-            maybeToolMessage ChangeSelectedIssue "selectedIssue" flags,
-            maybeToolMessage ChangeSelectedCategory "selectedCategory" flags
-        ]
+        mmsgs =
+            [ maybeToolMessage ChangeSelectedIssue "selectedIssue" flags
+            , maybeToolMessage ChangeSelectedCategory "selectedCategory" flags
+            ]
 
-        updateCollectingCmds mmsg (m1, cs1) =
+        updateCollectingCmds mmsg ( m1, cs1 ) =
             case mmsg of
                 Just msg ->
                     let
-                        (m2, cs2) = update msg m1
+                        ( m2, cs2 ) =
+                            update msg m1
                     in
-                        (m2 ! [cs1, cs2])
-                Nothing -> (m1 ! [cs1])
+                    m2 ! [ cs1, cs2 ]
+
+                Nothing ->
+                    m1 ! [ cs1 ]
     in
-        List.foldr updateCollectingCmds (model ! []) mmsgs
+    List.foldr updateCollectingCmds (model ! []) mmsgs
 
 
 maybeToolMessage : (String -> msg) -> String -> D.Value -> Maybe msg
@@ -66,15 +70,18 @@ maybeToolMessage msg fieldName flags =
         getFieldId : Maybe String
         getFieldId =
             case decodeField of
-                Result.Ok v -> v
-                Result.Err e -> Nothing
+                Result.Ok v ->
+                    v
+
+                Result.Err e ->
+                    Nothing
 
         decodeField : Result String (Maybe String)
         decodeField =
             D.decodeValue (D.maybe (D.field fieldName D.string)) flags
-
     in
-        Maybe.map msg getFieldId
+    Maybe.map msg getFieldId
+
 
 
 -- VIEW

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -49,6 +49,7 @@ init flags =
             , maybeToolMessage ChangeSelectedIssue "selectedIssue" flags
             , maybeToolMessage ChangeSelectedCategory "selectedCategory" flags
             , maybeToolMessage ChangeSelectedService "selectedService" flags
+            , maybeToolMessage SelectTool "selectedTool" flags
             ]
 
         updateCollectingCmds mmsg ( m1, cs1 ) =

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -45,8 +45,10 @@ init flags =
             decodeInitialModel flags
 
         mmsgs =
-            [ maybeToolMessage ChangeSelectedIssue "selectedIssue" flags
+            [ maybeToolMessage ChangeSelectedTier "selectedTier" flags
+            , maybeToolMessage ChangeSelectedIssue "selectedIssue" flags
             , maybeToolMessage ChangeSelectedCategory "selectedCategory" flags
+            , maybeToolMessage ChangeSelectedService "selectedService" flags
             ]
 
         updateCollectingCmds mmsg ( m1, cs1 ) =

--- a/app/javascript/packs/Main.elm
+++ b/app/javascript/packs/Main.elm
@@ -45,11 +45,11 @@ init flags =
             decodeInitialModel flags
 
         mmsgs =
-            [ maybeToolMessage ChangeSelectedTier "selectedTier" flags
-            , maybeToolMessage ChangeSelectedIssue "selectedIssue" flags
-            , maybeToolMessage ChangeSelectedCategory "selectedCategory" flags
-            , maybeToolMessage ChangeSelectedService "selectedService" flags
-            , maybeToolMessage SelectTool "selectedTool" flags
+            [ maybeMsgFromFlag ChangeSelectedTier "selectedTier" flags
+            , maybeMsgFromFlag ChangeSelectedIssue "selectedIssue" flags
+            , maybeMsgFromFlag ChangeSelectedCategory "selectedCategory" flags
+            , maybeMsgFromFlag ChangeSelectedService "selectedService" flags
+            , maybeMsgFromFlag SelectTool "selectedTool" flags
             ]
 
         updateCollectingCmds mmsg ( m1, cs1 ) =
@@ -67,8 +67,8 @@ init flags =
     List.foldr updateCollectingCmds (model ! []) mmsgs
 
 
-maybeToolMessage : (String -> msg) -> String -> D.Value -> Maybe msg
-maybeToolMessage msg fieldName flags =
+maybeMsgFromFlag : (String -> msg) -> String -> D.Value -> Maybe msg
+maybeMsgFromFlag msg fieldName flags =
     let
         getFieldId : Maybe String
         getFieldId =

--- a/app/javascript/packs/Msg.elm
+++ b/app/javascript/packs/Msg.elm
@@ -18,3 +18,4 @@ type Msg
     | ClearError
     | ClusterChargingInfoModal Modal.Visibility
     | ChargeablePreSubmissionModal Modal.Visibility
+    | SelectTool String

--- a/app/javascript/packs/SelectList/Extra.elm
+++ b/app/javascript/packs/SelectList/Extra.elm
@@ -1,6 +1,7 @@
 module SelectList.Extra
     exposing
         ( find
+        , findValueBy
         , fromList
         , mapSelected
         , nameOrderedDecoder
@@ -11,6 +12,7 @@ module SelectList.Extra
 
 import Json.Decode as D
 import List.Extra
+import Maybe.Extra
 import SelectList exposing (Position(..), SelectList)
 
 
@@ -143,3 +145,19 @@ find :
     -> Maybe a
 find predicate selectList =
     List.Extra.find predicate (SelectList.toList selectList)
+
+
+{-|
+
+    Return the first result for which applying `fn` returns `Just`.
+
+-}
+findValueBy :
+    (a -> Maybe b)
+    -> SelectList a
+    -> Maybe b
+findValueBy fn selectList =
+    selectList
+        |> SelectList.map fn
+        |> find Maybe.Extra.isJust
+        |> Maybe.Extra.join

--- a/app/javascript/packs/SelectList/Extra.elm
+++ b/app/javascript/packs/SelectList/Extra.elm
@@ -1,6 +1,7 @@
 module SelectList.Extra
     exposing
-        ( fromList
+        ( find
+        , fromList
         , mapSelected
         , nameOrderedDecoder
         , nestedSelect
@@ -9,6 +10,7 @@ module SelectList.Extra
         )
 
 import Json.Decode as D
+import List.Extra
 import SelectList exposing (Position(..), SelectList)
 
 
@@ -127,3 +129,17 @@ updateNested selectList getNested asNestedIn transform =
                     |> asNestedIn item
     in
     mapSelected updateNested selectList
+
+
+{-|
+
+    Find the first element in the given select list matching the given
+    predicate.
+
+-}
+find :
+    (a -> Bool)
+    -> SelectList a
+    -> Maybe a
+find predicate selectList =
+    List.Extra.find predicate (SelectList.toList selectList)

--- a/app/javascript/packs/Service.elm
+++ b/app/javascript/packs/Service.elm
@@ -91,10 +91,7 @@ findTierAndAncestors predicate services =
                 findTierAddingIssue issue =
                     Maybe.map ((,) issue) (Issue.findTier predicate issue)
             in
-            issues
-                |> SelectList.map findTierAddingIssue
-                |> SelectList.Extra.find Maybe.Extra.isJust
-                |> Maybe.Extra.join
+            SelectList.Extra.findValueBy findTierAddingIssue issues
 
         findCategoryIssueAndTier :
             (Tier -> Bool)
@@ -110,10 +107,7 @@ findTierAndAncestors predicate services =
                         Nothing ->
                             Nothing
             in
-            categories
-                |> SelectList.map findIssueAddingCategory
-                |> SelectList.Extra.find Maybe.Extra.isJust
-                |> Maybe.Extra.join
+            SelectList.Extra.findValueBy findIssueAddingCategory categories
 
         findServiceCategoryIssueAndTier :
             Service
@@ -136,7 +130,4 @@ findTierAndAncestors predicate services =
                         _ ->
                             Nothing
     in
-    services
-        |> SelectList.map findServiceCategoryIssueAndTier
-        |> SelectList.Extra.find Maybe.Extra.isJust
-        |> Maybe.Extra.join
+    SelectList.Extra.findValueBy findServiceCategoryIssueAndTier services

--- a/app/javascript/packs/State/Update.elm
+++ b/app/javascript/packs/State/Update.elm
@@ -165,10 +165,7 @@ handleSelectTool : State -> String -> ( State, Cmd Msg )
 handleSelectTool state toolName =
     let
         services =
-            state
-                |> .clusters
-                |> SelectList.selected
-                |> .services
+            State.selectedCluster state |> .services
 
         isWantedTier : Tier.Tier -> Bool
         isWantedTier tier =
@@ -194,7 +191,7 @@ handleSelectTool state toolName =
                     state.clusters
                         |> flip Cluster.setSelectedService service.id
                         |> maybeSetCategory mcategory
-                        |> flip Cluster.setSelectedIssue (issue |> Issue.data |> .id)
+                        |> flip Cluster.setSelectedIssue (Issue.id issue)
                         |> flip Cluster.setSelectedTier tier.id
             }
                 ! []

--- a/app/javascript/packs/new_case_form.js
+++ b/app/javascript/packs/new_case_form.js
@@ -14,6 +14,8 @@ const initializeFormApp = () => {
     const flags = {
       clusters: loadAttributeJson('data-clusters'),
       singlePart: loadAttributeJson('data-single-part'),
+      selectedCategory: loadAttributeJson('data-selected-category'),
+      selectedIssue: loadAttributeJson('data-selected-issue'),
     };
 
     Elm.Main.embed(target, flags);

--- a/app/javascript/packs/new_case_form.js
+++ b/app/javascript/packs/new_case_form.js
@@ -16,6 +16,8 @@ const initializeFormApp = () => {
       singlePart: loadAttributeJson('data-single-part'),
       selectedCategory: loadAttributeJson('data-selected-category'),
       selectedIssue: loadAttributeJson('data-selected-issue'),
+      selectedService: loadAttributeJson('data-selected-service'),
+      selectedTier: loadAttributeJson('data-selected-tier'),
     };
 
     Elm.Main.embed(target, flags);

--- a/app/javascript/packs/new_case_form.js
+++ b/app/javascript/packs/new_case_form.js
@@ -18,6 +18,7 @@ const initializeFormApp = () => {
       selectedIssue: loadAttributeJson('data-selected-issue'),
       selectedService: loadAttributeJson('data-selected-service'),
       selectedTier: loadAttributeJson('data-selected-tier'),
+      selectedTool: loadAttributeJson('data-selected-tool'),
     };
 
     Elm.Main.embed(target, flags);

--- a/app/views/cases/new.html.erb
+++ b/app/views/cases/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:subtitle) { 'Open New Support Case' } %>
 <%= render 'partials/tabs', activate: :cases do %>
   <div class='card-body'>
-    <%= new_case_form(clusters: @clusters, single_part: @single_part) %>
+    <%= new_case_form(clusters: @clusters, single_part: @single_part, selected: @selected) %>
   </div>
 <% end %>

--- a/app/views/cases/new.html.erb
+++ b/app/views/cases/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:subtitle) { 'Open New Support Case' } %>
 <%= render 'partials/tabs', activate: :cases do %>
   <div class='card-body'>
-    <%= new_case_form(clusters: @clusters, single_part: @single_part, selected: @selected) %>
+    <%= new_case_form(clusters: @clusters, single_part: @single_part, pre_selected: @pre_selected) %>
   </div>
 <% end %>

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -28,6 +28,11 @@
       <li class="list-group-item">
         <h6>MOTD</h6>
         <%= simple_format(cluster.motd) %>
+        <%= link_to "Request change",
+            new_cluster_case_path(@cluster, tool: 'motd'),
+            role: 'button',
+            class: "btn btn-secondary"
+        %>
       </li>
     </ul>
   </div>
@@ -39,4 +44,3 @@
     <% end %>
   </div>
 </div>
-

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,6 +11,7 @@
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
         "NoRedInk/elm-rails": "6.2.0 <= v < 7.0.0",
         "elm-community/html-extra": "2.2.0 <= v < 3.0.0",
+        "elm-community/list-extra": "7.1.0 <= v < 8.0.0",
         "elm-community/maybe-extra": "4.0.0 <= v < 5.0.0",
         "elm-community/string-extra": "1.4.0 <= v < 2.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -69,6 +69,33 @@ RSpec.describe CasesController, type: :controller do
         end.to raise_error(ActionController::RoutingError)
       end
     end
+
+    context 'when given a tool' do
+      it 'assigns the correct category and issue' do
+        create(:tier)
+        create(:level_1_tier)
+        tier_with_tool = create(:tier_with_tool)
+
+        get :new, params: { tool: 'motd' }
+
+        expect(assigns(:selected)).to eq({
+          category: tier_with_tool.issue.category.id,
+          issue: tier_with_tool.issue.id,
+        })
+      end
+    end
+
+    context 'when not given a tool' do
+      it 'does not assign a category or issue' do
+        create(:tier)
+        create(:level_1_tier)
+        create(:tier_with_tool)
+
+        get :new, params: { tool: nil }
+
+        expect(assigns(:selected)).to eq({})
+      end
+    end
   end
 
   describe 'POST #create' do

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CasesController, type: :controller do
         end.to raise_error(ActionController::RoutingError)
       end
 
-      context 'case form tool pre-poulation' do
+      context 'case form pre-population' do
         before(:each) do
           # Add additional tools and services so that we can be confident we
           # are selecting the correct items, and not just selecting the only
@@ -42,56 +42,73 @@ RSpec.describe CasesController, type: :controller do
           create(:service, service_type: create(:service_type), cluster: first_cluster)
         end
 
-        let(:category) { create(:category) }
+        let(:category) { create(:category, name: 'My category name') }
         let(:tier) { create(:tier_with_tool, issue: issue) }
         let(:service_type) { create(:service_type) }
         let!(:service) do
-          create(:service, service_type: service_type, cluster: first_cluster)
+          create(:service, service_type: service_type, cluster: first_cluster, name: 'My service name')
+        end
+        let!(:issue) do
+          create(:issue_requiring_service, service_type: service_type, category: category, name: 'My issue name')
         end
 
-        context 'when given a tool within a category' do
-          let(:issue) do
-            create(:issue_requiring_service, service_type: service_type, category: category)
-          end
 
-          it 'assigns the correct items to @selected' do
+        context 'when given a tool' do
+          it 'assigns the correct tool to @pre_selected' do
             get :new, params: { tool: tier.tool, cluster_id: first_cluster.id }
 
-            expect(assigns(:selected)).to eq({
+            expect(assigns(:pre_selected)).to eq({
+              tool: tier.tool
+            })
+          end
+        end
+
+        context 'when given a service' do
+          it 'assigns the correct service id to @pre_selected' do
+            get :new, params: { service: service.name, cluster_id: first_cluster.id }
+
+            expect(assigns(:pre_selected)).to eq({
+              service: service.id,
+            })
+          end
+        end
+
+        context 'when given a category' do
+          it 'assigns the correct category id to @pre_selected' do
+            issue = category.issues.first
+            service = issue.present? ?
+              Service.find_by(service_type: issue.service_type, cluster: first_cluster) :
+              nil
+
+            get :new, params: { category: category.name, cluster_id: first_cluster.id }
+
+            expect(assigns(:pre_selected)).to eq({
+              category: category.id,
+              service: service.present? ? service.id : nil,
+            })
+          end
+        end
+
+        context 'when given a issue' do
+          it 'assigns the correct service, category, issue and tier to @pre_selected' do
+            service = Service.find_by(service_type: issue.service_type, cluster: first_cluster)
+
+            get :new, params: { issue: issue.name, cluster_id: first_cluster.id }
+
+            expect(assigns(:pre_selected)).to eq({
               category: issue.category.id,
               issue: issue.id,
-              tier: tier.level,
               service: service.id,
+              tier: issue.tiers.first.id,
             })
           end
         end
 
-        context 'when given a tool without a category' do
-          let(:issue) do
-            create(:issue_requiring_service, service_type: service_type)
-          end
+        context 'when given no pre-populations' do
+          it 'does not assign anything to @pre_selected' do
+            get :new, params: { cluster_id: first_cluster.id }
 
-          it 'assigns the correct items to @selected' do
-            get :new, params: { tool: tier.tool, cluster_id: first_cluster.id }
-
-            expect(assigns(:selected)).to eq({
-              category: nil,
-              issue: issue.id,
-              tier: tier.level,
-              service: service.id,
-            })
-          end
-        end
-
-        context 'when not given a tool' do
-          it 'does not assign anything meaningful to @selected' do
-            create(:tier)
-            create(:level_1_tier)
-            create(:tier_with_tool)
-
-            get :new, params: { tool: nil, cluster_id: first_cluster.id }
-
-            expect(assigns(:selected)).to eq({})
+            expect(assigns(:pre_selected)).to eq({})
           end
         end
       end

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -4,6 +4,11 @@ FactoryBot.define do
     name 'New user/group'
     requires_component false
 
+    factory :issue_with_category do
+      name 'Motd change request'
+      category
+    end
+
     factory :issue_requiring_component do
       requires_component true
 

--- a/spec/factories/tier.rb
+++ b/spec/factories/tier.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
       factory :tier_with_tool do
         association :issue, factory: :issue_with_category
-        tool 'motd'
+        tool :motd
         fields { nil }
       end
     end

--- a/spec/factories/tier.rb
+++ b/spec/factories/tier.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
       factory :tier_with_tool do
         association :issue, factory: :issue_with_category
-        tool :motd
+        tool 'motd'
         fields { nil }
       end
     end

--- a/spec/factories/tier.rb
+++ b/spec/factories/tier.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
       level 1
 
       factory :tier_with_tool do
+        association :issue, factory: :issue_with_category
         tool :motd
         fields { nil }
       end


### PR DESCRIPTION
This PR adds a button on the cluster's overview in the MOTD section to display the case form ready populated for creating a "MOTD change request".  

This works by adding `data-selected-category` and `data-seleted-issue` to the `new-case-form` DOM element which are passed into the elm app along with the other flags.  The elm `init` function then returns a list of `Cmd Msg`s to set the desired category and issue.

Whist this works, it would be better to have `decodeInitialModel` set the desired category and issue from `flags`.  Doing that would avoid a couple of trips through the elm runtime.  Unfortunately, how to do that is not immediately obvious to me.

Still to do: ~tests~