### PR TITLE
Fix Case form breaking after history navigation (fixes #407)

### DIFF
--- a/app/javascript/packs/new_case_form.js
+++ b/app/javascript/packs/new_case_form.js
@@ -3,11 +3,15 @@ import Elm from 'Main';
 const initializeFormApp = () => {
   const target = document.getElementById('new-case-form');
 
-  // Only initialize the form app if the target exists (we're on a page
-  // requiring the form) and has no children (indicates app has already been
-  // initialized, e.g. this occurs due to Turbolinks if navigate away and then
-  // back to page using browser back/forward buttons).
-  if (target && !target.hasChildNodes()) {
+  // Only initialize the form app if the target exists, i.e. we're on a page
+  // requiring the form.
+  if (target) {
+    // Clear any existing contents of the form root, e.g. if this page has been
+    // reached via history navigation Turbolinks will have cached the last seen
+    // version of the form, but without the corresponding JS (compiled Elm), so
+    // we just want to completely replace this.
+    target.innerHTML = '';
+
     const loadAttributeJson = attribute =>
       JSON.parse(target.getAttribute(attribute));
 


### PR DESCRIPTION
According to
https://github.com/turbolinks/turbolinks#restoration-visits:

> If possible, Turbolinks will render a copy of the page from cache without making a request.

When navigating away and back to the Case form this was happening, and
so a cached version of the Case form was being displayed.

However, due to our use of `!target.hasChildNodes()` when deciding
whether to initialize the Case form, although the page looked correct
due to the cached HTML, the corresponding JS (compiled Elm) was not also
being initialized, and so the form did not have any of the intended
dynamic functionality and could not be submitted.

A heavy-handed way to fix this would be to set a `<meta
name="turbolinks-cache-control" content="no-cache">` tag on this page
and avoid Turbolinks caching this page altogether, however this seems
overkill as we would then need a more jarring full page request every
time this page is visited.

Instead, each time this page is visited we can instead just always clear
any existing form content, (hopefully) ensuring the Case form is always
freshly and fully initialized however we reach this page.