### PR TITLE
Use policies to control visibility of CR state buttons

### DIFF
--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -1,4 +1,3 @@
-
 <% if @case.open? %>
   <% if @case.tier_level < 3 %>
     <%
@@ -57,7 +56,7 @@
         </div>
       </div>
     </div>
-  <% elsif @case.can_create_change_request? && current_user.admin? %>
+  <% elsif @case.can_create_change_request? && policy(ChangeRequest).create? %>
     <%= link_to 'Create change request',
                 new_cluster_case_change_request_path(@case.cluster.id, @case.display_id),
                 class: 'btn btn-sm btn-warning',

--- a/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
+++ b/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
@@ -1,8 +1,5 @@
-<% if current_user.admin? %>
-  <p>
-    This change request is awaiting authorisation from the customer.
-  </p>
-<% else %>
+<% my_policy = policy(cr) %>
+<% if my_policy.authorise? %>
   <%= link_to 'Authorise',
               authorise_case_change_request_path(cr.case),
               class: 'btn btn-success form-control mb-2',
@@ -12,6 +9,8 @@
               method: 'post',
               role: 'button'
   %>
+<% end %>
+<% if my_policy.decline? %>
   <%= link_to 'Decline',
               decline_case_change_request_path(cr.case),
               class: 'btn btn-danger form-control',
@@ -23,4 +22,9 @@
               method: 'post',
               role: 'button'
   %>
+<% end %>
+<% if !my_policy.authorise? && !my_policy.decline? %>
+  <p>
+    This change request is awaiting authorisation from the customer.
+  </p>
 <% end %>

--- a/app/views/change_requests/state_controls/_draft.html.erb
+++ b/app/views/change_requests/state_controls/_draft.html.erb
@@ -1,9 +1,12 @@
-<% if current_user.admin? %>
+<% my_policy = policy(cr) %>
+<% if my_policy.edit? %>
   <%= link_to 'Edit',
               edit_cluster_case_change_request_path(cr.case.cluster, cr.case),
               class: 'btn btn-primary form-control mb-2',
               role: 'button'
   %>
+<% end %>
+<% if my_policy.propose? %>
   <%= link_to 'Submit for authorisation',
               propose_case_change_request_path(cr.case),
               class: 'btn btn-danger form-control',
@@ -15,7 +18,9 @@
               method: 'post',
               role: 'button'
   %>
-<% else %>
+<% end %>
+
+<% if !my_policy.edit? && !my_policy.propose? %>
 <p>
   This CR is in draft. When it has been completed you will be able to authorize or
   decline it.

--- a/app/views/change_requests/state_controls/_in_handover.html.erb
+++ b/app/views/change_requests/state_controls/_in_handover.html.erb
@@ -1,8 +1,4 @@
-<% if current_user.admin? %>
-  <p>
-    This change request is awaiting customer approval.
-  </p>
-<% else %>
+<% if policy(cr).complete? %>
   <%= link_to 'Approve work and close CR',
               complete_case_change_request_path(cr.case),
               class: 'btn btn-success form-control mb-2',
@@ -12,4 +8,8 @@
               method: 'post',
               role: 'button'
   %>
+<% else %>
+  <p>
+    This change request is awaiting customer approval.
+  </p>
 <% end %>

--- a/app/views/change_requests/state_controls/_in_progress.html.erb
+++ b/app/views/change_requests/state_controls/_in_progress.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.admin? %>
+<% if policy(cr).handover? %>
   <%= link_to 'Begin handover',
               handover_case_change_request_path(cr.case),
               class: 'btn btn-danger form-control mb-2',

--- a/spec/features/change_request/show_spec.rb
+++ b/spec/features/change_request/show_spec.rb
@@ -6,32 +6,39 @@ RSpec.describe 'Change request view', type: :feature do
     draft: {
       admin: ['Edit', 'Submit for authorisation'],
       contact: [],
+      viewer: [],
     },
     awaiting_authorisation: {
       admin: [],
       contact: ['Authorise', 'Decline'],
+      viewer: [],
     },
     declined: {
       admin: [],
       contact: [],
+      viewer: [],
     },
     in_progress: {
       admin: ['Begin handover'],
       contact: [],
+      viewer: [],
     },
     in_handover: {
       admin: [],
       contact: ['Approve work and close CR'],
+      viewer: [],
     },
     completed: {
       admin: [],
       contact: [],
+      viewer: [],
     }
   }.freeze
 
   let(:site) { create(:site) }
   let(:admin) { create(:admin) }
   let(:contact) { create(:contact, site: site) }
+  let(:viewer) { create(:viewer, site: site) }
   let(:cluster) { create(:cluster, site: site) }
   let(:kase) { build(:open_case, tier_level: 4, cluster: cluster) }
 


### PR DESCRIPTION
This PR updates the guards around CR state buttons (including the initial "create CR" button) to use `Policy`s, consistent with the rest of the site. (`Policy` and friends weren't around when the work on CRs was started.)

Trello: https://trello.com/c/7JKGHzZv/361-improve-user-authorisation-handling-once-cr-pr-merged