### PR TITLE
Handle invalid SSO tokens without raising HTTP 500 errors

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,11 @@ class User < ApplicationRecord
       #  u.name = claims.fetch('username')
       #  u.save
     end
+  rescue JWT::DecodeError
+    # Either the token isn't syntactically valid (not Base64-encoded valid JSON)
+    # or else signature verification failed (fraudulent token, or staging token
+    # being used in production or vice versa).
+    nil
   end
 
   def remember_token

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -133,4 +133,23 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#from_jwt-token' do
+    let(:email_address) { 'some.user@example.com' }
+    let!(:user) { create(:contact, email: email_address) }
+
+    let(:valid_token) {
+      ::JsonWebToken.encode(email: email_address)
+    }
+
+    it 'returns user from valid token' do
+      expect(User.from_jwt_token(valid_token)).to eq user
+    end
+
+    it 'returns nil from invalid token' do
+      # A primitive way of invalidating the token but it works...
+      invalid_token = valid_token << 'F'
+      expect(User.from_jwt_token(invalid_token)).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
This PR handles the case where an invalid (either syntactically or semantically) SSO token was leading to a server error, by instead making `User.from_jwt_token` return `nil` in those cases.

I've also added a couple of tests for that method.

Trello: https://trello.com/c/xdF4dcDH/349-fix-500-when-sso-token-verification-fails