### PR TITLE
Change request event Slack notifications

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -109,7 +109,11 @@ class ChangeRequestsController < ApplicationController
       # the record to the database (or raised an exception). Hence we can be
       # certain that, if we reach this point, the model is saved and valid, so
       # it's safe to send the email.
-      CaseMailer.change_request(cr.case, cr.transitions.last.decorate.text_for_event).deliver_later
+      CaseMailer.change_request(
+        cr.case,
+        cr.transitions.last.decorate.text_for_event,
+        current_user
+      ).deliver_later
     end
   end
 

--- a/app/mailer_previews/case_mailer_preview.rb
+++ b/app/mailer_previews/case_mailer_preview.rb
@@ -23,7 +23,8 @@ class CaseMailerPreview < ApplicationMailerPreview
   def change_request
     CaseMailer.change_request(
       get_case,
-      'has text to be replaced with the text from ChangeRequestStateTransitionDecorator.'
+      'has text to be replaced with the text from ChangeRequestStateTransitionDecorator.',
+      'User'
     )
   end
 

--- a/app/mailer_previews/case_mailer_preview.rb
+++ b/app/mailer_previews/case_mailer_preview.rb
@@ -24,7 +24,7 @@ class CaseMailerPreview < ApplicationMailerPreview
     CaseMailer.change_request(
       get_case,
       'has text to be replaced with the text from ChangeRequestStateTransitionDecorator.',
-      'User'
+      user
     )
   end
 

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -64,5 +64,6 @@ class CaseMailer < ApplicationMailer
       cc: @case.email_recipients,
       subject: @case.email_reply_subject
     )
+    SlackNotifier.change_request_notification(@case, @text)
   end
 end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -57,13 +57,13 @@ class CaseMailer < ApplicationMailer
     window.set_maintenance_ending_soon_email_flag
   end
 
-  def change_request(my_case, text)
+  def change_request(my_case, text, user)
     @case = my_case
     @text = text
     mail(
       cc: @case.email_recipients,
       subject: @case.email_reply_subject
     )
-    SlackNotifier.change_request_notification(@case, @text)
+    SlackNotifier.change_request_notification(@case, @text, user)
   end
 end

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -26,7 +26,7 @@ class SlackNotifier
         title: subject_and_id_title(kase),
         title_link: case_url,
         text: notification_details,
-        mrkdwn: true
+        mrkdwn: false
       }
 
       send_notification(case_note)
@@ -34,7 +34,6 @@ class SlackNotifier
 
     def assignee_notification(kase, assignee)
       notification_text = "#{assignee.name} has been assigned to #{kase.display_id}"
-
       assignee_note = {
         fallback: notification_text,
         color: "#6e5494",
@@ -98,6 +97,19 @@ class SlackNotifier
       }
 
       send_notification(log_note)
+    end
+
+    def change_request_notification(kase, text)
+      text = "The change request for this case #{text}"
+      change_request_note = {
+        fallback: text,
+        color: '#f44192',
+        title: subject_and_id_title(kase),
+        title_link: cluster_case_url(kase.cluster, kase),
+        text: "*<#{case_change_request_url(kase)}|Change Request Event>*\n#{text}",
+      }
+
+      send_notification(change_request_note)
     end
 
     private

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -99,11 +99,12 @@ class SlackNotifier
       send_notification(log_note)
     end
 
-    def change_request_notification(kase, text)
+    def change_request_notification(kase, text, user)
       text = "The change request for this case #{text}"
       change_request_note = {
         fallback: text,
         color: '#f44192',
+        author_name: user.name,
         title: subject_and_id_title(kase),
         title_link: cluster_case_url(kase.cluster, kase),
         text: "*<#{case_change_request_url(kase)}|Change Request Event>*\n#{text}",

--- a/spec/controllers/change_requests_controller_spec.rb
+++ b/spec/controllers/change_requests_controller_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe ChangeRequestsController, type: :controller do
 
         expect(CaseMailer).to receive(:change_request).with(
           kase,
-          message
+          message,
+          send(user)
         ).and_return(stub_mail)
 
         sign_in_as(send(user))

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -188,4 +188,16 @@ RSpec.describe 'Case mailer', :type => :mailer do
       end
     end
   end
+
+  describe 'Change Request emails' do
+    let (:text) { "Request to change please" }
+    context 'change request event' do
+      subject { CaseMailer.change_request(kase, text, requestor) }
+      it 'sends a notification to Slack' do
+        expect(SlackNotifier).to receive(:change_request_notification)
+          .with(kase, text, requestor)
+        subject
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds Slack notifications for whenever a change request event sends an email out. These will be displayed like so:

![change-request-slack](https://user-images.githubusercontent.com/36155339/41784631-3334d016-7638-11e8-99c4-89e03f622040.png)

With links to both the associated case and the change request itself.

[Trello](https://trello.com/c/8XlyhP8U/359-add-slack-notifications-to-change-request-events)