### PR TITLE
Use a styled `div` rather than `blockquote` in emails.

### DIFF
--- a/app/views/case_mailer/comment.html.erb
+++ b/app/views/case_mailer/comment.html.erb
@@ -2,8 +2,8 @@
 
 <h3><%= @case.display_id %> <%= @case.ticket_subject %></h3>
 
-<blockquote>
+<div class="blockquote">
   <%= simple_format(@comment.text) %>
   <br />
   <cite><%= @comment.updated_at.to_formatted_s(:long) %> - <b><%= @comment.user.name %></b></cite>
-</blockquote>
+</div>

--- a/app/views/case_mailer/new_case.html.erb
+++ b/app/views/case_mailer/new_case.html.erb
@@ -2,7 +2,7 @@
 
 <h3><%= @case.display_id %> <%= @case.ticket_subject %></h3>
 
-<blockquote>
+<div class="blockquote">
   <% @case.email_properties.each do |key, value| %>
     <strong><%= key %>:</strong>
     <% if value.is_a?(Hash) %>
@@ -20,4 +20,4 @@
     <br/>
   <% end %>
   <cite><%= @case.created_at.to_formatted_s(:long) %> - <b><%= @case.user.name %></b></cite>
-</blockquote>
+</div>

--- a/app/views/layouts/mailer/_inline_main.scss
+++ b/app/views/layouts/mailer/_inline_main.scss
@@ -118,7 +118,7 @@ code {
     padding: 2px 4px;
 }
 
-blockquote {
+blockquote, div.blockquote {
     padding: 1rem;
     border-radius: 5px;
     box-shadow: 0 0 5px $c-primary-color;

--- a/app/views/layouts/mailer/_inline_main.scss
+++ b/app/views/layouts/mailer/_inline_main.scss
@@ -118,7 +118,7 @@ code {
     padding: 2px 4px;
 }
 
-blockquote, div.blockquote {
+div.blockquote {
     padding: 1rem;
     border-radius: 5px;
     box-shadow: 0 0 5px $c-primary-color;


### PR DESCRIPTION
Hopefully this will stop Mark's email client from getting confused.

Fixes #335.

Trello: https://trello.com/c/VoWTgepK/348-blockquote-tag-in-email-confuses-airmail-email-client