### PR TITLE
Credit charge and deposit validations

### DIFF
--- a/app/models/credit_charge.rb
+++ b/app/models/credit_charge.rb
@@ -4,7 +4,7 @@ class CreditCharge < CreditEvent
   attr_readonly :case
 
   validates :amount, numericality: {
-    minimum: 0,
+    greater_than_or_equal_to: 0,
     only_integer: true,
   }
 end

--- a/app/models/credit_deposit.rb
+++ b/app/models/credit_deposit.rb
@@ -4,7 +4,7 @@ class CreditDeposit < CreditEvent
   attr_readonly :cluster
 
   validates :amount, numericality: {
-    minimum: 1,
+    greater_than_or_equal_to: 1,
     only_integer: true,
   }
 end

--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -36,11 +36,6 @@ RSpec.describe ClustersController, type: :controller do
         post :deposit, params: params
         cluster.reload
         expect(cluster.credit_balance).to eq 8
-
-        # This demonstrates that we do intentionally permit negative "deposits"
-        post :deposit, params: { cluster_id: cluster, credit_deposit: { amount: -6 } }
-        cluster.reload
-        expect(cluster.credit_balance).to eq 2
       end
 
     end

--- a/spec/models/credit_charge_spec.rb
+++ b/spec/models/credit_charge_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe CreditCharge, type: :model do
+  it do
+    is_expected.to validate_numericality_of(:amount)
+      .only_integer
+      .is_greater_than_or_equal_to(0)
+  end
+end

--- a/spec/models/credit_deposit_spec.rb
+++ b/spec/models/credit_deposit_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe CreditDeposit, type: :model do
+  it do
+    is_expected.to validate_numericality_of(:amount)
+      .only_integer
+      .is_greater_than_or_equal_to(1)
+  end
+end


### PR DESCRIPTION
Both credit charging and depositing should now properly enforce validity checks.

[Trello](https://trello.com/c/VCZW5HW3/362-creditcharge-and-creditdeposit-validations-not-working)