### PR TITLE
Disable all the things for viewers

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -62,11 +62,14 @@ a.btn.disabled {
   }
 }
 
-button.btn.disabled {
-  // Do not change text color of disabled buttons on hover, since this implies
-  // they could be interacted with.
-  &:hover {
-    color: inherit;
+// Do not change text colour of disabled buttons/button links on hover, since
+// this implies they could be interacted with. This is not completely ideal as
+// this overrides the non-disabled button text colour, but I couldn't find
+// another way to do this which consistently works across every button type
+// (`button`/`a`/`input`) and style (`btn-primary`/`btn-warning` etc.).
+.btn.disabled {
+  &, &:hover {
+    color: white !important;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -62,6 +62,14 @@ a.btn.disabled {
   }
 }
 
+button.btn.disabled {
+  // Do not change text color of disabled buttons on hover, since this implies
+  // they could be interacted with.
+  &:hover {
+    color: inherit;
+  }
+}
+
 .elm-overlay {
   // So Elm debugger always appears on top in development.
   z-index: 10000;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,6 +47,13 @@ body {
   // if this changes to cross threshold where scrollbar would be needed while
   // using app.
   overflow-y: scroll;
+
+  // Override Bootstrap setting `pointer-events: none` on disabled button links
+  // (see https://github.com/twbs/bootstrap/issues/17703), so title text on
+  // these links is shown and cursor changes appropriately.
+  a.btn.disabled {
+    pointer-events: auto;
+  }
 }
 
 .elm-overlay {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,18 +47,18 @@ body {
   // if this changes to cross threshold where scrollbar would be needed while
   // using app.
   overflow-y: scroll;
+}
 
-  // Override Bootstrap setting `pointer-events: none` on disabled button links
-  // (see https://github.com/twbs/bootstrap/issues/17703), so title text on
-  // these links is shown and cursor changes appropriately.
-  a.btn.disabled {
-    pointer-events: auto;
+// Override Bootstrap setting `pointer-events: none` on disabled button links
+// (see https://github.com/twbs/bootstrap/issues/17703), so title text on these
+// links is shown and cursor changes appropriately.
+a.btn.disabled {
+  pointer-events: auto !important;
 
-    // Prevent default Bootstrap styling of focused button link (so should
-    // appear same as if unfocused).
-    &:focus {
-      box-shadow: none;
-    }
+  // Prevent default Bootstrap styling of focused button link (so should appear
+  // same as if unfocused).
+  &:focus {
+    box-shadow: none !important;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,6 +53,12 @@ body {
   // these links is shown and cursor changes appropriately.
   a.btn.disabled {
     pointer-events: auto;
+
+    // Prevent default Bootstrap styling of focused button link (so should
+    // appear same as if unfocused).
+    &:focus {
+      box-shadow: none;
+    }
   }
 }
 

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -1,8 +1,9 @@
 class ClustersController < ApplicationController
   decorates_assigned :cluster
 
-  # :credit_usage is a read-only action so should not require authorization.
-  after_action :verify_authorized, except: NO_AUTH_ACTIONS + [:credit_usage]
+  additional_read_only_actions = [:credit_usage, :documents]
+  after_action :verify_authorized,
+    except: NO_AUTH_ACTIONS + additional_read_only_actions
 
   def credit_usage
     credit_events = ClusterCreditEvents.new(@cluster, start_date, end_date)

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -11,7 +11,7 @@ class ApplicationDecorator < Draper::Decorator
   #   end
 
   def start_maintenance_request_link
-    return unless h.current_user.admin?
+    return unless Pundit.policy!(h.current_user, MaintenanceWindow).create?
 
     title = "Start request for maintenance of this #{readable_model_name}"
     h.link_to(

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -11,7 +11,7 @@ class ApplicationDecorator < Draper::Decorator
   #   end
 
   def start_maintenance_request_link
-    return unless Pundit.policy!(h.current_user, MaintenanceWindow).create?
+    return unless policy(MaintenanceWindow).create?
 
     title = "Start request for maintenance of this #{readable_model_name}"
     h.link_to(
@@ -60,6 +60,12 @@ class ApplicationDecorator < Draper::Decorator
   end
 
   private
+
+  # Method with same signature as `policy` method provided by Pundit in views,
+  # so can use `policy(Foo).bar?` in decorators in the same way as in views.
+  def policy(record_or_class)
+    Pundit.policy!(h.current_user, record_or_class)
+  end
 
   def convert_scope_path(s)
     name_for_path = scope_name_for_paths.dup.tap do |name|

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -126,6 +126,9 @@ class ApplicationDecorator < Draper::Decorator
   end
 
   def tabs_builder
-    @tabs_builder ||= TabsBuilder.new(object)
+    @tabs_builder ||= TabsBuilder.new(
+      user: h.current_user,
+      scope: object,
+    )
   end
 end

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -35,10 +35,6 @@ class CaseDecorator < ApplicationDecorator
     h.tier_description(tier_level)
   end
 
-  def commenting_disabled?
-    commenting.disabled?
-  end
-
   def commenting_disabled_text
     commenting.disabled_text
   end

--- a/app/decorators/cluster_part_decorator.rb
+++ b/app/decorators/cluster_part_decorator.rb
@@ -66,8 +66,7 @@ class ClusterPartDecorator < ApplicationDecorator
       "Are you sure you want to request #{change_description} of #{name}?"
     confirm_text = [confirm_question, change_details.squish].join("\n\n")
 
-    h.button_to "Request #{change_description}",
-      h.cases_path,
+    default_html_options = {
       class: "btn #{button_class} support-type-button",
       title: issue.name,
       params: {
@@ -80,5 +79,16 @@ class ClusterPartDecorator < ApplicationDecorator
         }
       },
       data: { confirm: confirm_text }
+    }
+
+    action_description = "request #{change_description} of a #{readable_model_name}"
+    html_options = PolicyDependentOptions.wrap(
+      default_html_options,
+      policy: policy(Case).create?,
+      action_description: action_description,
+      user: h.current_user
+    )
+
+    h.button_to "Request #{change_description}", h.cases_path, html_options
   end
 end

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -2,7 +2,7 @@ class NoteDecorator < ApplicationDecorator
   delegate_all
 
   def subtitle
-    if current_user.admin?
+    if h.current_user.admin?
       "#{flavour.capitalize} notes"
     else
       "Cluster notes"
@@ -10,16 +10,16 @@ class NoteDecorator < ApplicationDecorator
   end
 
   def new_form_intro
-    if current_user.admin?
+    if h.current_user.admin?
       "There are currently no #{flavour} notes for this cluster. You may add
-      them below."
+      them below.".squish
     else
       "There are currently no notes for this cluster. You may add them below."
     end
   end
 
   def edit_form_intro
-    if current_user.admin?
+    if h.current_user.admin?
       "Edit the #{flavour} notes for this cluster below."
     else
       'Edit your cluster notes below.'

--- a/app/decorators/note_decorator.rb
+++ b/app/decorators/note_decorator.rb
@@ -13,16 +13,24 @@ class NoteDecorator < ApplicationDecorator
     if h.current_user.admin?
       "There are currently no #{flavour} notes for this cluster. You may add
       them below.".squish
-    else
+    elsif h.current_user.contact?
       "There are currently no notes for this cluster. You may add them below."
+    elsif h.current_user.viewer?
+      "There are currently no notes for this cluster."
+    else
+      raise_as_unhandled
     end
   end
 
   def edit_form_intro
     if h.current_user.admin?
       "Edit the #{flavour} notes for this cluster below."
-    else
+    elsif h.current_user.contact?
       'Edit your cluster notes below.'
+    else
+      # Viewers are the only other role at the moment, and they cannot access
+      # the edit notes page.
+      raise_as_unhandled
     end
   end
 
@@ -36,5 +44,11 @@ class NoteDecorator < ApplicationDecorator
 
   def form_path
     [note.cluster, note]
+  end
+
+  private
+
+  def raise_as_unhandled
+    raise "Don't know how to handle this user"
   end
 end

--- a/app/helpers/policy_dependent_options.rb
+++ b/app/helpers/policy_dependent_options.rb
@@ -1,0 +1,33 @@
+
+class PolicyDependentOptions
+  def self.wrap(options, **kwargs)
+    new(options, **kwargs).wrap
+  end
+
+  def wrap
+    policy ? options : disabled_options
+  end
+
+  private
+
+  attr_reader :options, :policy, :action_description, :user
+
+  def initialize(options, policy:, action_description:, user:)
+    @options = options
+    @policy = policy
+    @action_description = action_description
+    @user = user
+  end
+
+  def disabled_options
+    options.merge(
+      disabled: true,
+      title: "As a #{user.role} you cannot #{action_description}",
+      class: disabled_classes
+    )
+  end
+
+  def disabled_classes
+    Array.wrap(options[:class]) + ['disabled']
+  end
+end

--- a/app/helpers/policy_dependent_options.rb
+++ b/app/helpers/policy_dependent_options.rb
@@ -22,6 +22,7 @@ class PolicyDependentOptions
   def disabled_options
     options.merge(
       disabled: true,
+      onclick: 'return false;',
       title: "As a #{user.role} you cannot #{action_description}",
       class: disabled_classes
     )

--- a/app/helpers/policy_dependent_options.rb
+++ b/app/helpers/policy_dependent_options.rb
@@ -20,6 +20,10 @@ class PolicyDependentOptions
   end
 
   def disabled_options
+    # `disabled` attribute is all that is needed to appropriately disable real
+    # buttons; `disabled` class is needed to style button links like disabled
+    # buttons, and this `onclick` attribute is also needed to prevent normal
+    # click handling on button links.
     options.merge(
       disabled: true,
       onclick: 'return false;',

--- a/app/helpers/tabs_builder.rb
+++ b/app/helpers/tabs_builder.rb
@@ -49,7 +49,7 @@ class TabsBuilder
   attr_reader :user, :scope
 
   def new_case_entry
-    if user.editor?
+    if Pundit.policy!(user, Case).create?
       {
         text: 'Create',
         path: scope.new_scope_case_path,

--- a/app/helpers/tabs_builder.rb
+++ b/app/helpers/tabs_builder.rb
@@ -1,6 +1,7 @@
 
 class TabsBuilder
-  def initialize(scope)
+  def initialize(user:, scope:)
+    @user = user
     @scope = scope.decorate
   end
 
@@ -12,10 +13,10 @@ class TabsBuilder
     {
       id: :cases, path: scope.scope_cases_path,
       dropdown: [
-        { text: 'Create', path: scope.new_scope_case_path },
+        new_case_entry,
         { text: "Current (#{scope.cases.active.size})", path: scope.scope_cases_path },
         { text: 'Resolved', path: scope.resolved_scope_cases_path }
-      ]
+      ].compact
     }
   end
 
@@ -45,5 +46,14 @@ class TabsBuilder
 
   private
 
-  attr_reader :scope
+  attr_reader :user, :scope
+
+  def new_case_entry
+    if user.editor?
+      {
+        text: 'Create',
+        path: scope.new_scope_case_path,
+      }
+    end
+  end
 end

--- a/app/helpers/tabs_builder.rb
+++ b/app/helpers/tabs_builder.rb
@@ -14,8 +14,8 @@ class TabsBuilder
       id: :cases, path: scope.scope_cases_path,
       dropdown: [
         new_case_entry,
-        { text: "Current (#{scope.cases.active.size})", path: scope.scope_cases_path },
-        { text: 'Resolved', path: scope.resolved_scope_cases_path }
+        current_cases_entry,
+        resolved_cases_entry,
       ].compact
     }
   end
@@ -55,5 +55,19 @@ class TabsBuilder
         path: scope.new_scope_case_path,
       }
     end
+  end
+
+  def current_cases_entry
+    {
+      text: "Current (#{scope.cases.active.size})",
+      path: scope.scope_cases_path,
+    }
+  end
+
+  def resolved_cases_entry
+    {
+      text: 'Resolved',
+      path: scope.resolved_scope_cases_path,
+    }
   end
 end

--- a/app/views/asset_records/show.html.erb
+++ b/app/views/asset_records/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:subtitle) { 'Asset Record' } %>
 <%= render 'partials/tabs', activate: :asset_record do %>
-  <% if current_user.admin? %>
+  <% if policy(:asset_record).edit? %>
     <div class='nav nav-tabs nav-justified'>
       <%= link_to 'Edit',
                   @scope.decorate.edit_asset_record_path,

--- a/app/views/case_comments/_form.html.erb
+++ b/app/views/case_comments/_form.html.erb
@@ -1,15 +1,4 @@
-<% if @case.commenting_disabled? %>
-
- <div class="card bg-light">
-   <div class="card-body">
-     <span class="float-left mr-3">
-       <%= icon('info') %>
-     </span>
-     <%= @case.commenting_disabled_text %>
-   </div>
- </div>
-
-<% else %>
+<% if policy(@comment).create? %>
 
   <%= form_for [@case, @comment] do |f| %>
     <div class="form-group">
@@ -24,5 +13,16 @@
       %>
     </div>
   <% end %>
+
+<% else %>
+
+ <div class="card bg-light">
+   <div class="card-body">
+     <span class="float-left mr-3">
+       <%= icon('info') %>
+     </span>
+     <%= @case.commenting_disabled_text %>
+   </div>
+ </div>
 
 <% end %>

--- a/app/views/cases/_case_assignment_controls.html.erb
+++ b/app/views/cases/_case_assignment_controls.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? %>
+<% if policy(@case).assign? %>
   <%= form_for @case, url: assign_case_path, method: :post do |f| %>
     <div class="form-group">
       <div class="input-group">

--- a/app/views/cases/_case_comment_toggle_controls.html.erb
+++ b/app/views/cases/_case_comment_toggle_controls.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? && @case.comments_could_be_enabled? %>
+<% if policy(@case).set_commenting? && @case.comments_could_be_enabled? %>
   <div class="alert alert-info d-flex justify-content-between align-items-center">
     <i class="fa fa-info fa-2x mr-2"></i>
     <span style="flex-grow: 1">

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -1,41 +1,40 @@
-<% if current_user.admin? %>
-  <% if @case.can_resolve? %>
-    <%= link_to 'Resolve this case',
-                resolve_case_path(@case.id),
-                class: 'btn btn-secondary ml-2 btn-sm',
-                method: :post,
-                role: 'button',
-                title: 'Resolve this support case if it has been completed or is no longer relevant',
-                data: {
-                    confirm: 'Are you sure you want to resolve this support case?'
-                }
-    %>
-  <% end %>
-  <% if @case.can_close? %>
-    <%= form_tag({controller: 'cases', action: 'close'},
-                 method: :post,
-                 class: 'form-inline',
-                 id: 'case-close-form'
-        ) do %>
-      <div class="form-group">
-        <div class="input-group">
-          <%= number_field :credit_charge,
-                           :amount,
-                           class: 'form-control',
-                           min: 0,
-                           value: 0,
-                           required: 'required'
+
+<% if policy(@case).resolve? && @case.can_resolve? %>
+  <%= link_to 'Resolve this case',
+              resolve_case_path(@case.id),
+              class: 'btn btn-secondary ml-2 btn-sm',
+              method: :post,
+              role: 'button',
+              title: 'Resolve this support case if it has been completed or is no longer relevant',
+              data: {
+                  confirm: 'Are you sure you want to resolve this support case?'
+              }
+  %>
+<% end %>
+<% if policy(@case).close? && @case.can_close? %>
+  <%= form_tag({controller: 'cases', action: 'close'},
+               method: :post,
+               class: 'form-inline',
+               id: 'case-close-form'
+      ) do %>
+    <div class="form-group">
+      <div class="input-group">
+        <%= number_field :credit_charge,
+                         :amount,
+                         class: 'form-control',
+                         min: 0,
+                         value: 0,
+                         required: 'required'
+        %>
+        <div class="input-group-append">
+          <%= submit_tag 'Set charge and close case',
+                         class: 'form-control btn btn-primary',
+                         data: {
+                             confirm: 'Are you sure you want to close this support case?'
+                         }
           %>
-          <div class="input-group-append">
-            <%= submit_tag 'Set charge and close case',
-                           class: 'form-control btn btn-primary',
-                           data: {
-                               confirm: 'Are you sure you want to close this support case?'
-                           }
-            %>
-          </div>
         </div>
       </div>
-    <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.admin? %>
-  <% if @case.state == 'open' %>
+  <% if @case.can_resolve? %>
     <%= link_to 'Resolve this case',
                 resolve_case_path(@case.id),
                 class: 'btn btn-secondary ml-2 btn-sm',
@@ -10,7 +10,8 @@
                     confirm: 'Are you sure you want to resolve this support case?'
                 }
     %>
-  <% elsif @case.state == 'resolved' %>
+  <% end %>
+  <% if @case.can_close? %>
     <%= form_tag({controller: 'cases', action: 'close'},
                  method: :post,
                  class: 'form-inline',

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -4,13 +4,14 @@
       modal_label = 'escalateModalLabel'
 
       user_can_escalate = policy(@case).escalate?
+      disabled_class = user_can_escalate ? '' : 'disabled'
       disabled = !user_can_escalate
       title = disabled ? "As a #{current_user.role} you cannot escalate a case" : nil
   %>
 
   <%= button_tag 'Escalate',
     {
-      class: 'btn btn-warning btn-sm ml-2',
+      class: "btn btn-warning btn-sm ml-2 #{disabled_class}",
       data: {
         toggle: 'modal',
         target: "##{modal_id}",

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -1,3 +1,11 @@
+
+<%#
+  This is the same logic as `Case#comments_could_be_enabled?` although the
+  purpose is different - possibly there's some underlying shared concept for
+  when both these should be toggled that we should extract? Not sure if this is
+  just conincidental though and they could later independently change, which is
+  why I've not done this yet.
+%>
 <% if @case.open? && !@case.consultancy? %>
   <%
       modal_id = 'escalateModal'

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -2,23 +2,21 @@
   <%
       modal_id = 'escalateModal'
       modal_label = 'escalateModalLabel'
-
-      user_can_escalate = policy(@case).escalate?
-      disabled_class = user_can_escalate ? '' : 'disabled'
-      disabled = !user_can_escalate
-      title = disabled ? "As a #{current_user.role} you cannot escalate a case" : nil
   %>
 
   <%= button_tag 'Escalate',
-    {
-      class: "btn btn-warning btn-sm ml-2 #{disabled_class}",
-      data: {
-        toggle: 'modal',
-        target: "##{modal_id}",
+    PolicyDependentOptions.wrap(
+      {
+        class: "btn btn-warning btn-sm ml-2",
+        data: {
+          toggle: 'modal',
+          target: "##{modal_id}",
+        },
       },
-      disabled: disabled,
-      title: title,
-    }
+      policy: policy(@case).escalate?,
+      action_description: 'escalate a case',
+      user: current_user
+  )
   %>
 
   <div

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -1,7 +1,14 @@
 <% if @case.open? && !@case.consultancy? %>
-  <button type="button" class="btn btn-warning btn-sm ml-2" data-toggle="modal" data-target="#escalateModal">
-    Escalate
-  </button>
+  <%= button_tag 'Escalate',
+    {
+      class: 'btn btn-warning btn-sm ml-2',
+      data: {
+        toggle: 'modal',
+        target: '#escalateModal',
+      }
+    }
+  %>
+
   <div class="modal fade" id="escalateModal" tabindex="-1" role="dialog" aria-labelledby="escalateModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -1,19 +1,24 @@
 <% if @case.open? && !@case.consultancy? %>
+  <%
+      modal_id = 'escalateModal'
+      modal_label = 'escalateModalLabel'
+  %>
+
   <%= button_tag 'Escalate',
     {
       class: 'btn btn-warning btn-sm ml-2',
       data: {
         toggle: 'modal',
-        target: '#escalateModal',
+        target: "##{modal_id}",
       }
     }
   %>
 
-  <div class="modal fade" id="escalateModal" tabindex="-1" role="dialog" aria-labelledby="escalateModalLabel" aria-hidden="true">
+  <div class="modal fade" id="<%= modal_id %>" tabindex="-1" role="dialog" aria-labelledby="<%= modal_label %>" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="escalateModalLabel">Escalating this support case may incur charges</h5>
+          <h5 class="modal-title" id="<%= modal_label %>">Escalating this support case may incur charges</h5>
           <button class="close" data-dismiss="modal">×</button>
         </div>
         <div class="modal-body">

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -2,6 +2,10 @@
   <%
       modal_id = 'escalateModal'
       modal_label = 'escalateModalLabel'
+
+      user_can_escalate = policy(@case).escalate?
+      disabled = !user_can_escalate
+      title = disabled ? "As a #{current_user.role} you cannot escalate a case" : nil
   %>
 
   <%= button_tag 'Escalate',
@@ -10,7 +14,9 @@
       data: {
         toggle: 'modal',
         target: "##{modal_id}",
-      }
+      },
+      disabled: disabled,
+      title: title,
     }
   %>
 

--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -14,11 +14,20 @@
     }
   %>
 
-  <div class="modal fade" id="<%= modal_id %>" tabindex="-1" role="dialog" aria-labelledby="<%= modal_label %>" aria-hidden="true">
+  <div
+    class="modal fade"
+    id="<%= modal_id %>"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="<%= modal_label %>"
+    aria-hidden="true"
+  >
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="<%= modal_label %>">Escalating this support case may incur charges</h5>
+          <h5 class="modal-title" id="<%= modal_label %>">
+            Escalating this support case may incur charges
+          </h5>
           <button class="close" data-dismiss="modal">×</button>
         </div>
         <div class="modal-body">
@@ -27,7 +36,9 @@
           <p>Do you wish to continue?</p>
         </div>
         <div class="modal-footer">
-          <button class="btn btn-outline-primary" data-dismiss="modal">Cancel</button>
+          <button class="btn btn-outline-primary" data-dismiss="modal">
+            Cancel
+          </button>
           <%= link_to 'Escalate',
                       escalate_case_path(@case.id),
                       class: 'btn btn-outline-warning',

--- a/app/views/cases/_fields_or_requests_row.html.erb
+++ b/app/views/cases/_fields_or_requests_row.html.erb
@@ -23,7 +23,7 @@
     <th>Requested MOTD</th>
     <td>
       <%= simple_format(motd_request.motd) %>
-      <% if current_user.admin? %>
+      <% if policy(motd_request).apply? %>
         <%
             button_class, button_text =
               if motd_request.unapplied?

--- a/app/views/cases/_time_worked_row.html.erb
+++ b/app/views/cases/_time_worked_row.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin?
+<% if policy(@case).set_time?
   hours, minutes = @case.time_worked.divmod(60)
 %>
 <tr>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -19,7 +19,7 @@
         <th>Association</th>
         <td>
           <%= @case.association_info %>
-          <% if current_user.admin? && @case.open? %>
+          <% if policy(MaintenanceWindow).create? && @case.open? %>
             <%= link_to 'Request maintenance',
                         @case.request_maintenance_path,
                         class: 'btn btn-secondary ml-2 btn-sm',

--- a/app/views/clusters/_deposit_form.html.erb
+++ b/app/views/clusters/_deposit_form.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? %>
+<% if policy(cluster).deposit? %>
   <%= form_tag({controller: 'clusters', action: 'deposit'},
                method: :post,
                class: 'form',

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -30,8 +30,15 @@
         <%= simple_format(cluster.motd) %>
         <%= link_to "Request change",
             new_cluster_case_path(@cluster, tool: 'motd'),
-            role: 'button',
-            class: "btn btn-secondary"
+            PolicyDependentOptions.wrap(
+              {
+                role: 'button',
+                class: "btn btn-secondary",
+              },
+              policy: policy(Case).create?,
+              action_description: 'request a change to the MOTD',
+              user: current_user
+            )
         %>
       </li>
     </ul>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -7,7 +7,7 @@
     <div class="col-sm-12">
       <div class="card-deck mb-2">
         <%= render 'clusters/credit_balance', cluster: cluster do %>
-         <%= render 'clusters/deposit_form', cluster: cluster %>
+          <%= render 'clusters/deposit_form', cluster: cluster %>
         <% end %>
         <div class="card">
           <div class="card-body">

--- a/app/views/component_expansions/index.html.erb
+++ b/app/views/component_expansions/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:subtitle) { 'Expansions' } %>
 <%= render 'partials/tabs', activate: :expansions do %>
-  <% if current_user.admin? %>
+  <% if policy(ComponentExpansion).create? %>
     <div class='nav nav-tabs nav-justified'>
       <%= link_to 'Add, Update, or Delete Expansions',
                   edit_component_component_expansion_path(@scope),

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -29,7 +29,7 @@
 <% end %>
 
 
-<% if current_user.admin? %>
+<% if policy(@new_log).create? %>
   <div class='card'>
     <%= render 'partials/card_header_nav', title: 'Add Log' %>
     <div class='card-body table-responsive'>

--- a/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
+++ b/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
@@ -1,21 +1,13 @@
 
-<%
-  user_can_confirm_maintenance = policy(window).confirm?
-  confirm_disabled_class = user_can_confirm_maintenance ? '' : 'disabled'
-  confirm_disabled = !user_can_confirm_maintenance
-  confirm_title = if user_can_confirm_maintenance
-                    nil
-                  else
-                    "As a #{current_user.role} you cannot confirm maintenance"
-                  end
-%>
-
 <%= link_to(
   raw('Unconfirmed &mdash; click to confirm'),
   window.confirm_path,
-  class: ['btn', 'btn-success', 'btn-block', confirm_disabled_class],
-  disabled: confirm_disabled,
-  title: confirm_title
+  PolicyDependentOptions.wrap(
+    {class: ['btn', 'btn-success', 'btn-block']},
+    policy: policy(window).confirm?,
+    action_description: 'confirm maintenance',
+    user: current_user
+  )
 )
 %>
 

--- a/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
+++ b/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
@@ -22,13 +22,20 @@
 <% else %>
   <%= button_to 'Reject request for maintenance',
     reject_maintenance_window_path(window),
-    class: ['btn', 'btn-danger', 'btn-block'],
-    data: {
-      confirm: <<~EOF.squish
-        Are you sure you want to reject this requested maintenance? Alces
-        Software engineers will not be able to perform this maintenance until
-        you have confirmed it.
-      EOF
-    }
+    PolicyDependentOptions.wrap(
+      {
+        class: ['btn', 'btn-danger', 'btn-block'],
+        data: {
+          confirm: <<~EOF.squish
+            Are you sure you want to reject this requested maintenance? Alces
+            Software engineers will not be able to perform this maintenance
+            until you have confirmed it.
+          EOF
+        }
+      },
+      policy: policy(window).reject?,
+      action_description: 'reject maintenance',
+      user: current_user
+    )
   %>
 <% end %>

--- a/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
+++ b/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
@@ -6,7 +6,7 @@
 )
 %>
 
-<% if current_user.admin? %>
+<% if policy(window).cancel? %>
   <%= button_to 'Cancel request for maintenance',
     cancel_maintenance_window_path(window),
     class: ['btn', 'btn-warning', 'btn-block'],

--- a/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
+++ b/app/views/maintenance_windows/_unconfirmed_buttons.html.erb
@@ -1,8 +1,21 @@
 
+<%
+  user_can_confirm_maintenance = policy(window).confirm?
+  confirm_disabled_class = user_can_confirm_maintenance ? '' : 'disabled'
+  confirm_disabled = !user_can_confirm_maintenance
+  confirm_title = if user_can_confirm_maintenance
+                    nil
+                  else
+                    "As a #{current_user.role} you cannot confirm maintenance"
+                  end
+%>
+
 <%= link_to(
   raw('Unconfirmed &mdash; click to confirm'),
   window.confirm_path,
-  class: ['btn', 'btn-success', 'btn-block']
+  class: ['btn', 'btn-success', 'btn-block', confirm_disabled_class],
+  disabled: confirm_disabled,
+  title: confirm_title
 )
 %>
 

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -25,7 +25,7 @@
           <%= window.transition_info(:confirmed) ||
             render('maintenance_windows/unconfirmed_buttons', window: window) %>
 
-          <% if window.can_end? && current_user.admin? %>
+          <% if window.can_end? && policy(window).end? %>
             <%= button_to 'End ongoing maintenance',
               end_maintenance_window_path(window),
               class: ['btn', 'btn-danger', 'btn-block'],
@@ -37,7 +37,7 @@
             %>
           <% end %>
 
-          <% if window.can_extend_duration? && current_user.admin? %>
+          <% if window.can_extend_duration? && policy(window).extend? %>
             <%= form_tag(
               extend_maintenance_window_path(window),
               class: 'form-inline'

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -6,12 +6,14 @@
       <%= intro_text %>
     </p>
     <%= form_for note.form_path do |f| %>
-      <div class="form-group">
-        <%= f.text_area :description, class: 'form-control', rows: 10 %>
-      </div>
-      <p class="form-text text-muted">
-        Styling with markdown is supported
-      </p>
+      <% if policy(note).create? %>
+        <div class="form-group">
+          <%= f.text_area :description, class: 'form-control', rows: 10 %>
+        </div>
+        <p class="form-text text-muted">
+          Styling with markdown is supported
+        </p>
+      <% end %>
       <div class="form-group" style="overflow: hidden;">
         <%#
             This page is only rendered in the `new` case when the

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,23 +1,23 @@
 <div class="card-body">
-    <p>
+  <p>
     <%= intro_text %>
+  </p>
+  <%= form_for note.form_path do |f| %>
+    <div class="form-group">
+      <%= f.text_area :description, class: 'form-control', rows: 10 %>
+    </div>
+    <p class="form-text text-muted">
+      Styling with markdown is supported
     </p>
-    <%= form_for note.form_path do |f| %>
-        <div class="form-group">
-            <%= f.text_area :description, class: 'form-control', rows: 10 %>
-        </div>
-        <p class="form-text text-muted">
-            Styling with markdown is supported
-        </p>
-        <div class="form-group" style="overflow: hidden;">
-            <%= f.submit button_text,
-                PolicyDependentOptions.wrap(
-                    {class: dark_button_classes},
-                    policy: policy(note).create?,
-                    action_description: 'create cluster notes',
-                    user: current_user
-            )
-            %>
-        </div>
-    <% end %>
+    <div class="form-group" style="overflow: hidden;">
+      <%= f.submit button_text,
+        PolicyDependentOptions.wrap(
+          {class: dark_button_classes},
+          policy: policy(note).create?,
+          action_description: 'create cluster notes',
+          user: current_user
+      )
+      %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -13,6 +13,12 @@
         Styling with markdown is supported
       </p>
       <div class="form-group" style="overflow: hidden;">
+        <%#
+            This page is only rendered in the `new` case when the
+            `current_user` can't perform the action of the form, since users
+            who cannot edit cannot access the edit page. If this ever changes
+            then we may want to adjust the create-specific stuff below.
+        %>
         <%= f.submit button_text,
           PolicyDependentOptions.wrap(
             {class: dark_button_classes},

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,23 +1,27 @@
-<div class="card-body">
-  <p>
-    <%= intro_text %>
-  </p>
-  <%= form_for note.form_path do |f| %>
-    <div class="form-group">
-      <%= f.text_area :description, class: 'form-control', rows: 10 %>
-    </div>
-    <p class="form-text text-muted">
-      Styling with markdown is supported
+<% content_for(:subtitle) { note.subtitle } %>
+
+<%= render 'partials/tabs', activate: :notes do %>
+  <div class="card-body">
+    <p>
+      <%= intro_text %>
     </p>
-    <div class="form-group" style="overflow: hidden;">
-      <%= f.submit button_text,
-        PolicyDependentOptions.wrap(
-          {class: dark_button_classes},
-          policy: policy(note).create?,
-          action_description: 'create cluster notes',
-          user: current_user
-      )
-      %>
-    </div>
-  <% end %>
-</div>
+    <%= form_for note.form_path do |f| %>
+      <div class="form-group">
+        <%= f.text_area :description, class: 'form-control', rows: 10 %>
+      </div>
+      <p class="form-text text-muted">
+        Styling with markdown is supported
+      </p>
+      <div class="form-group" style="overflow: hidden;">
+        <%= f.submit button_text,
+          PolicyDependentOptions.wrap(
+            {class: dark_button_classes},
+            policy: policy(note).create?,
+            action_description: 'create cluster notes',
+            user: current_user
+        )
+        %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -10,7 +10,14 @@
             Styling with markdown is supported
         </p>
         <div class="form-group" style="overflow: hidden;">
-            <%= f.submit button_text, class: dark_button_classes %>
+            <%= f.submit button_text,
+                PolicyDependentOptions.wrap(
+                    {class: dark_button_classes},
+                    policy: policy(note).create?,
+                    action_description: 'create cluster notes',
+                    user: current_user
+            )
+            %>
         </div>
     <% end %>
 </div>

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -1,12 +1,14 @@
 <% content_for(:subtitle) { note.subtitle } %>
 
+<% can_create_note = policy(note).create? %>
+
 <%= render 'partials/tabs', activate: :notes do %>
   <div class="card-body">
     <p>
       <%= intro_text %>
     </p>
     <%= form_for note.form_path do |f| %>
-      <% if policy(note).create? %>
+      <% if can_create_note %>
         <div class="form-group">
           <%= f.text_area :description, class: 'form-control', rows: 10 %>
         </div>
@@ -24,7 +26,7 @@
         <%= f.submit button_text,
           PolicyDependentOptions.wrap(
             {class: dark_button_classes},
-            policy: policy(note).create?,
+            policy: can_create_note,
             action_description: 'create cluster notes',
             user: current_user
         )

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,5 +1,1 @@
-<% content_for(:subtitle) { note.subtitle } %>
-
-<%= render 'partials/tabs', activate: :notes do %>
-    <%= render 'form', intro_text: note.edit_form_intro, button_text: 'Update notes' %>
-<% end %>
+<%= render 'form', intro_text: note.edit_form_intro, button_text: 'Update notes' %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,5 +1,1 @@
-<% content_for(:subtitle) { note.subtitle } %>
-
-<%= render 'partials/tabs', activate: :notes do %>
-    <%= render 'form', intro_text: note.new_form_intro, button_text: 'Create notes' %>
-<% end %>
+<%= render 'form', intro_text: note.new_form_intro, button_text: 'Create notes' %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:subtitle) { note.subtitle } %>
 
 <%= render 'partials/tabs', activate: :notes do %>
-    <div class="card-body">
-        <%= note.rendered_description %>
-    </div>
-    <%= link_to 'Edit notes',
-        note.edit_path,
-        class: 'btn btn-secondary m-2 btn-sm',
-        role: 'button'
-    %>
+  <div class="card-body">
+    <%= note.rendered_description %>
+  </div>
+  <%= link_to 'Edit notes',
+    note.edit_path,
+    class: 'btn btn-secondary m-2 btn-sm',
+    role: 'button'
+  %>
 <% end %>

--- a/app/views/notes/show.html.erb
+++ b/app/views/notes/show.html.erb
@@ -6,7 +6,14 @@
   </div>
   <%= link_to 'Edit notes',
     note.edit_path,
-    class: 'btn btn-secondary m-2 btn-sm',
-    role: 'button'
+    PolicyDependentOptions.wrap(
+      {
+        class: 'btn btn-secondary m-2 btn-sm',
+        role: 'button',
+      },
+      policy: policy(note).edit?,
+      action_description: 'edit cluster notes',
+      user: current_user
+    )
   %>
 <% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -45,25 +45,14 @@
                           ]
               %>
 
-              <%
-                  user_can_create_case = policy(Case).create?
-                  disabled_class = user_can_create_case ? '' : 'disabled'
-                  disabled = !user_can_create_case
-                  title = if user_can_create_case
-                            nil
-                          else
-                            "As a #{current_user.role} you cannot create a case"
-                          end
-              %>
               <%= link_to "Create case",
                           new_cluster_case_path(cluster),
-                          class: [
-                            'btn',
-                            'btn-danger',
-                            disabled_class,
-                          ],
-                          disabled: disabled,
-                          title: title
+                          PolicyDependentOptions.wrap(
+                            {class: ['btn', 'btn-danger']},
+                            policy: policy(Case).create?,
+                            action_description: 'create a case',
+                            user: current_user
+                          )
               %>
             </span>
           </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -44,12 +44,26 @@
                             'btn-primary'
                           ]
               %>
+
+              <%
+                  user_can_create_case = policy(Case).create?
+                  disabled_class = user_can_create_case ? '' : 'disabled'
+                  disabled = !user_can_create_case
+                  title = if user_can_create_case
+                            nil
+                          else
+                            "As a #{current_user.role} you cannot create a case"
+                          end
+              %>
               <%= link_to "Create case",
                           new_cluster_case_path(cluster),
                           class: [
                             'btn',
-                            'btn-danger'
-                          ]
+                            'btn-danger',
+                            disabled_class,
+                          ],
+                          disabled: disabled,
+                          title: title
               %>
             </span>
           </div>

--- a/spec/decorators/note_decorator_spec.rb
+++ b/spec/decorators/note_decorator_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe NoteDecorator do
         )
       end
     end
+
+    context 'as a viewer' do
+      let(:current_user) { build_stubbed(:viewer) }
+
+      it do
+        is_expected.to eq(
+          'There are currently no notes for this cluster.'
+        )
+      end
+    end
   end
 
   describe '#edit_form_intro' do
@@ -59,6 +69,16 @@ RSpec.describe NoteDecorator do
       it do
         is_expected.to eq(
           'Edit your cluster notes below.'
+        )
+      end
+    end
+
+    context 'as a viewer' do
+      let(:current_user) { build_stubbed(:viewer) }
+
+      it "is unhandled as Users can't edit" do
+        expect { subject }.to raise_error(
+          "Don't know how to handle this user"
         )
       end
     end

--- a/spec/decorators/note_decorator_spec.rb
+++ b/spec/decorators/note_decorator_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe NoteDecorator do
+  before :each do
+    allow(h).to receive(:current_user).and_return(current_user)
+  end
+
+  let :note do
+    build_stubbed(:note, flavour: flavour).decorate
+  end
+  let(:flavour) { :$flavour }
+
+  describe '#new_form_intro' do
+    subject { note.new_form_intro }
+
+    context 'as an admin' do
+      let(:current_user) { build_stubbed(:admin) }
+
+      it do
+        is_expected.to eq(
+          <<~TEXT.squish
+            There are currently no #{flavour} notes for this cluster. You may
+            add them below.
+          TEXT
+        )
+      end
+    end
+
+    context 'as a contact' do
+      let(:current_user) { build_stubbed(:contact) }
+
+      it do
+        is_expected.to eq(
+          <<~TEXT.squish
+            There are currently no notes for this cluster. You may add them
+            below.
+          TEXT
+        )
+      end
+    end
+  end
+
+  describe '#edit_form_intro' do
+    subject { note.edit_form_intro }
+
+    context 'as an admin' do
+      let(:current_user) { build_stubbed(:admin) }
+
+      it do
+        is_expected.to eq(
+          "Edit the #{flavour} notes for this cluster below."
+        )
+      end
+    end
+
+    context 'as a contact' do
+      let(:current_user) { build_stubbed(:contact) }
+
+      it do
+        is_expected.to eq(
+          'Edit your cluster notes below.'
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     end
 
     factory :contact do
-      role :primary_contact
+      role :secondary_contact
 
       factory :primary_contact do
         role :primary_contact

--- a/spec/features/asset_record/edit_spec.rb
+++ b/spec/features/asset_record/edit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Asset Record', type: :feature   do
+RSpec.feature 'Asset Record', type: :feature do
   let(:admin) { create(:admin) }
   let(:component) { create(:component) }
   let(:component_group) { create(:component_group) }

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe 'Case page', type: :feature do
 
     context 'for open tier 2 case' do
       subject do
-        create(:open_case, tier_level: 2)
+        create(:open_case, tier_level: 2, cluster: cluster)
       end
 
       it 'can be escalated using button' do
@@ -457,35 +457,11 @@ RSpec.describe 'Case page', type: :feature do
         expect(subject.tier_level).to eq 3
       end
 
-      context 'for viewer' do
-        let(:viewer) do
-          create(:viewer, site: subject.site)
-        end
-
-        it 'has disabled escalate button' do
-          visit case_path(subject, as: viewer)
-
-          button = find('button', text: escalate_button_text)
-
-          expect(button).to be_disabled
-          expect(button[:title]).to eq(
-            'As a viewer you cannot escalate a case'
-          )
-        end
-      end
-
-      context 'for non-viewer' do
-        let(:contact) do
-          create(:contact, site: subject.site)
-        end
-
-        it 'does not have disabled escalate button' do
-          visit case_path(subject, as: contact)
-
-          button = find('button', text: escalate_button_text)
-
-          expect(button).not_to be_disabled
-          expect(button[:title]).to be nil
+      it_behaves_like 'button is disabled for viewers' do
+        let(:path) { case_path(subject, as: user) }
+        let(:button_text) { escalate_button_text }
+        let(:disabled_button_title) do
+          'As a viewer you cannot escalate a case'
         end
       end
     end

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -456,6 +456,38 @@ RSpec.describe 'Case page', type: :feature do
         subject.reload
         expect(subject.tier_level).to eq 3
       end
+
+      context 'for viewer' do
+        let(:viewer) do
+          create(:viewer, site: subject.site)
+        end
+
+        it 'has disabled escalate button' do
+          visit case_path(subject, as: viewer)
+
+          button = find('button', text: escalate_button_text)
+
+          expect(button).to be_disabled
+          expect(button[:title]).to eq(
+            'As a viewer you cannot escalate a case'
+          )
+        end
+      end
+
+      context 'for non-viewer' do
+        let(:contact) do
+          create(:contact, site: subject.site)
+        end
+
+        it 'does not have disabled escalate button' do
+          visit case_path(subject, as: contact)
+
+          button = find('button', text: escalate_button_text)
+
+          expect(button).not_to be_disabled
+          expect(button[:title]).to be nil
+        end
+      end
     end
 
     RSpec.shared_examples 'for inapplicable cases' do

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -434,18 +434,21 @@ RSpec.describe 'Case page', type: :feature do
   end
 
   describe 'escalation' do
+    let(:escalate_button_text) { 'Escalate' }
+
     context 'for open tier 2 case' do
       subject do
-        create(:open_case, tier_level:2)
+        create(:open_case, tier_level: 2)
       end
-      it 'shows escalate button' do
+
+      it 'can be escalated using button' do
         visit case_path(subject, as: admin)
 
         expect do
-          find_button 'Escalate'
+          find_button escalate_button_text
         end.not_to raise_error
 
-        click_button 'Escalate'
+        click_button escalate_button_text
 
         # Using find(...).click instead of click_button waits for modal to appear
         find('#confirm-escalate-button').click
@@ -460,7 +463,7 @@ RSpec.describe 'Case page', type: :feature do
         visit case_path(subject, as: admin)
 
         expect do
-          find_button 'Escalate'
+          find_button escalate_button_text
         end.to raise_error(Capybara::ElementNotFound)
       end
     end
@@ -469,6 +472,7 @@ RSpec.describe 'Case page', type: :feature do
       subject do
         create(:open_case, tier_level: 3)
       end
+
       it_behaves_like 'for inapplicable cases'
     end
 
@@ -476,6 +480,7 @@ RSpec.describe 'Case page', type: :feature do
       subject do
         create(:resolved_case, tier_level: 2)
       end
+
       it_behaves_like 'for inapplicable cases'
     end
 
@@ -483,6 +488,7 @@ RSpec.describe 'Case page', type: :feature do
       subject do
         create(:closed_case, tier_level: 2)
       end
+
       it_behaves_like 'for inapplicable cases'
     end
   end

--- a/spec/features/cluster/show_spec.rb
+++ b/spec/features/cluster/show_spec.rb
@@ -21,4 +21,14 @@ RSpec.describe 'Cluster overview page', type: :feature do
       expect(list).to have_text("1 self-managed #{part_type.to_s}")
     end
   end
+
+  it_behaves_like 'button is disabled for viewers', button_link: true do
+    let(:cluster) { create(:cluster, site: site) }
+
+    let(:path) { cluster_path(cluster, as: user) }
+    let(:button_text) { 'Request change' }
+    let(:disabled_button_title) do
+      'As a viewer you cannot request a change to the MOTD'
+    end
+  end
 end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -91,6 +91,7 @@ RSpec.feature "Maintenance windows", type: :feature do
 
   let(:valid_requested_start) { Time.zone.local(2022, 9, 10, 13, 0) }
 
+  let(:confirm_button_link_text) { 'Unconfirmed' }
   let(:reject_button_text) { 'Reject' }
   let(:end_button_text) { 'End' }
   let(:cancel_button_text) { 'Cancel' }
@@ -344,8 +345,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       )
 
       visit cluster_maintenance_windows_path(component.cluster, as: user)
-      button_link_text = 'Unconfirmed'
-      click_link(button_link_text)
+      click_link(confirm_button_link_text)
 
       expected_path = confirm_component_maintenance_window_path(
         window, component_id: component
@@ -459,6 +459,50 @@ RSpec.feature "Maintenance windows", type: :feature do
         expect do
           find('p.alert-warning')
         end.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+  end
+
+  context 'when maintenance is requested' do
+    let! :window do
+      create(
+        :requested_maintenance_window,
+        cluster: cluster,
+        case: support_case
+      )
+    end
+
+    context 'for viewer' do
+      let :user do
+        create(:viewer, site: site)
+      end
+
+      it 'has disabled confirm maintenance button' do
+        visit cluster_maintenance_windows_path(cluster, as: user)
+
+        button = find('a', text: confirm_button_link_text)
+
+        expect(button).to be_disabled
+        expect(button[:class]).to include('disabled')
+        expect(button[:title]).to eq(
+          'As a viewer you cannot confirm maintenance'
+        )
+      end
+    end
+
+    context 'for non-viewer' do
+      let(:user) do
+        create(:contact, site: site)
+      end
+
+      it 'does not have disabled confirm maintenance button' do
+        visit cluster_maintenance_windows_path(cluster, as: user)
+
+        button = find('a', text: confirm_button_link_text)
+
+        expect(button).not_to be_disabled
+        expect(button[:class]).not_to include('disabled')
+        expect(button[:title]).to be nil
       end
     end
   end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -472,37 +472,11 @@ RSpec.feature "Maintenance windows", type: :feature do
       )
     end
 
-    context 'for viewer' do
-      let :user do
-        create(:viewer, site: site)
-      end
-
-      it 'has disabled confirm maintenance button' do
-        visit cluster_maintenance_windows_path(cluster, as: user)
-
-        button = find('a', text: confirm_button_link_text)
-
-        expect(button).to be_disabled
-        expect(button[:class]).to include('disabled')
-        expect(button[:title]).to eq(
-          'As a viewer you cannot confirm maintenance'
-        )
-      end
-    end
-
-    context 'for non-viewer' do
-      let(:user) do
-        create(:contact, site: site)
-      end
-
-      it 'does not have disabled confirm maintenance button' do
-        visit cluster_maintenance_windows_path(cluster, as: user)
-
-        button = find('a', text: confirm_button_link_text)
-
-        expect(button).not_to be_disabled
-        expect(button[:class]).not_to include('disabled')
-        expect(button[:title]).to be nil
+    it_behaves_like 'button is disabled for viewers', button_tag: 'a' do
+      let(:path) { cluster_maintenance_windows_path(cluster, as: user) }
+      let(:button_text) { confirm_button_link_text }
+      let(:disabled_button_title) do
+        'As a viewer you cannot confirm maintenance'
       end
     end
   end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -472,11 +472,19 @@ RSpec.feature "Maintenance windows", type: :feature do
       )
     end
 
+    let(:path) { cluster_maintenance_windows_path(cluster, as: user) }
+
     it_behaves_like 'button is disabled for viewers', button_link: true do
-      let(:path) { cluster_maintenance_windows_path(cluster, as: user) }
       let(:button_text) { confirm_button_link_text }
       let(:disabled_button_title) do
         'As a viewer you cannot confirm maintenance'
+      end
+    end
+
+    it_behaves_like 'button is disabled for viewers' do
+      let(:button_text) { reject_button_text }
+      let(:disabled_button_title) do
+        'As a viewer you cannot reject maintenance'
       end
     end
   end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -472,7 +472,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       )
     end
 
-    it_behaves_like 'button is disabled for viewers', button_tag: 'a' do
+    it_behaves_like 'button is disabled for viewers', button_link: true do
       let(:path) { cluster_maintenance_windows_path(cluster, as: user) }
       let(:button_text) { confirm_button_link_text }
       let(:disabled_button_title) do

--- a/spec/features/notes/show_spec.rb
+++ b/spec/features/notes/show_spec.rb
@@ -6,9 +6,35 @@ RSpec.describe 'Show notes page', type: :feature do
 
   let(:path) { cluster_notes_path(cluster, :customer, as: user) }
 
+  before :each do
+    visit path
+  end
+
   # This context actually tests what is rendered by `new` view, which is
   # rendered by `show` action when there are no notes already.
   context 'when no notes already' do
+    let(:description) { :note_description }
+
+    context 'for contact' do
+      let(:user) { create(:contact, site: site) }
+
+      it 'has textarea for note description' do
+        expect do
+          fill_in(description, with: 'words')
+        end.not_to raise_error
+      end
+    end
+
+    context 'for viewer' do
+      let(:user) { create(:viewer, site: site) }
+
+      it 'does not have textarea for note description' do
+        expect do
+          fill_in(description, with: 'words')
+        end.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+
     it_behaves_like 'button is disabled for viewers' do
       let(:button_text) { 'Create notes' }
       let(:disabled_button_title) do

--- a/spec/features/notes/show_spec.rb
+++ b/spec/features/notes/show_spec.rb
@@ -1,14 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe 'Show notes page', type: :feature do
-  it_behaves_like 'button is disabled for viewers' do
-    let(:site) { create(:site) }
-    let(:cluster) { create(:cluster, site: site) }
+  let(:site) { create(:site) }
+  let(:cluster) { create(:cluster, site: site) }
 
-    let(:path) { cluster_notes_path(cluster, :customer, as: user) }
-    let(:button_text) { 'Create notes' }
-    let(:disabled_button_title) do
-      'As a viewer you cannot create cluster notes'
+  let(:path) { cluster_notes_path(cluster, :customer, as: user) }
+
+  # This context actually tests what is rendered by `new` view, which is
+  # rendered by `show` action when there are no notes already.
+  context 'when no notes already' do
+    it_behaves_like 'button is disabled for viewers' do
+      let(:button_text) { 'Create notes' }
+      let(:disabled_button_title) do
+        'As a viewer you cannot create cluster notes'
+      end
+    end
+  end
+
+  context 'when cluster already has notes' do
+    before :each do
+      create(:customer_note, cluster: cluster)
+    end
+
+    it_behaves_like 'button is disabled for viewers', button_link: true do
+      let(:button_text) { 'Edit notes' }
+      let(:disabled_button_title) do
+        'As a viewer you cannot edit cluster notes'
+      end
     end
   end
 end

--- a/spec/features/notes/show_spec.rb
+++ b/spec/features/notes/show_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'Show notes page', type: :feature do
+  it_behaves_like 'button is disabled for viewers' do
+    let(:site) { create(:site) }
+    let(:cluster) { create(:cluster, site: site) }
+
+    let(:path) { cluster_notes_path(cluster, :customer, as: user) }
+    let(:button_text) { 'Create notes' }
+    let(:disabled_button_title) do
+      'As a viewer you cannot create cluster notes'
+    end
+  end
+end

--- a/spec/features/site/show_spec.rb
+++ b/spec/features/site/show_spec.rb
@@ -1,45 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Site page', type: :feature do
-  let(:site) { create(:site) }
-
-  describe 'Create Cluster Case button' do
+  it_behaves_like 'button is disabled for viewers', button_tag: 'a' do
+    let(:site) { create(:site) }
     let!(:cluster) { create(:cluster, site: site) }
 
-    let(:create_button_text) { 'Create case' }
-
-    context 'for viewer' do
-      let(:viewer) do
-        create(:viewer, site: site)
-      end
-
-      it 'has disabled create case button' do
-        visit root_path(as: viewer)
-
-        button = find('a', text: create_button_text)
-
-        expect(button).to be_disabled
-        expect(button[:class]).to include('disabled')
-        expect(button[:title]).to eq(
-          'As a viewer you cannot create a case'
-        )
-      end
-    end
-
-    context 'for non-viewer' do
-      let(:contact) do
-        create(:contact, site: site)
-      end
-
-      it 'does not have disabled create case button' do
-        visit root_path(as: contact)
-
-        button = find('a', text: create_button_text)
-
-        expect(button).not_to be_disabled
-        expect(button[:class]).not_to include('disabled')
-        expect(button[:title]).to be nil
-      end
+    let(:path) { root_path(cluster, as: user) }
+    let(:button_text) { 'Create case' }
+    let(:disabled_button_title) do
+      'As a viewer you cannot create a case'
     end
   end
 end

--- a/spec/features/site/show_spec.rb
+++ b/spec/features/site/show_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Site page', type: :feature do
+  let(:site) { create(:site) }
+
+  describe 'Create Cluster Case button' do
+    let!(:cluster) { create(:cluster, site: site) }
+
+    let(:create_button_text) { 'Create case' }
+
+    context 'for viewer' do
+      let(:viewer) do
+        create(:viewer, site: site)
+      end
+
+      it 'has disabled create case button' do
+        visit root_path(as: viewer)
+
+        button = find('a', text: create_button_text)
+
+        expect(button).to be_disabled
+        expect(button[:class]).to include('disabled')
+        expect(button[:title]).to eq(
+          'As a viewer you cannot create a case'
+        )
+      end
+    end
+
+    context 'for non-viewer' do
+      let(:contact) do
+        create(:contact, site: site)
+      end
+
+      it 'does not have disabled create case button' do
+        visit root_path(as: contact)
+
+        button = find('a', text: create_button_text)
+
+        expect(button).not_to be_disabled
+        expect(button[:class]).not_to include('disabled')
+        expect(button[:title]).to be nil
+      end
+    end
+  end
+end

--- a/spec/features/site/show_spec.rb
+++ b/spec/features/site/show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Site page', type: :feature do
-  it_behaves_like 'button is disabled for viewers', button_tag: 'a' do
+  it_behaves_like 'button is disabled for viewers', button_link: true do
     let(:site) { create(:site) }
     let!(:cluster) { create(:cluster, site: site) }
 

--- a/spec/helpers/policy_dependent_options_spec.rb
+++ b/spec/helpers/policy_dependent_options_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe PolicyDependentOptions do
+  describe '.wrap' do
+    subject do
+      described_class.wrap(
+        options,
+        policy: policy,
+        action_description: action_description,
+        user: user
+      )
+    end
+
+    let(:options) {{ class: 'some-class', title: 'Some Title' }}
+    let(:user) { build_stubbed(:user) }
+    let(:action_description) { 'fly' }
+
+    context 'when policy is false' do
+      let(:policy) { false }
+
+      it 'adds `disabled` attribute to options' do
+        expect(subject[:disabled]).to be true
+      end
+
+      it 'creates and adds `title` attribute to options' do
+        role = 'squirrel'
+        allow(user).to receive(:role).and_return(role)
+
+        expect(subject[:title]).to eq(
+          "As a #{role} you cannot #{action_description}"
+        )
+      end
+
+      context 'when options contain `class` attribute with array value' do
+        let(:options) {{class: class_array}}
+        let(:class_array) {['some-class', 'another-class']}
+
+        it 'adds `disabled` class to array' do
+          expect(subject[:class]).to eq(
+            class_array + ['disabled']
+          )
+        end
+      end
+
+      context 'when options contain class attribute with string value' do
+        let(:options) {{class: class_string}}
+        let(:class_string) { 'some-class another-class' }
+
+        it 'converts class attribute to array with `disabled` value' do
+          expect(subject[:class]).to eq(
+            [class_string, 'disabled']
+          )
+        end
+      end
+    end
+
+    context 'when policy is true' do
+      let(:policy) { true }
+
+      it 'returns the same options' do
+        expect(subject).to eq(options)
+      end
+    end
+  end
+end

--- a/spec/helpers/policy_dependent_options_spec.rb
+++ b/spec/helpers/policy_dependent_options_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe PolicyDependentOptions do
         expect(subject[:disabled]).to be true
       end
 
+      it 'adds `onclick` attribute to options' do
+        expect(subject[:onclick]).to eq('return false;')
+      end
+
       it 'creates and adds `title` attribute to options' do
         role = 'squirrel'
         allow(user).to receive(:role).and_return(role)

--- a/spec/helpers/tabs_builder_spec.rb
+++ b/spec/helpers/tabs_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TabsBuilder do
   before :each do
     allow(helper).to receive(:current_user).and_return(user)
   end
-  let(:tab_builder) { TabsBuilder.new(scope) }
+  let(:tab_builder) { TabsBuilder.new(user: user, scope: scope) }
 
   describe '#cases' do
     subject { tab_builder.cases[:dropdown].map { |h| h[:path] } }
@@ -18,6 +18,10 @@ RSpec.describe TabsBuilder do
         it 'contains a link to the site cases' do
           expect(subject).to include(site_cases_path(scope))
         end
+
+        it 'includes a link to the new case page for the site' do
+          expect(subject).to include(new_site_case_path(scope))
+        end
       end
 
       context 'with a contact user' do
@@ -25,6 +29,18 @@ RSpec.describe TabsBuilder do
 
         it 'contains a link to the cases page' do
           expect(subject).to include(cases_path)
+        end
+
+        it 'includes a link to the new case page' do
+          expect(subject).to include(new_case_path)
+        end
+      end
+
+      context 'with a viewer user' do
+        let(:user) { build_stubbed(:viewer) }
+
+        it 'does not include a link to the new case page' do
+          expect(subject).not_to include(new_case_path)
         end
       end
     end

--- a/spec/support/shared_examples/button_disabled_for_viewers.rb
+++ b/spec/support/shared_examples/button_disabled_for_viewers.rb
@@ -36,7 +36,7 @@ RSpec.shared_examples 'button is disabled for viewers' do |args|
     it 'does not have disabled button' do
       expect(button).not_to be_disabled
       expect(button[:class]).not_to include('disabled')
-      expect(button[:title]).to be nil
+      expect(button[:title]).not_to eq(disabled_button_title)
     end
   end
 end

--- a/spec/support/shared_examples/button_disabled_for_viewers.rb
+++ b/spec/support/shared_examples/button_disabled_for_viewers.rb
@@ -1,11 +1,19 @@
 
 RSpec.shared_examples 'button is disabled for viewers' do |args|
   args ||= {}
-  button_tag = args.fetch(:button_tag, 'button')
+  button_link = args.fetch(:button_link, false)
 
   let :button do
     visit path
-    find(button_tag, text: button_text)
+
+    if button_link
+      # Just find the link, `disabled` attribute does not do anything by
+      # default to `a` tags and is not a supported argument to `find_link`.
+      find_link(button_text)
+    else
+      # Find the button, whether or not it is `disabled`.
+      find_button(button_text, disabled: :all)
+    end
   end
 
   context 'for viewer' do

--- a/spec/support/shared_examples/button_disabled_for_viewers.rb
+++ b/spec/support/shared_examples/button_disabled_for_viewers.rb
@@ -1,0 +1,34 @@
+
+RSpec.shared_examples 'button is disabled for viewers' do |args|
+  args ||= {}
+  button_tag = args.fetch(:button_tag, 'button')
+
+  let :button do
+    visit path
+    find(button_tag, text: button_text)
+  end
+
+  context 'for viewer' do
+    let :user do
+      create(:viewer, site: site)
+    end
+
+    it 'has disabled button' do
+      expect(button).to be_disabled
+      expect(button[:class]).to include('disabled')
+      expect(button[:title]).to eq(disabled_button_title)
+    end
+  end
+
+  context 'for non-viewer' do
+    let(:user) do
+      create(:contact, site: site)
+    end
+
+    it 'does not have disabled button' do
+      expect(button).not_to be_disabled
+      expect(button[:class]).not_to include('disabled')
+      expect(button[:title]).to be nil
+    end
+  end
+end

--- a/spec/support/shared_examples/support_type_change_buttons.rb
+++ b/spec/support/shared_examples/support_type_change_buttons.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
 
     it 'can request self-management' do
       visit cluster_parts_path
-      click_button 'Request self-management'
+      click_button request_self_management_text
 
       created_case = part.cases.first
       expect(created_case.send(part_name)).to eq(part)

--- a/spec/support/shared_examples/support_type_change_buttons.rb
+++ b/spec/support/shared_examples/support_type_change_buttons.rb
@@ -19,44 +19,56 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
     send("cluster_#{part_name.to_s.pluralize}_path", cluster, as: contact)
   end
 
-  it "can request self-management of a managed #{part_class_name}" do
-    part = create("managed_#{part_name}", cluster: cluster)
+  context "when #{part_class_name} is managed" do
+    let! :part do
+      create("managed_#{part_name}", cluster: cluster)
+    end
 
-    visit cluster_parts_path
-    click_button 'Request self-management'
+    it 'can request self-management' do
+      visit cluster_parts_path
+      click_button 'Request self-management'
 
-    created_case = part.cases.first
-    expect(created_case.send(part_name)).to eq(part)
-    issue = Issue.send("request_#{part_name}_becomes_advice_issue")
-    expect(created_case.issue).to eq(issue)
-    tier = issue.tiers.first
-    expect(created_case.fields).to eq(tier.fields)
-    expect(created_case.tier_level).to eq(tier.level)
+      created_case = part.cases.first
+      expect(created_case.send(part_name)).to eq(part)
+      issue = Issue.send("request_#{part_name}_becomes_advice_issue")
+      expect(created_case.issue).to eq(issue)
+      tier = issue.tiers.first
+      expect(created_case.fields).to eq(tier.fields)
+      expect(created_case.tier_level).to eq(tier.level)
+    end
   end
 
-  it "can request Alces management of an advice-only #{part_class_name}" do
-    part = create("advice_#{part_name}", cluster: cluster)
+  context "when #{part_class_name} is advice-only" do
+    let! :part do
+      create("advice_#{part_name}", cluster: cluster)
+    end
 
-    visit cluster_parts_path
-    click_button request_alces_management_text
+    it "can request Alces management" do
+      visit cluster_parts_path
+      click_button request_alces_management_text
 
-    created_case = part.cases.first
-    expect(created_case.send(part_name)).to eq(part)
-    issue = Issue.send("request_#{part_name}_becomes_managed_issue")
-    expect(created_case.issue).to eq(issue)
-    tier = issue.tiers.first
-    expect(created_case.fields).to eq(tier.fields)
-    expect(created_case.tier_level).to eq(tier.level)
+      created_case = part.cases.first
+      expect(created_case.send(part_name)).to eq(part)
+      issue = Issue.send("request_#{part_name}_becomes_managed_issue")
+      expect(created_case.issue).to eq(issue)
+      tier = issue.tiers.first
+      expect(created_case.fields).to eq(tier.fields)
+      expect(created_case.tier_level).to eq(tier.level)
+    end
   end
 
-  it "displays no buttons for internal #{part_class_name}" do
-    part = create(part_name, internal: true, cluster: cluster)
+  context "when #{part_class_name} is internal" do
+    let! :part do
+      create(part_name, internal: true, cluster: cluster)
+    end
 
-    visit cluster_parts_path
-    # Sanity check that part itself is actually being displayed.
-    expect(page).to have_text(part.name)
+    it 'displays no buttons' do
+      visit cluster_parts_path
+      # Sanity check that part itself is actually being displayed.
+      expect(page).to have_text(part.name)
 
-    expect(page).not_to have_button(request_self_management_text)
-    expect(page).not_to have_button(request_alces_management_text)
+      expect(page).not_to have_button(request_self_management_text)
+      expect(page).not_to have_button(request_alces_management_text)
+    end
   end
 end

--- a/spec/support/shared_examples/support_type_change_buttons.rb
+++ b/spec/support/shared_examples/support_type_change_buttons.rb
@@ -12,11 +12,11 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
   let(:request_alces_management_text) { 'Request Alces management' }
 
   let(:site) { create(:site) }
-  let(:contact) { create(:contact, site: site) }
+  let(:user) { create(:contact, site: site) }
   let(:cluster) { create(:cluster, site: site) }
 
-  let :cluster_parts_path do
-    send("cluster_#{part_name.to_s.pluralize}_path", cluster, as: contact)
+  let :path do
+    send("cluster_#{part_name.to_s.pluralize}_path", cluster, as: user)
   end
 
   context "when #{part_class_name} is managed" do
@@ -24,9 +24,17 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
       create("managed_#{part_name}", cluster: cluster)
     end
 
+    let(:button_text) { request_self_management_text }
+
+    it_behaves_like 'button is disabled for viewers' do
+      let :disabled_button_title do
+        "As a viewer you cannot request self-management of a #{part_name}"
+      end
+    end
+
     it 'can request self-management' do
-      visit cluster_parts_path
-      click_button request_self_management_text
+      visit path
+      click_button button_text
 
       created_case = part.cases.first
       expect(created_case.send(part_name)).to eq(part)
@@ -43,9 +51,17 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
       create("advice_#{part_name}", cluster: cluster)
     end
 
+    let(:button_text) { request_alces_management_text }
+
+    it_behaves_like 'button is disabled for viewers' do
+      let :disabled_button_title do
+        "As a viewer you cannot request Alces management of a #{part_name}"
+      end
+    end
+
     it "can request Alces management" do
-      visit cluster_parts_path
-      click_button request_alces_management_text
+      visit path
+      click_button button_text
 
       created_case = part.cases.first
       expect(created_case.send(part_name)).to eq(part)
@@ -63,7 +79,7 @@ RSpec.shared_examples 'can request support_type change via buttons' do |part_nam
     end
 
     it 'displays no buttons' do
-      visit cluster_parts_path
+      visit path
       # Sanity check that part itself is actually being displayed.
       expect(page).to have_text(part.name)
 


### PR DESCRIPTION
This PR makes various changes across Flight Center, to allow viewer Users to view all data Site contacts can, but not interact with anything in a way that would alter the state of their Site or anything belonging to their Site. This largely consists of UI changes, as viewers were already being denied access to all stateful actions by our existing Pundit policies and controller-level authorisation.

This completes https://trello.com/c/JvjCbEAh/339-prevent-viewers-from-interacting-with-things (at least for already merged things, outstanding PRs may still need to have similar changes to be made to them as in this PR to deny access to viewers).

Closes #301.