### PR TITLE
Differentiate users not logged in, and logged in without Center accounts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
+  gem 'show_me_the_cookies'  # Cookies helpers for Capybara
 
   gem 'dotenv-rails'
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,8 @@ GEM
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
+    show_me_the_cookies (4.0.0)
+      capybara (>= 2, < 4)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -490,6 +492,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   shoulda-matchers
+  show_me_the_cookies
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -4,7 +4,7 @@
       The page you were looking for cannot be found.
     </p>
 
-    <% unless current_user.present? %>
+    <% unless current_user.present? || signed_in_without_account? %>
 
       <p>
         This page may only be available to signed-in users, so you can try signing in.

--- a/app/views/sessions/_sign_in_box.html.erb
+++ b/app/views/sessions/_sign_in_box.html.erb
@@ -1,0 +1,13 @@
+<div id='clearance' class='card sign-in'>
+  <div class='card-header'>
+    <ul class='nav'>
+      <li class='nav-item'>
+        <span class='navbar-brand'><%= title %></span>
+      </li>
+    </ul>
+  </div>
+
+  <div class='card-body'>
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -25,25 +25,20 @@
     </p>
   </div>
   <div class="col-md-6 col-sm-12">
-    <div id='clearance' class='card sign-in'>
-      <div class='card-header'>
-        <ul class='nav'>
-          <li class='nav-item'>
-          <span class='navbar-brand'><%= t('.title') %></span>
-          </li>
-        </ul>
-      </div>
 
-      <div class='card-body'>
-        <p>Please sign in to Flight in order to use Flight Center.</p>
-        <%= render 'partials/sso_sign_in_button' %>
-        <h4>I've signed in, why am I seeing this?</h4>
+    <% if signed_in_without_account? %>
+      <%= render 'sessions/sign_in_box', title: 'Account not authorised' do %>
         <p>
           Your Alces Flight account manager must request that your Flight
           account be given access to Flight Center before you can get started.
         </p>
-      </div>
-    </div>
+      <% end %>
+    <% else %>
+      <%= render 'sessions/sign_in_box', title: t('.title') do %>
+        <p>Please sign in to Flight in order to use Flight Center.</p>
+        <%= render 'partials/sso_sign_in_button' %>
+      <% end %>
+    <% end %>
 
   </div>
 </div>

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -1,3 +1,4 @@
+require 'json_web_token'
 require 'rails_helper'
 
 RSpec.describe 'Error handling', type: :feature do
@@ -23,6 +24,25 @@ RSpec.describe 'Error handling', type: :feature do
     context 'when contact signed in' do
       it 'does not show SSO login button' do
         visit cluster_path(cluster, as: user)
+
+        expect(page).to have_http_status(404)
+
+        card_body = find('.page-container .card-body')
+        expect do
+          card_body.find('.sign-in-button')
+        end.to raise_error Capybara::ElementNotFound
+      end
+    end
+
+    context 'when logged in to SSO but no Center account' do
+
+      let(:valid_token) {
+        ::JsonWebToken.encode(email: 'otherwise_unused_email@example.com')
+      }
+
+      it 'does not show SSO login button' do
+        create_cookie('flight_sso', valid_token)
+        visit cluster_path(cluster)
 
         expect(page).to have_http_status(404)
 

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -1,0 +1,57 @@
+require 'json_web_token'
+require 'rails_helper'
+
+RSpec.feature 'Sessions (home page)', type: :feature do
+
+  let(:site) { create(:site, name: 'My Site') }
+
+  context 'when logged in as contact' do
+    let(:user) { create(:contact, site: site) }
+
+    it 'shows contact\'s site dashboard' do
+      visit root_path(as: user)
+
+      expect(find('.title-card')).to have_text 'Site Dashboard: My Site'
+    end
+  end
+
+  context 'when logged in as admin' do
+    let(:user) { create(:admin) }
+
+    it 'shows \'all sites\' dashboard' do
+      visit root_path(as: user)
+
+      expect(find('.title-card')).to have_text 'All Sites Dashboard'
+    end
+  end
+
+  context 'when not logged in' do
+    it 'politely suggests logging in' do
+      visit root_path
+
+      expect do
+        find('.title-card')
+      end.to raise_error(Capybara::ElementNotFound)
+
+      expect(find('.sign-in')).to have_text 'Please sign in to Flight'
+    end
+  end
+
+  context 'when logged in to SSO without a Center account' do
+    let(:valid_token) {
+      ::JsonWebToken.encode(email: 'otherwise_unused_email@example.com')
+    }
+
+    it 'shows the \'account not authorised\' message' do
+      create_cookie('flight_sso', valid_token)
+      visit root_path
+
+      expect do
+        find('.title-card')
+      end.to raise_error(Capybara::ElementNotFound)
+
+      expect(find('.sign-in')).to have_text 'Account not authorised'
+    end
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,4 +108,6 @@ RSpec.configure do |config|
     # tests.
     RequestStore.clear!
   end
+
+  config.include ShowMeTheCookies, :type => :feature
 end


### PR DESCRIPTION
Since the switch to Flight SSO-based login, it's been possible for users to enter a state where they are logged in to the Flight platform but do not have a Flight Center account associated with their SSO account.

This is an entirely valid state, since anyone can sign up for Flight SSO but only those with the anointing can use Flight Center.

This PR allows Flight Center to identify users in this state, and tailors the text displayed to them where appropriate.

I've also added a test documenting the behaviour of the root path for given states of logged-in-ness.

Trello: https://trello.com/c/RHKYWl0r/355-differentiate-user-not-logged-in-and-user-logged-in-to-sso-but-has-no-flight-account