### PR TITLE
Allow enabling contact comments on tier 1/2 cases

### DIFF
--- a/app/controllers/case_comments_controller.rb
+++ b/app/controllers/case_comments_controller.rb
@@ -6,7 +6,7 @@ class CaseCommentsController < ApplicationController
     authorize new_comment
 
     if new_comment.save
-      flash[:notice] = 'New comment added.'
+      flash[:success] = 'New comment added.'
     else
       flash[:error] = "Your comment was not added. #{new_comment.errors.full_messages.join('; ').strip}"
     end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -114,6 +114,15 @@ class CasesController < ApplicationController
     end
   end
 
+  def set_commenting
+    enabled = params.require(:comments_enabled)
+    verb = enabled == 'true' ? 'enabled' : 'disabled'
+
+    change_action "Commenting #{verb} for contacts on case %s" do |kase|
+      kase.comments_enabled = enabled
+    end
+  end
+
   private
 
   def case_params

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -189,6 +189,12 @@ class Case < ApplicationRecord
     tier_level >= 3
   end
 
+  def comments_could_be_enabled?
+    # If this condition is met then comments by contacts are enabled iff
+    # comments_enabled is true.
+    open? && !consultancy?
+  end
+
   def potential_assignees
     site.users.where.not(role: :viewer)
       .or(User.where(role: :admin))

--- a/app/models/case_commenting.rb
+++ b/app/models/case_commenting.rb
@@ -14,7 +14,7 @@ class CaseCommenting
       viewer_cannot_comment_message
     elsif !kase.open?
       not_open_message
-    elsif user.contact? && !kase.consultancy?
+    elsif user.contact? && !kase.consultancy? && !kase.comments_enabled
       non_consultancy_message
     else
       ''

--- a/app/models/case_commenting.rb
+++ b/app/models/case_commenting.rb
@@ -14,7 +14,7 @@ class CaseCommenting
       viewer_cannot_comment_message
     elsif !kase.open?
       not_open_message
-    elsif user.contact? && !kase.consultancy? && !kase.comments_enabled
+    elsif user.contact? && kase.comments_could_be_enabled? && !kase.comments_enabled
       non_consultancy_message
     else
       ''

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -6,6 +6,7 @@ class CasePolicy < ApplicationPolicy
   alias_method :assign?, :admin?
   alias_method :resolve?, :admin?
   alias_method :set_time?, :admin?
+  alias_method :set_commenting?, :admin?
 
   class Scope < Scope
     def resolve

--- a/app/views/cases/_case_comment_toggle_controls.html.erb
+++ b/app/views/cases/_case_comment_toggle_controls.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? && @case.open? && !@case.consultancy? %>
+<% if current_user.admin? && @case.comments_could_be_enabled? %>
   <div class="alert alert-info d-flex justify-content-between align-items-center">
     <i class="fa fa-info fa-2x mr-2"></i>
     <span style="flex-grow: 1">

--- a/app/views/cases/_case_comment_toggle_controls.html.erb
+++ b/app/views/cases/_case_comment_toggle_controls.html.erb
@@ -1,0 +1,15 @@
+<% if current_user.admin? && !@case.consultancy? %>
+  <div class="alert alert-info d-flex justify-content-between align-items-center">
+    <i class="fa fa-info fa-2x mr-2"></i>
+    <span style="flex-grow: 1">
+      Commenting by site contacts is currently <%= @case.comments_enabled ? 'enabled' : 'disabled' %>.
+    </span>
+
+    <% verb = @case.comments_enabled ? 'Disable' : 'Enable' %>
+    <%=
+      link_to verb, set_commenting_case_path(@case, params: { comments_enabled: !@case.comments_enabled }),
+              method: 'post',
+              class: 'btn btn-primary'
+    %>
+  </div>
+<% end %>

--- a/app/views/cases/_case_comment_toggle_controls.html.erb
+++ b/app/views/cases/_case_comment_toggle_controls.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? && !@case.consultancy? %>
+<% if current_user.admin? && @case.open? && !@case.consultancy? %>
   <div class="alert alert-info d-flex justify-content-between align-items-center">
     <i class="fa fa-info fa-2x mr-2"></i>
     <span style="flex-grow: 1">

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -60,6 +60,7 @@
       <tr>
         <th>Case history</th>
         <td colspan="3">
+          <%= render 'case_comment_toggle_controls' %>
           <%= render 'case_comments/form' %>
           <% @case.events.each do |event| %>
             <%= event.decorate.event_card %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
         post :close  # Only admins may close a case
         post :assign  # Only admins may (re)assign a case
         post :set_time
+        post :set_commenting
       end
     end
 

--- a/db/migrate/20180611103418_add_comments_enabled_to_case.rb
+++ b/db/migrate/20180611103418_add_comments_enabled_to_case.rb
@@ -1,0 +1,5 @@
+class AddCommentsEnabledToCase < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cases, :comments_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_05_135005) do
+ActiveRecord::Schema.define(version: 2018_06_11_103418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2018_06_05_135005) do
     t.string "display_id", null: false
     t.integer "time_worked", default: 0, null: false
     t.integer "credit_charge"
+    t.boolean "comments_enabled", default: false
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["component_id"], name: "index_cases_on_component_id"

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -287,6 +287,27 @@ RSpec.describe 'Case page' do
         expect(find('.alert')).to have_text('New comment added')
 
       end
+
+      it 'allows admin to enable commenting when disabled' do
+        visit case_path(subject, as: admin)
+        click_link 'Enable'
+
+        subject.reload
+        expect(subject.comments_enabled).to eq true
+        expect(find('.alert-success')).to have_text "Commenting enabled for contacts on case #{subject.display_id}"
+      end
+
+      it 'allows admin to disable commenting when enabled' do
+        subject.comments_enabled = true
+        subject.save
+
+        visit case_path(subject, as: admin)
+        click_link 'Disable'
+
+        subject.reload
+        expect(subject.comments_enabled).to eq false
+        expect(find('.alert-success')).to have_text "Commenting disabled for contacts on case #{subject.display_id}"
+      end
     end
 
     it 'allows a comment to be added' do
@@ -299,7 +320,7 @@ RSpec.describe 'Case page' do
 
       expect(open_case.case_comments.count).to be 1
       expect(find('.event-card').find('.card-body').text).to eq('This is a test comment')
-      expect(find('.alert')).to have_text('New comment added')
+      expect(find('.alert-success')).to have_text('New comment added')
     end
 
     it 'does not allow empty comments' do
@@ -311,7 +332,7 @@ RSpec.describe 'Case page' do
       open_case.reload
 
       expect(open_case.case_comments.count).to be 0
-      expect(find('.alert')).to have_text('Empty comments are not permitted')
+      expect(find('.alert-danger')).to have_text('Empty comments are not permitted')
     end
 
     %w(resolved closed).each do |state|

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -270,6 +270,23 @@ RSpec.describe 'Case page' do
 
         expect(find('.card.bg-light').text).to match 'Additional discussion is not available for cases in the current support tier'
       end
+
+      it 'enables commenting for site contact if comments_enabled is true' do
+        subject.comments_enabled = true
+        subject.save
+
+        visit case_path(subject, as: contact)
+
+        fill_in 'case_comment_text', with: 'This is a test comment'
+        click_button 'Add new comment'
+
+        subject.reload
+
+        expect(subject.case_comments.count).to be 1
+        expect(find('.event-card').find('.card-body').text).to eq('This is a test comment')
+        expect(find('.alert')).to have_text('New comment added')
+
+      end
     end
 
     it 'allows a comment to be added' do

--- a/spec/models/case_commenting_spec.rb
+++ b/spec/models/case_commenting_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe CaseCommenting do
             'Additional discussion is not available'
           )
         end
+
+        context 'when commenting explicitly enabled' do
+          before :each do
+            allow(kase).to receive(:comments_enabled).and_return(true)
+          end
+
+          include_examples 'commenting enabled'
+        end
       end
     end
   end


### PR DESCRIPTION
This PR allows contacts to comment on tier 1/2 cases, where they otherwise would not be able to, when permitted to do so by an admin.

Admins viewing open tier 1/2 cases will now see an option to enable commenting for contacts. For cases where commenting has been enabled, they will see a similar option to disable commenting.

Note that there's a display bug here: the `a.btn` within the `.alert` is being given a `text-decoration: underline;` that it shouldn't. I've fixed this already in one of the other branches I've been working on where this came up, so it'll be resolved when that branch gets merged into develop.

Closes #319.

Trello: https://trello.com/c/kcUUpdIh/341-allow-admins-to-enable-disable-user-communication-box-on-a-tier-1-2-case