### PR TITLE
Distinguish case history cards more

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,8 +18,8 @@
 //= require_tree .
 //
 
-function enable_tooltips() {
+function enableTooltips() {
   $('[title]').tooltip({delay: {show: 500, hide: 100}, placement: 'left'});
 }
 
-document.addEventListener('turbolinks:load', enable_tooltips);
+document.addEventListener('turbolinks:load', enableTooltips);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,8 +18,8 @@
 //= require_tree .
 //
 
-function enable_tooltips () {
-  $('[title]').tooltip({ delay: { show: 500, hide: 100 }, placement: "left" })
+function enable_tooltips() {
+  $('[title]').tooltip({delay: {show: 500, hide: 100}, placement: 'left'});
 }
 
 document.addEventListener('turbolinks:load', enable_tooltips);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,7 @@
 //
 
 function enable_tooltips () {
-  $('[data-toggle="tooltip"]').tooltip()
+  $('[title]').tooltip()
 }
 
 document.addEventListener('turbolinks:load', enable_tooltips);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,7 @@
 //
 
 function enable_tooltips () {
-  $('[title]').tooltip({ delay: { show: 500, hide: 100 }})
+  $('[title]').tooltip({ delay: { show: 500, hide: 100 }, placement: "left" })
 }
 
 document.addEventListener('turbolinks:load', enable_tooltips);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,7 @@
 //
 
 function enable_tooltips () {
-  $('[title]').tooltip()
+  $('[title]').tooltip({ delay: { show: 500, hide: 100 }})
 }
 
 document.addEventListener('turbolinks:load', enable_tooltips);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,10 @@
 //= require popper
 //= require bootstrap-sprockets
 //= require_tree .
+//
+
+function enable_tooltips () {
+  $('[data-toggle="tooltip"]').tooltip()
+}
+
+document.addEventListener('turbolinks:load', enable_tooltips);

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -22,20 +22,22 @@ module Audited
 
       type = send("#{field}_type")
       text = send("#{field}_text", from, to)
+      details = send("#{field}_details")
       admin_only = ADMIN_ONLY_CARDS.include?(field)
 
       if text
-        render_card(date, user&.name || 'Flight Center', type, text, admin_only)
+        render_card(date, user&.name || 'Flight Center', type, text, details, admin_only)
       end
     end
 
-    def render_card(date, name, type, text, admin_only)
+    def render_card(date, name, type, text, details, admin_only)
       h.render 'cases/event',
                admin_only: admin_only,
                date: date,
                name: name,
                text: text,
-               type: type
+               type: type,
+               details: details
     end
 
     def assignee_id_text(from, to)
@@ -54,12 +56,20 @@ module Audited
       'user'
     end
 
+    def assignee_id_details
+      'Assignee Change'
+    end
+
     def time_worked_text(from, to)
       "Changed time worked from #{format_minutes(from)} to #{format_minutes(to)}."
     end
 
     def time_worked_type
       'hourglass-half'
+    end
+
+    def time_worked_details
+      'Time Added'
     end
 
     def format_minutes(mins)
@@ -83,6 +93,10 @@ module Audited
 
     def tier_level_type
       'chevron-circle-up'
+    end
+
+    def tier_level_details
+      'Tier Change'
     end
   end
 end

--- a/app/decorators/case_comment_decorator.rb
+++ b/app/decorators/case_comment_decorator.rb
@@ -6,7 +6,8 @@ class CaseCommentDecorator < ApplicationDecorator
              date: object.created_at,
              text: object.rendered_text,
              formatted: true,
-             type: 'comment-o'
+             type: 'comment-o',
+             details: 'Comment'
   end
 
 end

--- a/app/decorators/case_state_transition_decorator.rb
+++ b/app/decorators/case_state_transition_decorator.rb
@@ -5,7 +5,8 @@ class CaseStateTransitionDecorator < ApplicationDecorator
        name: object.user.name,
        date: object.created_at,
        text: text,
-       type: icon
+       type: icon,
+       details: 'Case Transition'
   end
 
   private

--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -18,6 +18,7 @@ class CreditChargeDecorator < ApplicationDecorator
              date: created_at,
              name: user.name,
              text:  "A charge of #{h.pluralize(amount, 'credit')} was added for this case.",
-             type: 'usd'
+             type: 'usd',
+             details: 'Credit Charge'
   end
 end

--- a/app/decorators/log_decorator.rb
+++ b/app/decorators/log_decorator.rb
@@ -5,6 +5,7 @@ class LogDecorator < ApplicationDecorator
              date: object.created_at,
              text: object.rendered_details,
              formatted: true,
-             type: 'pencil-square-o'
+             type: 'pencil-square-o',
+             details: 'Log Entry'
   end
 end

--- a/app/decorators/maintenance_window_state_transition_decorator.rb
+++ b/app/decorators/maintenance_window_state_transition_decorator.rb
@@ -5,7 +5,8 @@ class MaintenanceWindowStateTransitionDecorator < ApplicationDecorator
              date: object.created_at,
              name: object.user&.name || 'Flight Center',
              text: comment_text,
-             type: 'wrench'
+             type: 'wrench',
+             details: 'Maintenance Information'
   end
 
   def comment_text

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -2,7 +2,7 @@
   <div class="card event-card">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
       <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
-      <%= icon(type) %>
+      <%= details %> &nbsp; <%= icon(type) %>
     </div>
     <div class="card-body">
         <% if local_assigns.fetch(:formatted, false) %>

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -2,7 +2,9 @@
   <div class="card event-card">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
       <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
-      <%= details %> &nbsp; <%= icon(type) %>
+      <div data-toggle="tooltip" data-placement="left" title="<%= details %>">
+          <%= icon(type) %>
+      </div>
     </div>
     <div class="card-body">
         <% if local_assigns.fetch(:formatted, false) %>

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -2,7 +2,7 @@
   <div class="card event-card">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
       <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
-      <div data-toggle="tooltip" data-placement="left" title="<%= details %>">
+      <div title="<%= details %>">
           <%= icon(type) %>
       </div>
     </div>


### PR DESCRIPTION
The changes made in this PR are somewhat subtle but that is by design. Making the cards more distinguishable without making them intrusive and ugly proved problematic. Therefore I opted with using Boostrap Tooltips that give more context to the icons when the user hovers over them. Hopefully this should clear any confusion that comes from these.

This had the knock on effect of making other areas where we use `title` as a tooltip to use this Bootstrap styling for them. Which should make those look a bit nicer than before as well.

[Trello](https://trello.com/c/Fvlb0KFq/352-consider-distinguishing-case-history-cards-more)