### PR TITLE
Extract comments to trello

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,9 +117,6 @@ class ApplicationController < RootController
   end
 
   def format_errors(model)
-    # XXX Improve error handling - for now we just return a formatted string of
-    # all errors; could be worth returning JSON which can be decoded and
-    # displayed inline with fields in app.
     model.errors.messages.map do |field, messages|
       "#{field} #{messages.join(', ')}"
     end.join('; ')

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -103,9 +103,6 @@ class MaintenanceWindowsController < ApplicationController
     !!params[:mandatory]
   end
 
-  # XXX if we changed `request` to be accessed at `/request` (rather than
-  # `/new`) then we wouldn't need to pass `template` here as it would be the
-  # same as `action`.
   def handle_form_submission(action:, template:)
     yield
 

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,7 +1,3 @@
-
-# XXX Nothing in here is applicable to every decorated model in the app, it's
-# just a bit of a dumping ground. At some point should pull things out to
-# better places.
 class ApplicationDecorator < Draper::Decorator
   # Define methods for all decorated objects.
   # Helpers are accessed through `helpers` (aka `h`). For example:

--- a/app/javascript/packs/State.elm
+++ b/app/javascript/packs/State.elm
@@ -44,9 +44,6 @@ decoder =
     let
         createInitialState =
             \( clusters, mode ) ->
-                -- XXX Change state structure/how things are passed in to Elm
-                -- app to make invalid states in 'single component mode'
-                -- impossible?
                 let
                     initialState =
                         { clusters = clusters

--- a/app/javascript/packs/State/View.elm
+++ b/app/javascript/packs/State/View.elm
@@ -10,11 +10,6 @@ import State exposing (State)
 import View.CaseForm as CaseForm
 import View.Charging as Charging
 
-
--- XXX Refactor functions in here and in `View.*` modules to use
--- `elm-bootstrap`.
-
-
 view : State -> Html Msg
 view state =
     div [ class "case-form" ]
@@ -34,9 +29,6 @@ submitErrorAlert state =
     let
         displayError =
             \error ->
-                -- XXX Update this to use new `Alert.dismissable` or
-                -- `Alert/dismissableWithAnimation` function from
-                -- elm-bootstrap, rather than handling dismissing ourselves.
                 Alert.simpleDanger
                     []
                     [ button

--- a/app/javascript/packs/Tier/Field.elm
+++ b/app/javascript/packs/Tier/Field.elm
@@ -27,9 +27,6 @@ type alias TextInputData =
     -- Whether this field has been touched yet by a user.
     , touched : Touched
 
-    -- XXX Could encode `optional` in `Field` type like:
-    -- | RequiredTextInput TextInput
-    -- | OptionalTextInput TextInput
     , optional : Bool
     , help : Maybe String
     }

--- a/app/javascript/packs/View/PartsField.elm
+++ b/app/javascript/packs/View/PartsField.elm
@@ -67,9 +67,6 @@ maybePartsField field partsFieldConfig toId state changeMsg =
             -- We're creating a Case for a specific part => don't want to allow
             -- selection of another part, but do still want to display any
             -- error between this part and selected Issue.
-            -- XXX Do nothing for this case for now (there are currently no
-            -- part validations in any case); add something appropriate back
-            -- once Tiers implemented.
             Nothing
 
         NotRequired ->

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -33,7 +33,7 @@ class Cluster < ApplicationRecord
   validates :canonical_name, presence: true
   validate :validate_all_cluster_parts_advice, if: :advice?
   validates :shortcode, presence: true, uniqueness: true
-  # validates_presence_of :motd
+  validates_presence_of :motd
 
   before_validation CanonicalNameCreator.new, on: :create
 

--- a/lib/alces/mailer/resender.rb
+++ b/lib/alces/mailer/resender.rb
@@ -46,8 +46,6 @@ module Alces
         def deliver_now
           super
         rescue ::Net::SMTPError => e
-          # XXX Also catch pipe errors and other problems that could occurr when
-          # communicating with the SMTP server.
           # We immediately try sending again as the problem could be temporary
           # and already resolved.
           begin

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CaseDecorator do
-  # XXX Parts of these tests and corresponding code duplicated and adapted for
-  # {Cluster,Component,Service}Decorator.
   describe '#association_info' do
     let(:cluster) { subject.cluster }
 
@@ -41,7 +39,6 @@ RSpec.describe CaseDecorator do
         )
       end
 
-      # XXX Same as test for Component.
       it 'includes link to Cluster' do
         expect(
           subject.association_info

--- a/spec/factories/case.rb
+++ b/spec/factories/case.rb
@@ -52,7 +52,6 @@ FactoryBot.define do
       end
     end
 
-    # XXX Very similar to above for Services.
     factory :case_requiring_service do
       association :issue, factory: :issue_requiring_service
 

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -7,11 +7,7 @@ RSpec.describe Cluster, type: :model do
   describe '#valid?' do
     subject { create(:cluster) }
 
-    # XXX Add this back once current staging deployed and so `rake
-    # alces:data:import_and_migrate_production` should succeed with this set
-    # (failing right now due to multiple Cluster data migrations since last
-    # deploy).
-    # it { is_expected.to validate_presence_of(:motd) }
+    it { is_expected.to validate_presence_of(:motd) }
 
     context 'when managed cluster' do
       subject do


### PR DESCRIPTION
All comments marked by `XXX` have been extracted to a card on the [Trello Board](https://trello.com/b/MIHTL78g/alces-flight-center-backlog) bar one which I fixed in 1c19265

[Trello](https://trello.com/c/5L1RXet9/247-grep-and-fix-move-into-trello-all-xxxs)