### PR TITLE
Prevent missing event details from breaking case page

### DIFF
--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -5,7 +5,8 @@ class ChangeRequestStateTransitionDecorator < ApplicationDecorator
              name: object.user.name,
              date: object.created_at,
              text: text,
-             type: 'cog'
+             type: 'cog',
+             details: 'Change Request Event'
   end
 
   def text_for_event

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -2,7 +2,7 @@
   <div class="card event-card">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
       <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
-      <div title="<%= details %>">
+      <div title="<%= details ||= nil %>">
           <%= icon(type) %>
       </div>
     </div>

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -2,7 +2,7 @@
   <div class="card event-card">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
       <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
-      <div title="<%= details ||= nil %>">
+      <div title="<%= details %>">
           <%= icon(type) %>
       </div>
     </div>

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -118,4 +118,21 @@ RSpec.describe ApplicationDecorator do
       end
     end
   end
+
+  describe 'event cards' do
+
+      Dir[File.join(Rails.root, 'app/decorators/*.rb')].each { |f| load f }
+
+      ApplicationDecorator.descendants.each do |decorator|
+        if decorator.instance_methods.include? :event_card
+          context decorator.name do
+            it 'renders event card' do
+              obj = create(decorator.object_class_name.underscore.to_sym)
+              obj.decorate.event_card
+            end
+          end
+        end
+      end
+
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
 
   factory :case_state_transition do
     association :case
+    association :user, factory: :admin
     event 'resolve'
     from 'open'
     to 'resolved'
@@ -101,6 +102,7 @@ FactoryBot.define do
   factory :credit_charge do
     amount 1
     association :user, factory: :admin
+    association :case
   end
 
   factory :change_request do
@@ -111,6 +113,7 @@ FactoryBot.define do
 
   factory :change_request_state_transition do
     association :change_request
+    association :user, factory: :admin
     event 'propose'
     from 'draft'
     to 'awaiting_authorisation'

--- a/spec/factories/maintenance_window.rb
+++ b/spec/factories/maintenance_window.rb
@@ -58,5 +58,7 @@ FactoryBot.define do
   factory :maintenance_window_state_transition do
     maintenance_window
     to :requested
+    event :request
+    association :user, factory: :admin
   end
 end

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -84,26 +84,33 @@ RSpec.describe 'Case page', type: :feature do
       # And a log entry
       create(:log, cases: [open_case], cluster: cluster, details: 'Loggy McLogface')
 
+      # And a change request
+      cr = create(:change_request, case: open_case, state: 'draft')
+      create(:change_request_state_transition, event: 'propose', user: admin, change_request: cr)
+
       visit case_path(open_case, as: admin)
 
       event_cards = all('.event-card')
-      expect(event_cards.size).to eq(7)
+      expect(event_cards.size).to eq(8)
 
-      expect(event_cards[6].find('.card-body').text).to eq('First')
-      expect(event_cards[5].find('.card-body').text).to eq('Second')
-      expect(event_cards[4].find('.card-body').text).to match(
+      expect(event_cards[7].find('.card-body').text).to eq('First')
+      expect(event_cards[6].find('.card-body').text).to eq('Second')
+      expect(event_cards[5].find('.card-body').text).to match(
         /Maintenance requested for .* from .* until .* by A Scientist; to proceed this maintenance must be confirmed on the cluster dashboard/
       )
-      expect(event_cards[3].find('.card-body').text).to eq 'Changed time worked from 0m to 2h 3m.'
+      expect(event_cards[4].find('.card-body').text).to eq 'Changed time worked from 0m to 2h 3m.'
 
-      expect(event_cards[2].find('.card-body').text).to eq(
+      expect(event_cards[3].find('.card-body').text).to eq(
           'Assigned this case to A Scientist.'
       )
-      expect(event_cards[1].find('.card-body').text).to eq(
+      expect(event_cards[2].find('.card-body').text).to eq(
           'Escalated this case to tier 3 (General Support).'
       )
-      expect(event_cards[0].find('.card-body').text).to eq(
+      expect(event_cards[1].find('.card-body').text).to eq(
           'Loggy McLogface'
+      )
+      expect(event_cards[0].find('.card-body').text).to eq(
+        'Change request has been proposed and is awaiting customer authorisation. View change request'
       )
     end
 


### PR DESCRIPTION
When I added tooltips to icons for case events in #357 I didn't account for new event cards missing a `details` key-value pair. However this should now assign a nil value to `details` if it is unable to find a value for the event card and therefore would not display any tooltip when hovering over the affected icon.