### PR TITLE
Clickable case row

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -94,3 +94,8 @@ table {
     width: 99%
   }
 }
+
+[onclick] {
+  cursor: pointer;
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -98,13 +98,3 @@ table {
 [onclick] {
   cursor: pointer;
 }
-
-.dim { opacity: 1; transition: opacity .15s ease-in; }
-.dim:hover, .dim:focus {
-  opacity: .6;
-  transition: opacity .15s ease-in;
-  background-color: #f7f7f7;
-  outline: 2px ridge #dee2e6;
-}
-.dim:active { opacity: .8; transition: opacity .15s ease-out; }
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -99,3 +99,12 @@ table {
   cursor: pointer;
 }
 
+.dim { opacity: 1; transition: opacity .15s ease-in; }
+.dim:hover, .dim:focus {
+  opacity: .6;
+  transition: opacity .15s ease-in;
+  background-color: #f7f7f7;
+  outline: 2px ridge #dee2e6;
+}
+.dim:active { opacity: .8; transition: opacity .15s ease-out; }
+

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -60,7 +60,7 @@
   }
   a {
     &:hover, &:focus, &:active {
-      font-weight: 500;
+      color: black;
     }
   }
 }

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -44,3 +44,23 @@
 .assigned-cases {
   background-color: rgba(39,148,216,0.1);
 }
+
+.case-highlight {
+  opacity: 1;
+  transition: opacity .15s ease-in;
+  &:hover, &:focus {
+    opacity: .6;
+    transition: opacity .15s ease-in;
+    background-color: #f7f7f7;
+    outline: 2px ridge #dee2e6;
+  }
+  &:active {
+    opacity: .8;
+    transition: opacity .15s ease-out;
+  }
+  a {
+    &:hover, &:focus, &:active {
+      font-weight: 500;
+    }
+  }
+}

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -15,6 +15,8 @@
         <%= kase.assignee&.name || 'Nobody' %>
       <% end %>
     </td>
+    <%# The below onclick makes sure that the onlick event within the row does
+      not get triggered when clicking the link within this column. %>
   <td onclick='event.stopPropagation();'><%= kase.association_info %></td>
   <% if kase.resolved? || kase.closed? %>
     <td><%= kase.credit_charge&.amount %></td>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,19 +1,20 @@
-<tr class='dim', onclick="window.location.href='<%= scope.dashboard_case_path(kase) %>'">
-  <td><%= link_to kase.display_id, scope.dashboard_case_path(kase) %></td>
-  <%= timestamp_td(
-    description:  'Support case created',
-    timestamp: kase.created_at
-  ) %>
-  <td><%= kase.user_facing_state %></td>
-  <td style="white-space: nowrap;"><%= kase.user.name %></td>
-  <td><%= kase.subject %></td>
-  <td>
-    <% if current_user == kase.assignee %>
-      <%= raw('<strong>Me</strong>') %>
-    <% else %>
-      <%= kase.assignee&.name || 'Nobody' %>
-    <% end %>
-  </td>
+<tr class='case-highlight'
+  onclick="window.location.href='<%= scope.dashboard_case_path(kase) %>'">
+    <td><%= link_to kase.display_id, scope.dashboard_case_path(kase) %></td>
+    <%= timestamp_td(
+      description:  'Support case created',
+      timestamp: kase.created_at
+    ) %>
+    <td><%= kase.user_facing_state %></td>
+    <td style="white-space: nowrap;"><%= kase.user.name %></td>
+    <td><%= kase.subject %></td>
+    <td>
+      <% if current_user == kase.assignee %>
+        <%= raw('<strong>Me</strong>') %>
+      <% else %>
+        <%= kase.assignee&.name || 'Nobody' %>
+      <% end %>
+    </td>
   <td onclick='event.stopPropagation();'><%= kase.association_info %></td>
   <% if kase.resolved? || kase.closed? %>
     <td><%= kase.credit_charge&.amount %></td>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -14,7 +14,7 @@
       <%= kase.assignee&.name || 'Nobody' %>
     <% end %>
   </td>
-  <td><%= kase.association_info %></td>
+  <td onclick='event.stopPropagation();'><%= kase.association_info %></td>
   <% if kase.resolved? || kase.closed? %>
     <td><%= kase.credit_charge&.amount %></td>
   <% end %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr class='dim', onclick="window.location.href='<%= scope.dashboard_case_path(kase) %>'">
   <td><%= link_to kase.display_id, scope.dashboard_case_path(kase) %></td>
   <%= timestamp_td(
     description:  'Support case created',

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,6 +1,6 @@
 <tr class='case-highlight'
   onclick="window.location.href='<%= scope.dashboard_case_path(kase) %>'">
-    <td><%= link_to kase.display_id, scope.dashboard_case_path(kase) %></td>
+    <td><%= kase.display_id %></td>
     <%= timestamp_td(
       description:  'Support case created',
       timestamp: kase.created_at


### PR DESCRIPTION
This PR highlights and makes the case row clickable. On click the user is redirected to the associated case page, just like the link via the case ID on the current site. However the links in the `Association` column still function as before.

During review it would be worth experimenting with the opacity within the `case-highlight` class found within `cases.scss`. You may find it looks better without any change in opacity but the option is there if you did want it that way.

It is also worth checking that links in the row are still distinct enough to stand out. I experimented with various css changes to try and find something that worked but it may not be enough.

[Trello](https://trello.com/c/tzcE8SSw/350-make-clicking-anywhere-on-case-row-in-table-link-to-case-page)