### PR TITLE
Cluster shortcode in links

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,7 @@ class ApplicationController < RootController
     @scope = case request.path
              when /^\/clusters/
                id = scope_id_param(:cluster_id).upcase
-               @cluster = Cluster.find_by_shortcode(id)
+               @cluster = Cluster.find_by_shortcode!(id)
              when /^\/components/
                id = scope_id_param(:component_id)
                @component = @cluster_part = Component.find(id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,11 @@ class ApplicationController < RootController
     @scope = case request.path
              when /^\/clusters/
                id = scope_id_param(:cluster_id).upcase
-               @cluster = Cluster.find_by_shortcode!(id)
+               @cluster = if /^[0-9]+$/.match(id)
+                            Cluster.find(id)
+                          else
+                            Cluster.find_by_shortcode!(id)
+                          end
              when /^\/components/
                id = scope_id_param(:component_id)
                @component = @cluster_part = Component.find(id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,11 +72,7 @@ class ApplicationController < RootController
     @scope = case request.path
              when /^\/clusters/
                id = scope_id_param(:cluster_id).upcase
-               @cluster = if /^[0-9]+$/.match(id)
-                            Cluster.find(id)
-                          else
-                            Cluster.find_by_shortcode!(id)
-                          end
+               @cluster = Cluster.find_from_id!(id)
              when /^\/components/
                id = scope_id_param(:component_id)
                @component = @cluster_part = Component.find(id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < RootController
 
     @scope = case request.path
              when /^\/clusters/
-               id = scope_id_param(:cluster_id)
+               id = scope_id_param(:cluster_id).upcase
                @cluster = Cluster.find_by_shortcode(id)
              when /^\/components/
                id = scope_id_param(:component_id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,7 @@ class ApplicationController < RootController
     @scope = case request.path
              when /^\/clusters/
                id = scope_id_param(:cluster_id)
-               @cluster = Cluster.find(id)
+               @cluster = Cluster.find_by_shortcode(id)
              when /^\/components/
                id = scope_id_param(:component_id)
                @component = @cluster_part = Component.find(id)

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -29,7 +29,7 @@ class CasesController < ApplicationController
     component_id = params[:component_id]
     service_id = params[:service_id]
     @clusters = if cluster_id
-                  [Cluster.find_by_shortcode!(cluster_id)]
+                  [Cluster.find_from_id!(cluster_id)]
                 elsif component_id
                   @single_part = Component.find(component_id)
                   [@single_part.cluster]

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -29,7 +29,7 @@ class CasesController < ApplicationController
     component_id = params[:component_id]
     service_id = params[:service_id]
     @clusters = if cluster_id
-                  [Cluster.find(cluster_id)]
+                  [Cluster.find_by_shortcode!(cluster_id)]
                 elsif component_id
                   @single_part = Component.find(component_id)
                   [@single_part.cluster]

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -89,7 +89,7 @@ class Cluster < ApplicationRecord
   end
 
   def to_param
-    shortcode
+    shortcode.parameterize.upcase
   end
 
   private

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -88,6 +88,10 @@ class Cluster < ApplicationRecord
     end
   end
 
+  def to_param
+    shortcode
+  end
+
   private
 
   def validate_all_cluster_parts_advice

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -92,6 +92,14 @@ class Cluster < ApplicationRecord
     shortcode.parameterize.upcase
   end
 
+  def self.find_from_id!(id)
+    if /^[0-9]+$/.match(id)
+      Cluster.find(id)
+    else
+      Cluster.find_by_shortcode!(id)
+    end
+  end
+
   private
 
   def validate_all_cluster_parts_advice

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe CasesController, type: :controller do
 
     context 'from cluster-level route' do
       it 'assigns just given cluster to @clusters' do
-        get :new, params: { cluster_id: first_cluster.id }
+        get :new, params: { cluster_id: first_cluster }
         expect(assigns(:clusters)).to eq([first_cluster])
       end
 
       it 'gives 404 if cluster does not belong to user site' do
         another_cluster = create(:cluster)
         expect do
-          get :new, params: { cluster_id: another_cluster.id }
+          get :new, params: { cluster_id: another_cluster }
         end.to raise_error(ActionController::RoutingError)
       end
 
@@ -55,7 +55,7 @@ RSpec.describe CasesController, type: :controller do
 
         context 'when given a tool' do
           it 'assigns the correct tool to @pre_selected' do
-            get :new, params: { tool: tier.tool, cluster_id: first_cluster.id }
+            get :new, params: { tool: tier.tool, cluster_id: first_cluster }
 
             expect(assigns(:pre_selected)).to eq({
               tool: tier.tool
@@ -65,7 +65,7 @@ RSpec.describe CasesController, type: :controller do
 
         context 'when given no pre-populations' do
           it 'does not assign anything to @pre_selected' do
-            get :new, params: { cluster_id: first_cluster.id }
+            get :new, params: { cluster_id: first_cluster }
 
             expect(assigns(:pre_selected)).to eq({})
           end

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ClustersController, type: :controller do
   describe 'POST #deposit' do
 
     let(:params) {
-      { cluster_id: cluster.id, credit_deposit: { amount: 4 } }
+      { cluster_id: cluster.shortcode, credit_deposit: { amount: 4 } }
     }
 
     context 'as an admin' do
@@ -26,7 +26,8 @@ RSpec.describe ClustersController, type: :controller do
         post :deposit, params: params
 
         expect(response).to have_http_status(:found)
-        expect(response.headers['Location']).to match(/\/clusters\/#{cluster.id}\/credit-usage$/)
+        expect(response.headers['Location'])
+          .to match(/\/clusters\/#{cluster.shortcode}\/credit-usage$/)
         expect(flash[:success]).to eq '4 credits added to cluster Some Cluster.'
 
         cluster.reload
@@ -37,7 +38,7 @@ RSpec.describe ClustersController, type: :controller do
         expect(cluster.credit_balance).to eq 8
 
         # This demonstrates that we do intentionally permit negative "deposits"
-        post :deposit, params: { cluster_id: cluster.id, credit_deposit: { amount: -6 } }
+        post :deposit, params: { cluster_id: cluster.shortcode, credit_deposit: { amount: -6 } }
         cluster.reload
         expect(cluster.credit_balance).to eq 2
       end

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ClustersController, type: :controller do
   describe 'POST #deposit' do
 
     let(:params) {
-      { cluster_id: cluster.shortcode, credit_deposit: { amount: 4 } }
+      { cluster_id: cluster, credit_deposit: { amount: 4 } }
     }
 
     context 'as an admin' do
@@ -38,7 +38,7 @@ RSpec.describe ClustersController, type: :controller do
         expect(cluster.credit_balance).to eq 8
 
         # This demonstrates that we do intentionally permit negative "deposits"
-        post :deposit, params: { cluster_id: cluster.shortcode, credit_deposit: { amount: -6 } }
+        post :deposit, params: { cluster_id: cluster, credit_deposit: { amount: -6 } }
         cluster.reload
         expect(cluster.credit_balance).to eq 2
       end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -324,7 +324,7 @@ RSpec.feature "Maintenance windows", type: :feature do
 
     context 'when maintenance is for the entire cluster' do
       it 'shows the entire-cluster-warning message' do
-        visit new_cluster_maintenance_window_path(cluster_id: cluster.id, as: user)
+        visit new_cluster_maintenance_window_path(cluster_id: cluster.shortcode, as: user)
 
         expect(find('p.alert-warning').text).to match 'Not what you want? Try selecting a component or a service from this cluster.'
       end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -324,7 +324,7 @@ RSpec.feature "Maintenance windows", type: :feature do
 
     context 'when maintenance is for the entire cluster' do
       it 'shows the entire-cluster-warning message' do
-        visit new_cluster_maintenance_window_path(cluster_id: cluster.shortcode, as: user)
+        visit new_cluster_maintenance_window_path(cluster_id: cluster, as: user)
 
         expect(find('p.alert-warning').text).to match 'Not what you want? Try selecting a component or a service from this cluster.'
       end

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     describe "get '/cluster/*'" do
       subject { cluster }
       before :each do
-        get cluster_path(cluster.shortcode, as: user)
+        get cluster_path(cluster, as: user)
       end
 
       it 'assigns correct navigation variables' do

--- a/spec/requests/navigation_variable_assignments_spec.rb
+++ b/spec/requests/navigation_variable_assignments_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Navigation variable assignments', type: :request do
     describe "get '/cluster/*'" do
       subject { cluster }
       before :each do
-        get cluster_path(cluster.id, as: user)
+        get cluster_path(cluster.shortcode, as: user)
       end
 
       it 'assigns correct navigation variables' do


### PR DESCRIPTION
This PR utilises the cluster shortcode to create a vanity URL for cluster related links.

[Trello](https://trello.com/c/TuSECh2A/357-use-cluster-shortcode-in-links-to-cluster)