### PR TITLE
Version display

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -128,6 +128,14 @@ table {
 }
 
 .version {
-  font-size: 10px;
-  text-align: center;
+  font-size: 13px;
+  color: white;
+  margin-bottom: 0; // Remove default margin from p element
+
+  // This should push the text to the bottom right of the page within the
+  // footer
+  position: relative;
+  float: right;
+  top: -2.2em;
+  right: 1em;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -126,3 +126,8 @@ table {
 .alert a.btn {
   text-decoration: none;
 }
+
+.version {
+  font-size: 10px;
+  text-align: center;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,8 +50,8 @@
 
     </div>
 
-    <p class="version"> 2018.4 <%= 'Daydreaming Dickcissel' unless Rails.env.production? %></p>
     <div id='brand-footer'></div>
+    <p class="version"><%= Rails.application.config.version %></p>
     <script>
       window.__SSO_BASE_URL__ = '<%= Rails.application.config.sso_base_url %>';
       window.__REFRESH_AFTER_LOGIN__ = true;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,6 +50,7 @@
 
     </div>
 
+    <p class="version"> 2018.4 <%= 'Daydreaming Dickcissel' unless Rails.env.production? %></p>
     <div id='brand-footer'></div>
     <script>
       window.__SSO_BASE_URL__ = '<%= Rails.application.config.sso_base_url %>';

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,6 @@ Rails.application.configure do
   config.slack_webhook_url = ENV['SLACK_WEBHOOK_URL']
   config.slack_channel = ENV['SLACK_CHANNEL']
   config.slack_username = 'Alces Flight Center [Development]'
+
+  config.version = 'Development'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,4 +125,6 @@ Rails.application.configure do
         'Alces Flight Center'
       ]
     end
+
+  config.version = ENV['VERSION']
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,4 +58,6 @@ Rails.application.configure do
   config.slack_webhook_url = 'http://example.com/slack'
   config.slack_channel = '#test'
   config.slack_username = 'test'
+
+  config.version = 'vTest.Test'
 end

--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -5,8 +5,8 @@ require 'erb'
 class Deployment
   include Rake::DSL
 
-  def initialize(type, dry_run: false)
-    @remote, @tag = parse_deploy_type(type)
+  def initialize(type, version_name, dry_run: false)
+    @remote, @tag = version_name
     @dry_run = dry_run
   end
 
@@ -59,23 +59,6 @@ class Deployment
 
   PRODUCTION_APP = 'flight-center'
   STAGING_APP = 'flight-center-staging'
-
-  def parse_deploy_type(type)
-    case type
-    when :production
-      [:production, today]
-    when :hotfix
-      [:production, "#{today}-hotfix"]
-    when :staging
-      [:staging, "#{today}-staging"]
-    else
-      raise "Unknown deployment type: '#{type}'"
-    end
-  end
-
-  def today
-    Date.today.iso8601
-  end
 
   def current_branch
     @current_branch ||= `git rev-parse --abbrev-ref HEAD`.strip.inquiry

--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -6,8 +6,11 @@ class Deployment
   include Rake::DSL
 
   def initialize(type, version_name, dry_run: false)
-    @remote, @tag = version_name
+    @remote = type
+    @tag = version_name
     @dry_run = dry_run
+
+    abort "Must set ENV['VERSION'] within command!" if @tag.nil?
   end
 
   def deploy

--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -35,6 +35,8 @@ class Deployment
     run "git tag -f #{tag} #{current_branch}"
     run "git push --tags -f origin #{current_branch}"
 
+    dokku_config_set('VERSION', tag, app: app_name)
+
     scp_database_backup_script
 
     output_manual_steps
@@ -173,6 +175,10 @@ class Deployment
   def dokku_config_get(env_var, app:)
     command = dokku_command("config:get #{app} #{env_var}")
     `#{command}`.strip
+  end
+
+  def dokku_config_set(key, value, app:)
+    run dokku_command("config:set #{app} #{key}=#{value}")
   end
 
   def dokku_stop(app)

--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -30,6 +30,7 @@ class Deployment
       abort unless input.downcase == 'y'
     end
 
+    dokku_config_set('VERSION', tag, app: app_name, restart: false)
     run "git push #{remote} -f #{current_branch}:master"
 
     import_production_backup_to_staging if staging?
@@ -37,8 +38,6 @@ class Deployment
     run "git tag -f #{remote} #{current_branch}"
     run "git tag -f #{tag} #{current_branch}"
     run "git push --tags -f origin #{current_branch}"
-
-    dokku_config_set('VERSION', tag, app: app_name)
 
     scp_database_backup_script
 
@@ -180,8 +179,8 @@ class Deployment
     `#{command}`.strip
   end
 
-  def dokku_config_set(key, value, app:)
-    run dokku_command("config:set #{app} #{key}=#{value}")
+  def dokku_config_set(key, value, app:, restart: true)
+    run dokku_command("config:set #{restart ? '' : '--no-restart'} #{app} #{key}=#{value}")
   end
 
   def dokku_stop(app)

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -6,13 +6,13 @@ namespace :alces do
     [:production, :staging].each do |deploy_type|
       desc "Deploy to #{deploy_type}"
       task deploy_type do
-        deploy(deploy_type)
+        deploy(deploy_type, ENV['VERSION'])
       end
 
       namespace deploy_type do
         desc "Output what will happen on deploy to #{deploy_type}, without doing anything"
         task :dry_run do
-          deploy(deploy_type, dry_run: true)
+          deploy(deploy_type, ENV['VERSION'], dry_run: true)
         end
       end
     end
@@ -20,13 +20,13 @@ namespace :alces do
     namespace :production do
       desc "Deploy hotfix release to production"
       task :hotfix do
-        deploy(:hotfix)
+        deploy(:hotfix, ENV['VERSION'])
       end
 
       namespace :hotfix do
         desc 'Output what will happen on hotfix deploy to production, without doing anything'
         task :dry_run do
-          deploy(:hotfix, dry_run: true)
+          deploy(:hotfix, ENV['VERSION'], dry_run: true)
         end
       end
     end


### PR DESCRIPTION
This PR adds a version display just above the footer. Initially I have this in the format of `<year>.<version_number> <version name>` where `version_name` is a two word alliteration based on the `version_number` (If this equals 4 then use the 4th letter). With the first word being a verb and the second a bird.

As it stands the `version_name` shows up everywhere but `Production`. However this can easily be changed, as well as the actually formatting of the version display.

Note: There is currently nowhere stating that this needs to be changed between releases so finding a suitable place for that would be great

[Trello](https://trello.com/c/u07sGH6U/318-flight-center-version-display)