### PR TITLE
Reduce number of case URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Re-run `bin/setup` script; it should safely be able to be run multiple times.
 
 - Specific tests: see `rspec -h`
 
+- To get Rails to throw exceptions rather than render fancy error pages, set
+  `EXCEPTIONS=true` when running `rspec`. This will cause some otherwise-passing
+  tests to fail!
+
 
 ### To develop with latest production data
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < RootController
   decorates_assigned :site
 
   helper_method :signed_in_without_account?
+  helper_method :case_url
 
   before_action :set_sentry_raven_context
   before_action :assign_current_user
@@ -46,6 +47,14 @@ class ApplicationController < RootController
     # We want to identify this scenario so that we can use more appropriate
     # language e.g. don't tell them to "log in" again.
     current_user.nil? && valid_sso_token?
+  end
+
+  def case_url(kase)
+    cluster_case_url(kase.cluster, kase)
+  end
+
+  def case_path(kase)
+    cluster_case_path(kase.cluster, kase)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < RootController
 
   helper_method :signed_in_without_account?
   helper_method :case_url
+  helper_method :case_path
 
   before_action :set_sentry_raven_context
   before_action :assign_current_user

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -3,7 +3,10 @@ class CasesController < ApplicationController
 
   # Authorization also not required for `resolved` here, since this is
   # effectively the same as `index` just with different Cases listed.
-  after_action :verify_authorized, except: NO_AUTH_ACTIONS + [:resolved]
+  after_action :verify_authorized, except: NO_AUTH_ACTIONS + [
+    :resolved,
+    :redirect_to_canonical_path,
+  ]
 
   def index
     index_action(show_resolved: false)
@@ -125,6 +128,11 @@ class CasesController < ApplicationController
     change_action "Commenting #{verb} for contacts on case %s" do |kase|
       kase.comments_enabled = enabled
     end
+  end
+
+  def redirect_to_canonical_path
+    kase = case_from_params
+    redirect_to cluster_case_path(kase.cluster, kase)
   end
 
   private

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -56,7 +56,7 @@ class CasesController < ApplicationController
         format.json do
           # Return no errors and success status to case form app; it will
           # redirect to the path we give it.
-          render json: { redirect: cluster_case_path(@case.cluster, @case) }
+          render json: { redirect: case_path(@case) }
         end
       else
         errors = format_errors(@case)
@@ -132,7 +132,7 @@ class CasesController < ApplicationController
 
   def redirect_to_canonical_path
     kase = case_from_params
-    redirect_to cluster_case_path(kase.cluster, kase)
+    redirect_to case_path(kase)
   end
 
   private

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -17,7 +17,7 @@ class ChangeRequestsController < ApplicationController
 
     if @case.save
       flash[:success] = "Created change request for case #{@case.display_id}."
-      redirect_to cluster_case_path(@case.cluster, @case)
+      redirect_to case_path(@case)
     else
       errors = format_errors(cr)
       flash[:error] = "Error creating change request: #{errors}." if errors

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -17,7 +17,7 @@ class ChangeRequestsController < ApplicationController
 
     if @case.save
       flash[:success] = "Created change request for case #{@case.display_id}."
-      redirect_to case_path(@case.display_id)
+      redirect_to cluster_case_path(@case.cluster, @case)
     else
       errors = format_errors(cr)
       flash[:error] = "Error creating change request: #{errors}." if errors

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -22,7 +22,7 @@ class CaseDecorator < ApplicationDecorator
   def case_link
     h.link_to(
       display_id,
-      h.cluster_case_path(self.cluster, self),
+      h.case_path(self),
       title: subject
     )
   end

--- a/app/decorators/component_decorator.rb
+++ b/app/decorators/component_decorator.rb
@@ -17,7 +17,6 @@ class ComponentDecorator < ClusterPartDecorator
       tabs_builder.overview,
       tabs_builder.logs,
       tabs_builder.asset_record,
-      tabs_builder.cases,
       tabs_builder.maintenance,
       { id: :expansions, path: h.component_component_expansions_path(self) },
     ]

--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -8,7 +8,7 @@ class CreditChargeDecorator < ApplicationDecorator
     h.render 'clusters/credit_charge_entry',
              amount: -object.amount,
              date: object.created_at do
-      h.link_to link_text, h.cluster_case_path(kase.cluster, kase), class: h.credit_value_class(-object.amount)
+      h.link_to link_text, h.case_path(kase), class: h.credit_value_class(-object.amount)
     end
   end
 

--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -8,7 +8,7 @@ class CreditChargeDecorator < ApplicationDecorator
     h.render 'clusters/credit_charge_entry',
              amount: -object.amount,
              date: object.created_at do
-      h.link_to link_text, h.case_path(kase), class: h.credit_value_class(-object.amount)
+      h.link_to link_text, h.cluster_case_path(kase.cluster, kase), class: h.credit_value_class(-object.amount)
     end
   end
 

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -13,7 +13,7 @@ class ServiceDecorator < ClusterPartDecorator
   end
 
   def tabs
-    [tabs_builder.overview, tabs_builder.cases, tabs_builder.maintenance]
+    [tabs_builder.overview, tabs_builder.maintenance]
   end
 
   def case_form_json

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -1,0 +1,11 @@
+module CasesHelper
+
+  def case_path(kase)
+    Rails.application.routes.url_helpers.cluster_case_path(kase.cluster, kase)
+  end
+
+  def case_url(kase)
+    Rails.application.routes.url_helpers.cluster_case_url(kase.cluster, kase)
+  end
+
+end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -51,4 +51,8 @@ module MailerHelper
     return nil if eh.blank?
     " #{eh}"
   end
+
+  def case_url(kase)
+    cluster_case_url(kase.cluster, kase)
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -21,7 +21,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def dashboard_case_path(kase)
-    Rails.application.routes.url_helpers.polymorphic_path([self, kase])
+    Rails.application.routes.url_helpers.cluster_case_path(kase.cluster, kase)
   end
 
   class << self

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,12 +25,4 @@ class Site < ApplicationRecord
   def primary_contact
     users.find_by(role: 'primary_contact')
   end
-
-  def dashboard_case_path(kase)
-    if current_user.site_user?
-      Rails.application.routes.url_helpers.cluster_case_path(kase.cluster, kase)
-    else
-      Rails.application.routes.url_helpers.polymorphic_path([self, kase])
-    end
-  end
 end

--- a/app/models/slack_notifier.rb
+++ b/app/models/slack_notifier.rb
@@ -107,7 +107,7 @@ class SlackNotifier
         author_name: user.name,
         title: subject_and_id_title(kase),
         title_link: cluster_case_url(kase.cluster, kase),
-        text: "*<#{case_change_request_url(kase)}|Change Request Event>*\n#{text}",
+        text: "*<#{cluster_case_change_request_url(kase.cluster, kase)}|Change Request Event>*\n#{text}",
       }
 
       send_notification(change_request_note)

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -8,6 +8,10 @@ class CasePolicy < ApplicationPolicy
   alias_method :set_time?, :admin?
   alias_method :set_commenting?, :admin?
 
+  def redirect_to_canonical_path?
+    true
+  end
+
   class Scope < Scope
     def resolve
       scope

--- a/app/views/change_requests/show.html.erb
+++ b/app/views/change_requests/show.html.erb
@@ -27,7 +27,7 @@
             <hr />
             <%=
               link_to 'Return to case',
-                      cluster_case_path(@case.cluster, @case),
+                      case_path(@case),
                       class: 'btn btn-primary form-control',
                       role: 'button'
             %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,8 +22,10 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = true
+  # If false, raise exceptions instead of rendering exception templates.
+  # Set EXCEPTIONS=true when running rspec to get useful exceptions out of
+  # test failures rather than have Capybara happily load the pretty error page.
+  config.action_dispatch.show_exceptions = !ENV.fetch('EXCEPTIONS', false)
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
   end
 
   cases = Proc.new do |**params, &block|
-    params[:only] = Array.wrap(params[:only]).concat [:show, :new, :index]
+    params[:only] = Array.wrap(params[:only]).concat [:index]
     resources :cases, **params do
       collection do
         get :resolved
@@ -103,10 +103,10 @@ Rails.application.routes.draw do
 
     root 'sites#index'
     resources :sites, only: [:show, :index] do
-      cases.call
+      cases.call(only: [:index, :new])
     end
 
-    resources :cases, only: [] do
+    cases.call(only: []) do
       member do
         post :resolve  # Only admins may resolve a case
         post :close  # Only admins may close a case
@@ -114,7 +114,7 @@ Rails.application.routes.draw do
         post :set_time
         post :set_commenting
       end
-      resource :change_request, only: [:new, :create, :edit, :update], path: 'change-request' do
+      resource :change_request, only: [:create, :update], path: 'change-request' do
         member do
           post :propose
           post :handover
@@ -129,13 +129,13 @@ Rails.application.routes.draw do
     end
 
     resources :clusters, only: [] do
+      cases.call(only: []) do
+        resource :change_request, only: [:new, :edit], path: 'change-request'
+      end
       request_maintenance_form.call
       admin_logs.call
       notes.call(true)
       post :deposit
-      cases.call do
-        resource :change_request, only: [:new, :create, :edit], path: 'change-request'
-      end
     end
 
     resources :components, only: []  do
@@ -175,16 +175,11 @@ Rails.application.routes.draw do
     root 'sites#show'
     delete '/sign_out' => 'sso_sessions#destroy', as: 'sign_out'  # Keeping this one around as it's correctly coupled to SSO
 
-    cases.call(only: [:create]) do
-      resources :case_comments, only: :create do
-        collection do
-          post :preview
-          post :write
-        end
-      end
+    cases.call(only: [:new, :create, :index]) do
       member do
         post :escalate
       end
+
       resource :change_request, only: [:show], path: 'change-request' do
         member do
           post :authorise
@@ -192,11 +187,18 @@ Rails.application.routes.draw do
           post :complete
         end
       end
+
+      resources :case_comments, only: :create do
+        collection do
+          post :preview
+          post :write
+        end
+      end
     end
 
     resources :clusters, only: :show do
-      cases.call do
-        resource :change_request, only: [:show], path: 'change-request'
+      cases.call(only: [:show, :create, :index, :new]) do
+         resource :change_request, only: [:show], path: 'change-request'
       end
       resources :services, only: :index
       maintenance_windows.call
@@ -209,7 +211,6 @@ Rails.application.routes.draw do
     end
 
     resources :components, only: :show do
-      cases.call
       maintenance_windows.call
       resources :component_expansions,
                 path: component_expansions_alias,
@@ -226,7 +227,6 @@ Rails.application.routes.draw do
     end
 
     resources :services, only: :show do
-      cases.call
       maintenance_windows.call
       confirm_maintenance_form.call
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,6 +169,9 @@ Rails.application.routes.draw do
     # rails-admin expects a `logout_path` route helper to exist which will sign
     # them out; this declaration defines this.
     delete :logout, to: 'sso_sessions#destroy'
+
+    # Support legacy case URLs
+    get '/sites/:site_id/cases/:id', to: 'cases#redirect_to_canonical_path'
   end
 
   constraints Clearance::Constraints::SignedIn.new do
@@ -236,6 +239,11 @@ Rails.application.routes.draw do
         post :reject
       end
     end
+
+    # Support legacy case URLs
+    get '/cases/:id', to: 'cases#redirect_to_canonical_path'
+    get '/services/:service_id/cases/:id', to: 'cases#redirect_to_canonical_path'
+    get '/components/:component_id/cases/:id', to: 'cases#redirect_to_canonical_path'
   end
 
   constraints Clearance::Constraints::SignedOut.new do

--- a/spec/features/case/new_spec.rb
+++ b/spec/features/case/new_spec.rb
@@ -66,18 +66,6 @@ RSpec.describe 'Case form', type: :feature, js: true do
     it_behaves_like 'it allows Case creation'
   end
 
-  context 'when accessed at `/service/*/cases/new`' do
-    let(:path) { new_service_case_path(service, as: user) }
-
-    it_behaves_like 'it allows Case creation'
-  end
-
-  context 'when accessed at `/component/*/cases/new`' do
-    let(:path) { new_component_case_path(component, as: user) }
-
-    it_behaves_like 'it allows Case creation'
-  end
-
   describe 'motd tool' do
     let!(:tier) do
       create(:tier_with_tool, issue: issue, tool: :motd)

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Case page', type: :feature do
         cluster: cluster
       )
 
-      visit case_path(kase, as: contact)
+      visit cluster_case_path(kase.cluster, kase, as: contact)
 
       header_text = all('th').map(&:text)
       expect(header_text).to include(field_name)
@@ -55,7 +55,7 @@ RSpec.describe 'Case page', type: :feature do
         change_motd_request: build(:change_motd_request, motd: motd),
       )
 
-      visit case_path(kase, as: contact)
+      visit cluster_case_path(kase.cluster, kase, as: contact)
 
       data_text = all('td').map(&:text)
       expect(data_text).to include(motd)
@@ -88,7 +88,7 @@ RSpec.describe 'Case page', type: :feature do
       cr = create(:change_request, case: open_case, state: 'draft')
       create(:change_request_state_transition, event: 'propose', user: admin, change_request: cr)
 
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster, open_case, as: admin)
 
       event_cards = all('.event-card')
       expect(event_cards.size).to eq(8)
@@ -118,7 +118,7 @@ RSpec.describe 'Case page', type: :feature do
       open_case.time_worked = 1138
       open_case.save
 
-      visit case_path(open_case, as: contact)
+      visit cluster_case_path(cluster, open_case, as: contact)
 
       open_case.reload
 
@@ -139,7 +139,7 @@ RSpec.describe 'Case page', type: :feature do
              cluster: cluster,
              details: '*Loggy* **McLogface**')
 
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster, open_case, as: admin)
 
       event_cards = all('.event-card')
       expect(event_cards.size).to eq(2)
@@ -152,54 +152,54 @@ RSpec.describe 'Case page', type: :feature do
     end
 
     it 'shows a card for creation of CreditCharge' do
-      visit case_path(closed_case, as: admin)
+      visit cluster_case_path(cluster, closed_case, as: admin)
       expect(find('.event-card').find('.card-body')).to have_text 'A charge of 1 credit was added for this case.'
     end
   end
 
   describe 'comments form' do
     it 'shows or hides add comment form for contacts' do
-      visit case_path(consultancy_case, as: contact)
+      visit cluster_case_path(cluster, consultancy_case, as: contact)
 
       form = find('#new_case_comment')
       form.find('#case_comment_text')
 
       expect(form.find('input').value).to eq 'Add new comment'
 
-      visit case_path(open_case, as: contact)
+      visit cluster_case_path(cluster, open_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
 
       # Observe that case state overrides case tier in terms of why we report commenting
       # being disabled.
-      visit case_path(resolved_case, as: contact)
+      visit cluster_case_path(cluster, resolved_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
       expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is resolved.'
 
-      visit case_path(closed_case, as: contact)
+      visit cluster_case_path(cluster, closed_case, as: contact)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
       expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is closed.'
     end
 
     it 'shows or hides add comment form for admins' do
-      visit case_path(consultancy_case, as: admin)
+      visit cluster_case_path(cluster, consultancy_case, as: admin)
 
       form = find('#new_case_comment')
       form.find('#case_comment_text')
 
       expect(form.find('input').value).to eq 'Add new comment'
 
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster, open_case, as: admin)
 
       form = find('#new_case_comment')
       form.find('#case_comment_text')
 
       expect(form.find('input').value).to eq 'Add new comment'
 
-      visit case_path(resolved_case, as: admin)
+      visit cluster_case_path(cluster, resolved_case, as: admin)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
       expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is resolved.'
 
-      visit case_path(closed_case, as: admin)
+      visit cluster_case_path(cluster,closed_case, as: admin)
       expect { find('#new_case_comment') }.to raise_error(Capybara::ElementNotFound)
       expect(find('.card.bg-light').text).to match 'Commenting is disabled as this case is closed.'
     end
@@ -207,30 +207,30 @@ RSpec.describe 'Case page', type: :feature do
 
   describe 'state controls' do
     it 'hides state controls for contacts' do
-      visit case_path(open_case, as: contact)
+      visit cluster_case_path(cluster,open_case, as: contact)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
 
-      visit case_path(resolved_case, as: contact)
+      visit cluster_case_path(cluster,resolved_case, as: contact)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
 
-      visit case_path(closed_case, as: contact)
+      visit cluster_case_path(cluster,closed_case, as: contact)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
     end
 
     it 'shows or hides state controls for admins' do
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster,open_case, as: admin)
 
       expect(find('#case-state-controls').find('a').text).to eq 'Resolve this case'
 
-      visit case_path(resolved_case, as: admin)
+      visit cluster_case_path(cluster,resolved_case, as: admin)
       expect(find('#case-state-controls').find('input[type=submit]').value).to eq 'Set charge and close case'
 
-      visit case_path(closed_case, as: admin)
+      visit cluster_case_path(cluster,closed_case, as: admin)
       expect { find('#case-state-controls').find('a') }.to raise_error(Capybara::ElementNotFound)
     end
 
     it 'requires a charge to be specified to close a case' do
-      visit case_path(resolved_case, as: admin)
+      visit cluster_case_path(cluster,resolved_case, as: admin)
       fill_in 'credit_charge_amount', with: ''
       click_button 'Set charge and close case'
 
@@ -240,7 +240,7 @@ RSpec.describe 'Case page', type: :feature do
     end
 
     let(:cr_case) {
-      create(:resolved_case, tier_level: 4, change_request: cr)
+      create(:resolved_case, tier_level: 4, change_request: cr, cluster: cluster)
     }
 
     context 'with a declined change request' do
@@ -253,7 +253,7 @@ RSpec.describe 'Case page', type: :feature do
       }
 
       it 'does not use CR charge as a minimum' do
-        visit case_path(cr_case, as: admin)
+        visit cluster_case_path(cluster, cr_case, as: admin)
 
         expect(find('#credit_charge_amount').value).to eq "0"
       end
@@ -269,7 +269,7 @@ RSpec.describe 'Case page', type: :feature do
       }
 
       it 'uses CR charge as a minimum' do
-        visit case_path(cr_case, as: admin)
+        visit cluster_case_path(cluster,cr_case, as: admin)
 
         expect(find('#credit_charge_amount').value).to eq "42"
         expect(find('#case-state-controls')).to have_text 'Charge below should include 42 credits from attached CR'
@@ -279,14 +279,14 @@ RSpec.describe 'Case page', type: :feature do
 
   describe 'case assignment' do
     it 'hides assignment controls for contacts' do
-      visit case_path(open_case, as: contact)
+      visit cluster_case_path(cluster, open_case, as: contact)
       assignment_td = find('#case-assignment')
       expect { assignment_td.find('input') }.to raise_error(Capybara::ElementNotFound)
       expect(assignment_td.text).to eq('Nobody')
     end
 
     it 'displays assignment controls for admins' do
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster, open_case, as: admin)
       assignment_select = find('#case-assignment').find('select')
 
       options = assignment_select.all('option').map(&:text)
@@ -296,7 +296,7 @@ RSpec.describe 'Case page', type: :feature do
     it 'changes assigned user when assignee is selected' do
       user = create(:admin, name: 'Jerry')
 
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster,open_case, as: admin)
       find('#case-assignment').select(user.name)
       click_button('Change assignment')
       open_case.reload
@@ -307,7 +307,7 @@ RSpec.describe 'Case page', type: :feature do
     context 'when a case has an assignee' do
       let(:assignee) { contact }
       it 'preselects the current assignee' do
-        visit case_path(open_case, as: admin)
+        visit cluster_case_path(cluster,open_case, as: admin)
         assignment_select = find('#case-assignment').find('select')
 
         expect(assignment_select.value).to eq(contact.id.to_s)
@@ -321,7 +321,7 @@ RSpec.describe 'Case page', type: :feature do
       subject { create(:open_case, cluster: cluster, tier_level: 2) }
 
       it 'disables commenting for site contact' do
-        visit case_path(subject, as: contact)
+        visit cluster_case_path(cluster,subject, as: contact)
 
         expect do
           find(comment_form_class)
@@ -334,7 +334,7 @@ RSpec.describe 'Case page', type: :feature do
         subject.comments_enabled = true
         subject.save
 
-        visit case_path(subject, as: contact)
+        visit cluster_case_path(cluster,subject, as: contact)
 
         fill_in 'case_comment_text', with: 'This is a test comment'
         click_button 'Add new comment'
@@ -348,7 +348,7 @@ RSpec.describe 'Case page', type: :feature do
       end
 
       it 'allows admin to enable commenting when disabled' do
-        visit case_path(subject, as: admin)
+        visit cluster_case_path(cluster,subject, as: admin)
         click_link 'Enable'
 
         subject.reload
@@ -360,7 +360,7 @@ RSpec.describe 'Case page', type: :feature do
         subject.comments_enabled = true
         subject.save
 
-        visit case_path(subject, as: admin)
+        visit cluster_case_path(cluster,subject, as: admin)
         click_link 'Disable'
 
         subject.reload
@@ -370,7 +370,7 @@ RSpec.describe 'Case page', type: :feature do
     end
 
     it 'allows a comment to be added' do
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster,open_case, as: admin)
 
       fill_in 'case_comment_text', with: 'This is a test comment'
       click_button 'Add new comment'
@@ -383,7 +383,7 @@ RSpec.describe 'Case page', type: :feature do
     end
 
     it 'does not allow empty comments' do
-      visit case_path(open_case, as: admin)
+      visit cluster_case_path(cluster,open_case, as: admin)
 
       fill_in 'case_comment_text', with: ''
       click_button 'Add new comment'
@@ -399,14 +399,14 @@ RSpec.describe 'Case page', type: :feature do
         subject { create("#{state}_case".to_sym, cluster: cluster, tier_level: 3) }
 
         it 'does not allow commenting by site contact' do
-          visit case_path(subject, as: contact)
+          visit cluster_case_path(cluster,subject, as: contact)
           expect do
             find('textarea')
           end.to raise_error(Capybara::ElementNotFound)
         end
 
         it 'does not allow commenting by admin' do
-          visit case_path(subject, as: admin)
+          visit cluster_case_path(cluster,subject, as: admin)
           expect do
             find('textarea')
           end.to raise_error(Capybara::ElementNotFound)
@@ -424,7 +424,7 @@ RSpec.describe 'Case page', type: :feature do
 
     RSpec.shared_examples 'time display' do
       it 'correctly displays existing time in hours and minutes' do
-        visit case_path(subject, as: admin)
+        visit cluster_case_path(cluster,subject, as: admin)
 
         form = find(time_form_id)
         expect(form.find_field('time[hours]', disabled: :all).value).to eq "2"
@@ -432,7 +432,7 @@ RSpec.describe 'Case page', type: :feature do
       end
 
       it 'doesn\'t show time worked to contacts' do
-        visit case_path(subject, as: contact)
+        visit cluster_case_path(cluster,subject, as: contact)
         expect { find(time_form_id) }.to raise_error(Capybara::ElementNotFound)
       end
     end
@@ -445,7 +445,7 @@ RSpec.describe 'Case page', type: :feature do
       include_examples 'time display'
 
       it 'allows admins to set time worked' do
-        visit case_path(subject, as: admin)
+        visit cluster_case_path(cluster,subject, as: admin)
 
         fill_in 'time[hours]', with: '3'
         fill_in 'time[minutes]', with: '42'
@@ -467,7 +467,7 @@ RSpec.describe 'Case page', type: :feature do
       include_examples 'time display'
 
       it 'does not allow time worked to be changed' do
-        visit case_path(subject, as: admin)
+        visit cluster_case_path(cluster,subject, as: admin)
 
         expect(find_field('time[hours]', disabled: true)).to be_disabled
         expect(find_field('time[minutes]', disabled: true)).to be_disabled
@@ -486,7 +486,7 @@ RSpec.describe 'Case page', type: :feature do
       end
 
       it 'can be escalated using button' do
-        visit case_path(subject, as: admin)
+        visit cluster_case_path(cluster,subject, as: admin)
 
         expect do
           find_button escalate_button_text
@@ -502,7 +502,7 @@ RSpec.describe 'Case page', type: :feature do
       end
 
       it_behaves_like 'button is disabled for viewers' do
-        let(:path) { case_path(subject, as: user) }
+        let(:path) { cluster_case_path(subject.cluster, subject, as: user) }
         let(:button_text) { escalate_button_text }
         let(:disabled_button_title) do
           'As a viewer you cannot escalate a case'
@@ -512,7 +512,7 @@ RSpec.describe 'Case page', type: :feature do
 
     RSpec.shared_examples 'for inapplicable cases' do
       it 'does not show escalate button' do
-        visit case_path(subject, as: admin)
+        visit cluster_case_path(cluster, subject, as: admin)
 
         expect do
           find_button escalate_button_text
@@ -522,7 +522,7 @@ RSpec.describe 'Case page', type: :feature do
 
     context 'for open tier 3 case' do
       subject do
-        create(:open_case, tier_level: 3)
+        create(:open_case, tier_level: 3, cluster: cluster)
       end
 
       it_behaves_like 'for inapplicable cases'
@@ -530,7 +530,7 @@ RSpec.describe 'Case page', type: :feature do
 
     context 'for resolved tier 2 case' do
       subject do
-        create(:resolved_case, tier_level: 2)
+        create(:resolved_case, tier_level: 2, cluster: cluster)
       end
 
       it_behaves_like 'for inapplicable cases'
@@ -538,7 +538,7 @@ RSpec.describe 'Case page', type: :feature do
 
     context 'for closed tier 2 case' do
       subject do
-        create(:closed_case, tier_level: 2)
+        create(:closed_case, tier_level: 2, cluster: cluster)
       end
 
       it_behaves_like 'for inapplicable cases'
@@ -549,7 +549,7 @@ RSpec.describe 'Case page', type: :feature do
 
     RSpec.shared_examples 'does not show maintenance button' do
       it 'doesn\'t show maintenance button' do
-        visit case_path(subject, as: user)
+        visit cluster_case_path(cluster, subject, as: user)
         expect do
           find('a', text: 'Request maintenance')
         end.to raise_error(Capybara::ElementNotFound)
@@ -563,7 +563,7 @@ RSpec.describe 'Case page', type: :feature do
         let(:user) { admin }
 
         it 'shows button' do
-          visit case_path(subject, as: user)
+          visit cluster_case_path(cluster,subject, as: user)
 
           request_link = find('a', text: 'Request maintenance')
           expect(request_link[:href]).to eq new_cluster_maintenance_window_path(cluster, case_id: open_case.id)
@@ -599,7 +599,7 @@ RSpec.describe 'Case page', type: :feature do
 
     let(:request) { create(:change_motd_request, state: :unapplied) }
 
-    let(:path) { case_path(subject, as: user) }
+    let(:path) { cluster_case_path(subject.cluster, subject, as: user) }
     let(:apply_button_text) { 'Done' }
     let(:reapply_button_text) { 'Already applied' }
 
@@ -665,7 +665,7 @@ RSpec.describe 'Case page', type: :feature do
 
     RSpec.shared_examples 'redirect examples' do
       it "redirects to the cluster dashboard case page from /cases/:id" do
-        visit(case_path(kase, as: user))
+        visit(cluster_case_path(cluster, kase, as: user))
         expect(current_path).to eq(cluster_case_path(kase.cluster, kase))
       end
 


### PR DESCRIPTION
This PR lays some groundwork for multiple `Case` associations by reducing the number of URLs at which a `Case` can be viewed.

- The "canonical" path for a case is now `/clusters/:cluster_id/cases/:id`. 
- Actions on cases still happen at `/cases/:case_id/<action>`; these URLs are not visible to users and typically result in a redirect to the canonical path at the end of the action.
- Legacy URLs such as `/cases/:id`, `/sites/:site_id/cases/:id`, and those for `Service`s and `Component`s, redirect to the canonical URL - the latter two ignore the service/component ID entirely since this will no longer be a permanent way of identifying a case.
- Case lists for components and services no longer exist. They will be replaced in due course by filters on the case index pages.

Trello: https://trello.com/c/w3b5YcVt/367-change-urls-at-which-cases-are-available