### PR TITLE
Use Turbolinks.visit to avoid full page refresh

### DIFF
--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -34,7 +34,8 @@
             >
               <script type="text/javascript">
                 function viewCreditPeriod(date) {
-                  window.location.href = "<%= cluster_credit_usage_path(cluster) %>/" + date;
+                  var url = "<%= cluster_credit_usage_path(cluster) %>/" + date;
+                  Turbolinks.visit(url);
                 }
               </script>
               <label for="start_date">

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -1,5 +1,5 @@
 <tr class='case-highlight'
-  onclick="window.location.href='<%= scope.dashboard_case_path(kase) %>'">
+  onclick="Turbolinks.visit('<%= scope.dashboard_case_path(kase) %>')">
     <td><%= kase.display_id %></td>
     <%= timestamp_td(
       description:  'Support case created',


### PR DESCRIPTION
By directly setting `window.location.href` in JS, these event handlers
were causing full page refreshes, slowing down the navigation and making
this transition more jarring than normal navigation via `a` links etc.,
which uses Turbolinks. Using `Turbolink.visit` in these places instead
fixes this.

Fixes
https://trello.com/c/2lJRAgSV/356-prevent-full-page-refresh-from-couple-of-places-using-windowlocationhref.