### PR TITLE
Prevent slack notification for invalid logs

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -13,11 +13,11 @@ class LogsController < ApplicationController
     new_log = @scope.logs.build(log_params)
     authorize new_log
     if new_log.save
+      SlackNotifier.log_notification(new_log)
       flash[:success] = 'Added new log entry'
     else
       error_flash_models [new_log], 'Could not add log entry'
     end
-    SlackNotifier.log_notification(new_log)
     redirect_back fallback_location: @cluster
   end
 


### PR DESCRIPTION
This is a minor fix for something I came across the other day. Where the `SlackNotifier` was being called within the `LogsController` meant that a notification was being sent to Slack regardless of the validity of the log (woops).