### PR TITLE
Support for flight terminal services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ export AWS_DOCUMENTS_PREFIX=development-documents
 # `https://accounts.alces-flight.com`. This is passed through into the
 # generated HTML.
 #
+# TERMINAL_SERVICE_BASE_URL=ABC - base URL for terminal service client app. In
+# production, should be `https://terminal-service.alces-flight.com`.
+#
 # JSON_WEB_TOKEN_SECRET - Shared secret for verifying SSO token signatures.
 # This should be the same value as that for `flight-sso` in the environment
 # you're running in.

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'business_time'
 gem "audited", "~> 4.7"
 gem 'jwt'
 gem 'pundit'
+# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making
+# cross-origin AJAX possible
+gem 'rack-cors'
 
 gem 'bootstrap', '~> 4.0.0'
 gem 'jquery-rails' # Required for Bootstrap.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,7 @@ GEM
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
+    rack-cors (1.0.2)
     rack-pjax (1.0.0)
       nokogiri (~> 1.5)
       rack (>= 1.1)
@@ -475,6 +476,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.7)
   pundit
+  rack-cors
   rails (~> 5.2)
   rails-controller-testing
   rails_admin (~> 1.3)

--- a/app/assets/stylesheets/sites.scss
+++ b/app/assets/stylesheets/sites.scss
@@ -2,7 +2,7 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.cluster-list, .site-services-list {
+.cluster-list {
   .list-group-item {
     display: flex;
     justify-content: space-between;
@@ -20,5 +20,12 @@
 }
 
 .site-services {
-  margin-top: 2rem;
+    h5 {
+        display: inline-block;
+        margin-right: 0.75rem;
+    }
+}
+
+.secondary_contacts_list, .viewers_list {
+    margin-bottom: 1em;
 }

--- a/app/assets/stylesheets/sites.scss
+++ b/app/assets/stylesheets/sites.scss
@@ -2,7 +2,7 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.cluster-list {
+.cluster-list, .site-services-list {
   .list-group-item {
     display: flex;
     justify-content: space-between;
@@ -17,4 +17,8 @@
       text-align: right;
     }
   }
+}
+
+.site-services {
+  margin-top: 2rem;
 }

--- a/app/controllers/terminal_services_controller.rb
+++ b/app/controllers/terminal_services_controller.rb
@@ -1,6 +1,6 @@
 class TerminalServicesController < ApplicationController
   def show
-    config = policy_scope(FlightDirectoryConfig).first || FlightDirectoryConfig.new
+    config = @site.flight_directory_config || @site.build_flight_directory_config
     authorize config, :show?
     site = config.site
 

--- a/app/controllers/terminal_services_controller.rb
+++ b/app/controllers/terminal_services_controller.rb
@@ -8,6 +8,7 @@ class TerminalServicesController < ApplicationController
       flight_directory_config: {
         hostname: config.hostname,
         username: config.username,
+        ssh_key: config.encrypted_ssh_key,
       },
       site: {
         name: site.name,

--- a/app/controllers/terminal_services_controller.rb
+++ b/app/controllers/terminal_services_controller.rb
@@ -1,0 +1,17 @@
+class TerminalServicesController < ApplicationController
+  def show
+    config = policy_scope(FlightDirectoryConfig).first || FlightDirectoryConfig.new
+    authorize config, :show?
+    site = config.site
+
+    render json: {
+      flight_directory_config: {
+        hostname: config.hostname,
+        username: config.username,
+      },
+      site: {
+        name: site.name,
+      },
+    }
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,12 @@
+class UsersController < ApplicationController
+  def show
+    if current_user.nil?
+      render json: nil
+      return
+    end
+    render json: {
+      name: current_user.name,
+      role: current_user.role,
+    }
+  end
+end

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -20,6 +20,15 @@ class SiteDecorator < ApplicationDecorator
     )
   end
 
+  def directory_service_url
+    base_url = ENV.fetch('TERMINAL_SERVICE_BASE_URL')
+    if current_user.admin?
+      "#{base_url}/sites/#{id}/directory"
+    else
+      "#{base_url}/directory"
+    end
+  end
+
   private
 
   # When a Site user is signed in we don't want/need the `/sites/:site_id`

--- a/app/models/concerns/admin_config/encryption_key.rb
+++ b/app/models/concerns/admin_config/encryption_key.rb
@@ -1,0 +1,14 @@
+module AdminConfig::EncryptionKey
+  extend ActiveSupport::Concern
+
+  included do
+    rails_admin do
+      edit do
+        configure :public_key do
+          label 'Public RSA key'
+          html_attributes rows: 30, cols: 80
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/admin_config/flight_directory_config.rb
+++ b/app/models/concerns/admin_config/flight_directory_config.rb
@@ -3,6 +3,34 @@ module AdminConfig::FlightDirectoryConfig
 
   included do
     rails_admin do
+      show do
+        configure :encrypted_ssh_key do
+          hide
+        end
+      end
+
+      edit do
+        configure :ssh_key, :text do
+          label 'Private SSH key'
+          html_attributes rows: 30, cols: 80
+          help <<-EOF
+            It will be encrypted before being stored in the database.  Leave
+            blank to use the current SSH key.
+          EOF
+          formatted_value do
+            nil
+          end
+        end
+        configure :encrypted_ssh_key do
+          hide
+        end
+      end
     end
+  end
+
+  # Creating new FlightDirectoryConfigs with rails admin breaks without this
+  # method being added.
+  def ssh_key
+    nil
   end
 end

--- a/app/models/concerns/admin_config/flight_directory_config.rb
+++ b/app/models/concerns/admin_config/flight_directory_config.rb
@@ -1,0 +1,8 @@
+module AdminConfig::FlightDirectoryConfig
+  extend ActiveSupport::Concern
+
+  included do
+    rails_admin do
+    end
+  end
+end

--- a/app/models/encryption_key.rb
+++ b/app/models/encryption_key.rb
@@ -1,0 +1,28 @@
+require "openssl"
+
+#
+# Public key pair to encrypt private ssh keys.
+#
+class EncryptionKey < ActiveRecord::Base
+
+  include AdminConfig::EncryptionKey
+
+  validates :public_key,
+    presence: true
+
+  def self.encrypt(string)
+    first.encrypt(string)
+  end
+
+  def encrypt(string)
+    # We're explicit about the padding used as the default used by the Ruby
+    # OpenSSL bindings and the default used by the nodejs bindings are not the
+    # same.
+    padding = OpenSSL::PKey::RSA::PKCS1_PADDING
+    Base64.strict_encode64(public_key.public_encrypt(string, padding))
+  end
+
+  def public_key
+    @public_key ||= OpenSSL::PKey::RSA.new(super)
+  end
+end

--- a/app/models/flight_directory_config.rb
+++ b/app/models/flight_directory_config.rb
@@ -5,4 +5,13 @@ class FlightDirectoryConfig < ApplicationRecord
 
   validates :hostname, presence: true
   validates :username, presence: true
+
+  validates :encrypted_ssh_key,
+    presence: true,
+    length: {maximum: 4 * 1024}
+
+  def ssh_key=(plaintext_ssh_key)
+    return if plaintext_ssh_key.empty?
+    self.encrypted_ssh_key = EncryptionKey.encrypt(plaintext_ssh_key)
+  end
 end

--- a/app/models/flight_directory_config.rb
+++ b/app/models/flight_directory_config.rb
@@ -1,0 +1,8 @@
+class FlightDirectoryConfig < ApplicationRecord
+  include AdminConfig::FlightDirectoryConfig
+
+  belongs_to :site
+
+  validates :hostname, presence: true
+  validates :username, presence: true
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -8,6 +8,7 @@ class Site < ApplicationRecord
   has_many :cases, through: :clusters
   has_many :components, through: :clusters
   has_many :services, through: :clusters
+  has_one :flight_directory_config
 
   validates :name, presence: true
   validates :canonical_name, presence: true

--- a/app/policies/flight_directory_config_policy.rb
+++ b/app/policies/flight_directory_config_policy.rb
@@ -1,7 +1,9 @@
 class FlightDirectoryConfigPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if user.contact?
+      if user.admin?
+        scope
+      elsif user.contact?
         scope.
           joins(site: :users).
           where(users: {id: user.id})

--- a/app/policies/flight_directory_config_policy.rb
+++ b/app/policies/flight_directory_config_policy.rb
@@ -1,13 +1,13 @@
 class FlightDirectoryConfigPolicy < ApplicationPolicy
-  def show?
-    scope.exists? && user.contact?
-  end
-
   class Scope < Scope
     def resolve
-      scope.
-        joins(site: :users).
-        where(users: {id: user.id})
+      if user.contact?
+        scope.
+          joins(site: :users).
+          where(users: {id: user.id})
+      else
+        scope.none
+      end
     end
   end
 end

--- a/app/policies/flight_directory_config_policy.rb
+++ b/app/policies/flight_directory_config_policy.rb
@@ -1,0 +1,13 @@
+class FlightDirectoryConfigPolicy < ApplicationPolicy
+  def show?
+    scope.exists? && user.contact?
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.
+        joins(site: :users).
+        where(users: {id: user.id})
+    end
+  end
+end

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -9,12 +9,15 @@
       <h4>Primary site contact</h4>
       <ul><li><%= site.primary_contact&.decorate&.info || raw('<em>Unset</em>') %></li></ul>
 
-      <%= site.secondary_contacts_list %>
+      <div class="secondary_contacts_list">
+        <%= site.secondary_contacts_list %>
+      </div>
 
-      <%= site.viewers_list %>
+      <div class="viewers_list">
+        <%= site.viewers_list %>
+      </div>
 
       <% if site.additional_contacts.present? %>
-
         <h4>Additional site contacts</h4>
         <ul>
           <% site.additional_contacts.each do |contact| %>
@@ -22,7 +25,30 @@
           <% end %>
         </ul>
       <% end %>
-  </div>
+      <div class="site-services">
+        <h4>Site services</h4>
+        <% if site.flight_directory_config.present? %>
+          <ul>
+            <li>
+              <h5>User and group directory</h5>
+              <span>
+                <%= link_to "Manage",
+                            "#{ENV.fetch('TERMINAL_SERVICE_BASE_URL')}/directory",
+                            PolicyDependentOptions.wrap(
+                              {class: ['btn', 'btn-primary']},
+                              policy: policy(site.flight_directory_config).show?,
+                              action_description: 'manage user and group directory',
+                              user: current_user
+                            )
+                %>
+              </span>
+            </li>
+          </ul>
+        <% else %>
+          No site services are currently available for this site.
+        <% end %>
+      </div>
+    </div>
     <div class="col">
       <h3>Clusters</h3>
       <div class="list-group cluster-list">
@@ -57,31 +83,6 @@
             </span>
           </div>
         <% end %>
-      </div>
-      <div class="site-services">
-        <h3>Site services</h3>
-        <div class="list-group site-services-list">
-          <% if site.flight_directory_config.present? %>
-            <div class="list-group-item">
-              <h4>User and group directory</h4>
-              <span>
-                <%= link_to "Manage",
-                            "#{ENV.fetch('TERMINAL_SERVICE_BASE_URL')}/directory",
-                            PolicyDependentOptions.wrap(
-                              {class: ['btn', 'btn-primary']},
-                              policy: policy(site.flight_directory_config).show?,
-                              action_description: 'manage user and group directory',
-                              user: current_user
-                            )
-                %>
-              </span>
-            </div>
-          <% else %>
-            <p>
-              No site services are currently available for this site.
-            </p>
-          <% end %>
-        </div>
       </div>
     </div>
   </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -58,6 +58,31 @@
           </div>
         <% end %>
       </div>
+      <div class="site-services">
+        <h3>Site services</h3>
+        <div class="list-group site-services-list">
+          <% if site.flight_directory_config.present? %>
+            <div class="list-group-item">
+              <h4>User and group directory</h4>
+              <span>
+                <%= link_to "Manage",
+                            "#{ENV.fetch('TERMINAL_SERVICE_BASE_URL')}/directory",
+                            PolicyDependentOptions.wrap(
+                              {class: ['btn', 'btn-primary']},
+                              policy: policy(site.flight_directory_config).show?,
+                              action_description: 'manage user and group directory',
+                              user: current_user
+                            )
+                %>
+              </span>
+            </div>
+          <% else %>
+            <p>
+              No site services are currently available for this site.
+            </p>
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -33,7 +33,7 @@
               <h5>User and group directory</h5>
               <span>
                 <%= link_to "Manage",
-                            "#{ENV.fetch('TERMINAL_SERVICE_BASE_URL')}/directory",
+                            site.directory_service_url,
                             PolicyDependentOptions.wrap(
                               {class: ['btn', 'btn-primary']},
                               policy: policy(site.flight_directory_config).show?,

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,12 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'https://alces-flight.com',
+      /^.*\.alces-flight.com$/,
+      /^.*\.alces-flight.lvh.me(:[0-9]+)?$/
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resource :terminal_services, only: [:show]
+
     # Support legacy case URLs
     get '/cases/:id', to: 'cases#redirect_to_canonical_path'
     get '/services/:service_id/cases/:id', to: 'cases#redirect_to_canonical_path'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,7 @@ Rails.application.routes.draw do
     end
 
     resource :terminal_services, only: [:show]
+    resource :users, only: [:show]
 
     # Support legacy case URLs
     get '/cases/:id', to: 'cases#redirect_to_canonical_path'
@@ -233,6 +234,7 @@ Rails.application.routes.draw do
 
   constraints Clearance::Constraints::SignedOut.new do
     root 'sso_sessions#new', as: 'sign_in'
+    resource :users, only: [:show]
   end
 
   # Routes defined here are only defined/used in certain tests which need

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
     root 'sites#index'
     resources :sites, only: [:show, :index] do
       cases.call(only: [:index, :new])
+      resource :terminal_services, only: [:show]
     end
 
     cases.call(only: []) do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,10 +20,12 @@
 development:
   secret_key_base: 9907da9db29df5f46a08ed56dac8f8db94d5dd36f953db4430c18c29a3b1b8c266ce8dcdb31723c52855a925136aaf41d115dce79c46f1f9eb703dca4e6b0fee
   json_web_token_secret: cabfa4559f1d674ee86e423a4a849f450393630dfc2c48b2a949efb8df510357f602b5cab6584668452d7e0eba961d5c88be6194d978eb1d7d5d55ce5ecbc204
+  private_key_passphrase: kwKMU89_cVN6E1JG62eOZG3w4x5c9gBJ0RZB-o7RCSc20nhZEswjzwZF6T6fEczYERnlf2qbzhLWIfjZnlYMK6NxqALNk2uiYfV4oNjEwhEuVvr5VKzkAVN0aYM0uSgh
 
 test:
   secret_key_base: d08d850b99f6bdd802c0168070e78585ab84647205c643c905b31f05b2fc9f37261a8b820d306cfffc7806adbbec80abd1b56778db75ad1b038dee949cbf3b3a
   json_web_token_secret: 3f75df1558de8e0f3cc2468df2742026c88ed78df7cb1d5e957982c2c69687a38676c7f44b8caba78b7ee75acb3e401f277b242c12a9756d62a04a91186d59b4
+  private_key_passphrase: Mq9YBUvS_sHAkdqMVC0Ngwm9i0mf4j3MLC4huCo-vKkfFTuKzAyUQP17w20wG-ZwYUng5YTE7hbfDL19W0VwCl_nlXYSWvNi-kPefHz0_aWRfMmxfhQp8aVi0Ppro5xk
 
 # Do not keep production secrets in the unencrypted secrets file.
 # Instead, either read values from the environment.
@@ -33,3 +35,4 @@ test:
 production:
   secret_key_base: <%= ENV.fetch("SECRET_KEY_BASE") if Rails.env.production? %>
   json_web_token_secret: <%= ENV.fetch('JSON_WEB_TOKEN_SECRET') if Rails.env.production? %>
+  private_key_passphrase: <%= ENV.fetch('PRIVATE_KEY_PASSPHRASE') if Rails.env.production? %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,12 +20,10 @@
 development:
   secret_key_base: 9907da9db29df5f46a08ed56dac8f8db94d5dd36f953db4430c18c29a3b1b8c266ce8dcdb31723c52855a925136aaf41d115dce79c46f1f9eb703dca4e6b0fee
   json_web_token_secret: cabfa4559f1d674ee86e423a4a849f450393630dfc2c48b2a949efb8df510357f602b5cab6584668452d7e0eba961d5c88be6194d978eb1d7d5d55ce5ecbc204
-  private_key_passphrase: kwKMU89_cVN6E1JG62eOZG3w4x5c9gBJ0RZB-o7RCSc20nhZEswjzwZF6T6fEczYERnlf2qbzhLWIfjZnlYMK6NxqALNk2uiYfV4oNjEwhEuVvr5VKzkAVN0aYM0uSgh
 
 test:
   secret_key_base: d08d850b99f6bdd802c0168070e78585ab84647205c643c905b31f05b2fc9f37261a8b820d306cfffc7806adbbec80abd1b56778db75ad1b038dee949cbf3b3a
   json_web_token_secret: 3f75df1558de8e0f3cc2468df2742026c88ed78df7cb1d5e957982c2c69687a38676c7f44b8caba78b7ee75acb3e401f277b242c12a9756d62a04a91186d59b4
-  private_key_passphrase: Mq9YBUvS_sHAkdqMVC0Ngwm9i0mf4j3MLC4huCo-vKkfFTuKzAyUQP17w20wG-ZwYUng5YTE7hbfDL19W0VwCl_nlXYSWvNi-kPefHz0_aWRfMmxfhQp8aVi0Ppro5xk
 
 # Do not keep production secrets in the unencrypted secrets file.
 # Instead, either read values from the environment.
@@ -35,4 +33,3 @@ test:
 production:
   secret_key_base: <%= ENV.fetch("SECRET_KEY_BASE") if Rails.env.production? %>
   json_web_token_secret: <%= ENV.fetch('JSON_WEB_TOKEN_SECRET') if Rails.env.production? %>
-  private_key_passphrase: <%= ENV.fetch('PRIVATE_KEY_PASSPHRASE') if Rails.env.production? %>

--- a/db/migrate/20180702095222_create_flight_directory_config.rb
+++ b/db/migrate/20180702095222_create_flight_directory_config.rb
@@ -1,0 +1,19 @@
+class CreateFlightDirectoryConfig < ActiveRecord::Migration[5.2]
+  def change
+    create_table :flight_directory_configs do |t|
+      t.string :hostname,
+        limit: 255,
+        null: false
+
+      t.string :username,
+        limit: 255,
+        null: false
+
+      t.references :site,
+        foreign_key: true,
+        null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180709091730_create_encryption_keypairs.rb
+++ b/db/migrate/20180709091730_create_encryption_keypairs.rb
@@ -1,0 +1,9 @@
+class CreateEncryptionKeypairs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :encryption_keys do |t|
+      t.text :public_key, limit: 8 * 1024
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20180709104724_add_ssh_key_to_flight_directory_config.rb
+++ b/db/migrate/20180709104724_add_ssh_key_to_flight_directory_config.rb
@@ -1,0 +1,7 @@
+class AddSshKeyToFlightDirectoryConfig < ActiveRecord::Migration[5.2]
+  def change
+    add_column :flight_directory_configs, :encrypted_ssh_key, :string,
+      limit: 4 * 1024,
+      null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -290,6 +290,7 @@ ActiveRecord::Schema.define(version: 2018_07_10_181058) do
     t.bigint "site_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "encrypted_ssh_key", limit: 4096, null: false
     t.index ["site_id"], name: "index_flight_directory_configs_on_site_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -258,6 +258,12 @@ ActiveRecord::Schema.define(version: 2018_07_10_181058) do
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
+  create_table "encryption_keys", force: :cascade do |t|
+    t.text "public_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "expansion_types", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -278,6 +278,15 @@ ActiveRecord::Schema.define(version: 2018_07_10_181058) do
     t.index ["expansion_type_id"], name: "index_expansions_on_expansion_type_id"
   end
 
+  create_table "flight_directory_configs", force: :cascade do |t|
+    t.string "hostname", limit: 255, null: false
+    t.string "username", limit: 255, null: false
+    t.bigint "site_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["site_id"], name: "index_flight_directory_configs_on_site_id"
+  end
+
   create_table "issues", force: :cascade do |t|
     t.string "name", null: false
     t.boolean "requires_component", default: false, null: false
@@ -432,6 +441,7 @@ ActiveRecord::Schema.define(version: 2018_07_10_181058) do
   add_foreign_key "expansions", "component_makes"
   add_foreign_key "expansions", "components"
   add_foreign_key "expansions", "expansion_types"
+  add_foreign_key "flight_directory_configs", "sites"
   add_foreign_key "issues", "categories"
   add_foreign_key "issues", "service_types"
   add_foreign_key "logs", "components"

--- a/lib/tasks/encryption_keypair.rake
+++ b/lib/tasks/encryption_keypair.rake
@@ -1,0 +1,36 @@
+require "openssl"
+
+namespace :alces do
+  namespace :encryption_keypair do
+    desc "Generate an encryption keypair for encrypting terminal service configuration"
+    task :generate => :environment do
+
+      if ENV['ALCES_GENERATE_KEY_PAIR'] != 'standard_out_is_not_saved'
+        STDERR.puts <<-EOF
+
+        WARNING:  Running this task will print both the public and private key
+        to standard output.  The private key must not be stored along side the
+        public key.  Before running this task make sure that standard output
+        will not be stored anywhere such as papertrail.com
+        
+        To generate the keypair set the environment variable
+        `ALCES_GENERATE_KEY_PAIR` to `standard_out_is_not_saved` and rerun
+        this task.
+
+        EOF
+
+        exit 1
+      end
+
+
+      STDOUT.puts "Generating keypair. This may take some time"
+
+      keypair = OpenSSL::PKey::RSA.new(16 * 1024)
+      public_key = OpenSSL::PKey::RSA.new(keypair.public_key.to_s)
+      private_key = OpenSSL::PKey::RSA.new(keypair.to_s)
+
+      STDOUT.puts public_key.to_pem
+      STDOUT.puts private_key.to_pem
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the new flight terminal services client.

The purpose of the terminal services is to provide convenient in-browser access to some of our CLI admin tools.  Currently this is limited to the flight directory tool.

The support required from Center is:

 1. A new model `FlightDirectoryConfig` belonging to `Site` which stores the hostname and username for SSH access to the Flight Directory service.
 2. An API to expose a sites configured terminal services.
 3. An API to expose the current center user.
 4. A button on the site overview dashboard to redirect to the terminal services client.

With that understood the PR should be straightforward.  If not, let me know what questions you have and I'll answer as best I can.
