### PR TITLE
Multiple associations for maintenance windows

### DIFF
--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -122,7 +122,7 @@ class MaintenanceWindowsController < ApplicationController
     yield
 
     flash[:success] = "Maintenance #{past_tense_of(action)}."
-    cluster = @maintenance_window.associated_cluster
+    cluster = @maintenance_window.cluster
     redirect_to cluster_maintenance_windows_path(cluster)
   rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition => e
     flash.now[:error] = "Unable to #{action} this maintenance. #{e}"
@@ -137,7 +137,7 @@ class MaintenanceWindowsController < ApplicationController
     window = MaintenanceWindow.find(params[:id])
     authorize window
     previous_user_facing_state = window.user_facing_state
-    cluster = window.associated_cluster
+    cluster = window.cluster
 
     yield window if block_given?
     window.public_send("#{event}!", current_user)

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -79,7 +79,6 @@ class MaintenanceWindowsController < ApplicationController
 
   def initial_maintenance_window_params
     {
-      associated_model: @scope,
       case_id: params[:case_id],
       requested_start: default_requested_start,
       duration: 1,

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -122,8 +122,11 @@ class MaintenanceWindowsController < ApplicationController
     yield
 
     flash[:success] = "Maintenance #{past_tense_of(action)}."
-    cluster = @maintenance_window.cluster
-    redirect_to cluster_maintenance_windows_path(cluster)
+    if action == :confirm
+      redirect_to cluster_maintenance_windows_path(@maintenance_window.cluster)
+    else
+      redirect_to case_path(@maintenance_window.case)
+    end
   rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition => e
     flash.now[:error] = "Unable to #{action} this maintenance. #{e}"
     render template

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -2,8 +2,11 @@ class MaintenanceWindowsController < ApplicationController
   decorates_assigned :maintenance_window
 
   def new
+    @case = Case.find_from_id!(params[:case_id])
     @maintenance_window = MaintenanceWindow.new(
-      initial_maintenance_window_params
+      initial_maintenance_window_params.merge(
+        maintenance_window_case_params(@case)
+      )
     )
     authorize @maintenance_window
   end
@@ -11,9 +14,14 @@ class MaintenanceWindowsController < ApplicationController
   def create
     event = mandatory? ? :mandate : :request
     action = mandatory? ? :schedule : :request
+    @case = Case.find_from_id!(params[:case_id])
 
     handle_form_submission(action: action, template: :new) do
-      @maintenance_window = MaintenanceWindow.new(request_maintenance_window_params)
+      @maintenance_window = MaintenanceWindow.new(
+        request_maintenance_window_params.merge(
+          maintenance_window_case_params(@case)
+        )
+      )
       authorize @maintenance_window
       ActiveRecord::Base.transaction do
         @maintenance_window.save!
@@ -65,10 +73,6 @@ class MaintenanceWindowsController < ApplicationController
   private
 
   REQUEST_PARAM_NAMES = [
-    :cluster_id,
-    :component_id,
-    :service_id,
-    :case_id,
     :requested_start,
     :duration,
   ].freeze
@@ -79,7 +83,6 @@ class MaintenanceWindowsController < ApplicationController
 
   def initial_maintenance_window_params
     {
-      case_id: params[:case_id],
       requested_start: default_requested_start,
       duration: 1,
     }
@@ -91,6 +94,19 @@ class MaintenanceWindowsController < ApplicationController
 
   def confirm_maintenance_window_params
     params.require(:maintenance_window).permit(CONFIRM_PARAM_NAMES)
+  end
+
+  def maintenance_window_case_params(kase)
+    # We want to inherit the _current_ associated cluster parts from @case
+    # (e.g. if the case gets changed later, we want the MW to remain
+    # the same as when it was created)
+    {
+      case: kase,
+      clusters: kase.clusters,
+      services: kase.services,
+      component_groups: kase.component_groups,
+      components: kase.components
+    }
   end
 
   def default_requested_start
@@ -108,8 +124,8 @@ class MaintenanceWindowsController < ApplicationController
     flash[:success] = "Maintenance #{past_tense_of(action)}."
     cluster = @maintenance_window.associated_cluster
     redirect_to cluster_maintenance_windows_path(cluster)
-  rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition
-    flash.now[:error] = "Unable to #{action} this maintenance."
+  rescue ActiveRecord::RecordInvalid, StateMachines::InvalidTransition => e
+    flash.now[:error] = "Unable to #{action} this maintenance. #{e}"
     render template
   end
 

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -6,17 +6,6 @@ class ApplicationDecorator < Draper::Decorator
   #     h.number_to_percentage object.amount, precision: 2
   #   end
 
-  def start_maintenance_request_link
-    return unless policy(MaintenanceWindow).create?
-
-    title = "Start request for maintenance of this #{readable_model_name}"
-    h.link_to(
-      h.raw(h.icon 'wrench', interactive: true),
-      new_maintenance_window_path,
-      title: title
-    )
-  end
-
   # Strictly speaking this gives the icons for a ClusterPart or entire Cluster,
   # but I don't have a better name for that yet.
   def cluster_part_icons

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -29,7 +29,7 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def request_maintenance_path
-    h.new_cluster_maintenance_window_path model.cluster, case_id: model.id
+    h.new_cluster_case_maintenance_path(model.cluster, model)
   end
 
   def tier_description

--- a/app/decorators/collated_case_association_audit_decorator.rb
+++ b/app/decorators/collated_case_association_audit_decorator.rb
@@ -1,7 +1,7 @@
 class CollatedCaseAssociationAuditDecorator < ApplicationDecorator
   def event_card
     h.render 'cases/event',
-             name: object.user.name,
+             name: object.user&.name || 'Flight Center',
              date: object.created_at,
              text: card_text,
              formatted: false,

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -21,10 +21,10 @@ class MaintenanceWindowDecorator < ApplicationDecorator
   end
 
   def confirm_path
-    associated_model_name = associated_model.underscored_model_name
-    path_method = "confirm_#{associated_model_name}_maintenance_window_path"
-    associated_model_id_param = associated_model_name.foreign_key.to_sym
-    h.send(path_method, self, associated_model_id_param => associated_model.id)
+    h.confirm_cluster_maintenance_window_path(
+       model.associated_cluster.id,
+       model
+    )
   end
 
   def case_attributes(form_action)
@@ -44,6 +44,10 @@ class MaintenanceWindowDecorator < ApplicationDecorator
     }.merge(
       conditional_attributes(action: form_action, field: 'duration')
     )
+  end
+
+  def associated_model_names
+    associated_models.map { |m| "#{m.name} (#{m.readable_model_name})"}.join(', ')
   end
 
   private

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -66,7 +66,7 @@ class MaintenanceWindowDecorator < ApplicationDecorator
       TITLE
       "<strong title=\"#{title}\">(expired)</strong>"
     else
-      ''
+      "(#{state})"
     end
   end
 

--- a/app/decorators/maintenance_window_decorator.rb
+++ b/app/decorators/maintenance_window_decorator.rb
@@ -21,8 +21,7 @@ class MaintenanceWindowDecorator < ApplicationDecorator
   end
 
   def confirm_path
-    h.confirm_cluster_maintenance_window_path(
-       model.associated_cluster.id,
+    h.confirm_maintenance_window_path(
        model
     )
   end
@@ -48,6 +47,10 @@ class MaintenanceWindowDecorator < ApplicationDecorator
 
   def associated_model_names
     associated_models.map { |m| "#{m.name} (#{m.readable_model_name})"}.join(', ')
+  end
+
+  def associated_model_links
+    associated_models.map { |m| m.decorate.links }.join(', ').html_safe
   end
 
   private

--- a/app/decorators/maintenance_window_state_transition_decorator.rb
+++ b/app/decorators/maintenance_window_state_transition_decorator.rb
@@ -15,15 +15,15 @@ class MaintenanceWindowStateTransitionDecorator < ApplicationDecorator
   end
 
   def associated_model_links
-    window.associated_models.map { |m| m.decorate.links }.join(', ')
+    window.associated_model_links
   end
 
   def associated_model_names
-    window.associated_models.map { |m| "#{m.name} (#{m.readable_model_name})"}.join(', ')
+    window.associated_model_names
   end
 
   def window
-    object.maintenance_window
+    object.maintenance_window.decorate
   end
 
   def cluster_dashboard_url

--- a/app/decorators/maintenance_window_state_transition_decorator.rb
+++ b/app/decorators/maintenance_window_state_transition_decorator.rb
@@ -27,7 +27,7 @@ class MaintenanceWindowStateTransitionDecorator < ApplicationDecorator
   end
 
   def cluster_dashboard_url
-    h.cluster_maintenance_windows_url(window.associated_cluster)
+    h.cluster_maintenance_windows_url(window.cluster)
   end
 
   def requested_start

--- a/app/decorators/maintenance_window_state_transition_decorator.rb
+++ b/app/decorators/maintenance_window_state_transition_decorator.rb
@@ -14,8 +14,12 @@ class MaintenanceWindowStateTransitionDecorator < ApplicationDecorator
     h.render(comment_template, transition: self).squish
   end
 
-  def associated_model
-    window.associated_model
+  def associated_model_links
+    window.associated_models.map { |m| m.decorate.links }.join(', ')
+  end
+
+  def associated_model_names
+    window.associated_models.map { |m| "#{m.name} (#{m.readable_model_name})"}.join(', ')
   end
 
   def window

--- a/app/helpers/tabs_builder.rb
+++ b/app/helpers/tabs_builder.rb
@@ -32,15 +32,6 @@ class TabsBuilder
     {
       id: :maintenance,
       path: scope.scope_maintenance_windows_path,
-      admin_dropdown: [
-        {
-          text: 'Pending',
-          path: scope.scope_maintenance_windows_path
-        }, {
-          text: 'Request',
-          path: scope.new_scope_maintenance_window_path
-        }
-      ]
     }
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -245,7 +245,19 @@ class Case < ApplicationRecord
 
   def resolvable?
     state_transitions.map(&:to_name).include?(:resolved) &&
-      !cr_in_progress?
+      !unresolvable_reason
+  end
+
+  def unresolvable_reason
+    if cr_in_progress?
+      'This case cannot be resolved as the change request is incomplete.'
+    else
+      unfinished_mws = maintenance_windows.unfinished.count
+      if unfinished_mws.positive?
+        "This case cannot be resolved as there #{unfinished_mws == 1 ? 'is an' : 'are'}
+         outstanding maintenance window#{unfinished_mws == 1 ? '': 's'}.".squish
+      end
+    end
   end
 
   def potential_assignees

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -21,7 +21,10 @@ class Cluster < ApplicationRecord
     dependent: :destroy
   has_many :services, dependent: :destroy
   has_many :cases
-  has_many :maintenance_windows
+
+  has_many :maintenance_window_associations, as: :associated_element
+  has_many :maintenance_windows, through: :maintenance_window_associations
+
   has_many :logs, dependent: :destroy
   has_many :notes, dependent: :destroy
   has_many :credit_deposits

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -65,7 +65,7 @@ class Cluster < ApplicationRecord
   end
 
   def unfinished_related_maintenance_windows
-    parts = [self, *components, *services]
+    parts = [self, *components, *component_groups, *services]
     parts
       .map(&:maintenance_windows)
       .flat_map(&:unfinished)

--- a/app/models/collated_case_association_audit.rb
+++ b/app/models/collated_case_association_audit.rb
@@ -4,7 +4,7 @@ class CollatedCaseAssociationAudit
   attr_accessor :created_at
 
   def initialize(user_id, created_at, audits)
-    @user = User.find(user_id)
+    @user = User.where(id: user_id).first
     @created_at = created_at
     @audits = audits
   end

--- a/app/models/component_group.rb
+++ b/app/models/component_group.rb
@@ -10,6 +10,8 @@ class ComponentGroup < ApplicationRecord
   has_one :component_type, through: :component_make
   has_many :components, dependent: :destroy
   has_many :asset_record_fields
+  has_many :maintenance_window_associations, as: :associated_element
+  has_many :maintenance_windows, through: :maintenance_window_associations
 
   validates :name, presence: true
 

--- a/app/models/concerns/cluster_part.rb
+++ b/app/models/concerns/cluster_part.rb
@@ -14,8 +14,8 @@ module ClusterPart
   included do
     has_many :case_associations, as: :associated_element
     has_many :cases, through: :case_associations
-
-    has_many :maintenance_windows
+    has_many :maintenance_window_associations, as: :associated_element
+    has_many :maintenance_windows, through: :maintenance_window_associations
 
     validates :name, presence: true
     validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true

--- a/app/models/maintenance_notifier.rb
+++ b/app/models/maintenance_notifier.rb
@@ -8,13 +8,16 @@ MaintenanceNotifier = Struct.new(:window) do
 
   private
 
-  delegate :associated_model, to: :window
+  def associated_model_names
+    window.decorate.associated_model_names
+  end
+
   delegate :cluster_maintenance_windows_url,
     to: 'Rails.application.routes.url_helpers'
 
   def request_comment
     <<-EOF
-      Maintenance requested for #{associated_model.name} from
+      Maintenance requested for #{associated_model_names} from
       #{requested_start} until #{expected_end} by #{window.requested_by.name};
       to proceed this maintenance must be confirmed on the cluster dashboard:
       #{cluster_dashboard_url}.
@@ -23,7 +26,7 @@ MaintenanceNotifier = Struct.new(:window) do
 
   def confirm_comment
     <<~EOF
-      Request for maintenance of #{associated_model.name} confirmed by
+      Request for maintenance of #{associated_model_names} confirmed by
       #{window.confirmed_by.name}; this maintenance has been scheduled from
       #{requested_start} until #{expected_end}.
     EOF
@@ -31,7 +34,7 @@ MaintenanceNotifier = Struct.new(:window) do
 
   def mandate_comment
     <<~EOF
-      Maintenance for #{associated_model.name} has been scheduled from
+      Maintenance for #{associated_model_names} has been scheduled from
       #{requested_start} until #{expected_end} by #{window.confirmed_by.name};
       this maintenance is mandatory.
     EOF
@@ -39,14 +42,14 @@ MaintenanceNotifier = Struct.new(:window) do
 
   def cancel_comment
     <<~EOF
-      Request for maintenance of #{associated_model.name} cancelled by
+      Request for maintenance of #{associated_model_names} cancelled by
       #{window.cancelled_by.name}.
     EOF
   end
 
   def reject_comment
     <<~EOF
-      Request for maintenance of #{associated_model.name} rejected by
+      Request for maintenance of #{associated_model_names} rejected by
       #{window.rejected_by.name}.
     EOF
   end
@@ -54,19 +57,18 @@ MaintenanceNotifier = Struct.new(:window) do
   def extend_duration_comment
     <<~EOF
       #{window.user_facing_state.capitalize} maintenance of
-      #{associated_model.name} has been extended, this
-      #{associated_model.readable_model_name} will now be under maintenance
-      from #{requested_start} until #{expected_end}.
+      #{associated_model_names} has been extended, they will now be under 
+      maintenance from #{requested_start} until #{expected_end}.
     EOF
   end
 
   def end_comment
-    "Maintenance of #{associated_model.name} ended by #{window.ended_by.name}."
+    "Maintenance of #{associated_model_names} ended by #{window.ended_by.name}."
   end
 
   def auto_expire_comment
     <<~EOF
-      Request for maintenance of #{associated_model.name} was not confirmed
+      Request for maintenance of #{associated_model_names} was not confirmed
       before requested start date of #{requested_start}; this maintenance can
       no longer occur as requested and must be rescheduled and confirmed on the
       cluster dashboard: #{cluster_dashboard_url}.
@@ -75,15 +77,15 @@ MaintenanceNotifier = Struct.new(:window) do
 
   def auto_start_comment
     <<~EOF
-      Scheduled maintenance of #{associated_model.name} has automatically
-      started; this #{associated_model.readable_model_name} is now under
+      Scheduled maintenance of #{associated_model_names} has automatically
+      started; they are now under
       maintenance until #{expected_end}.
     EOF
   end
 
   def auto_end_comment
     <<~EOF
-      Scheduled maintenance of #{associated_model.name} has automatically
+      Scheduled maintenance of #{associated_model_names} has automatically
       ended.
     EOF
   end

--- a/app/models/maintenance_notifier.rb
+++ b/app/models/maintenance_notifier.rb
@@ -95,7 +95,7 @@ MaintenanceNotifier = Struct.new(:window) do
   end
 
   def cluster_dashboard_url
-    cluster_maintenance_windows_url(window.associated_cluster)
+    cluster_maintenance_windows_url(window.cluster)
   end
 
   def requested_start

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -89,7 +89,7 @@ class MaintenanceWindow < ApplicationRecord
   end
 
   def associated_models
-    components + services + clusters
+    clusters + services + component_groups + components
   end
 
   def associated_cluster

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -4,9 +4,6 @@ class MaintenanceWindow < ApplicationRecord
 
   default_scope { order(created_at: :desc) }
   belongs_to :case
-  belongs_to :cluster, required: false
-  belongs_to :component, required: false
-  belongs_to :service, required: false
 
   has_many :maintenance_window_associations, dependent: :destroy
   has_many :services,

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -8,6 +8,31 @@ class MaintenanceWindow < ApplicationRecord
   belongs_to :component, required: false
   belongs_to :service, required: false
 
+  has_many :case_associations, dependent: :destroy
+  has_many :services,
+           dependent: :destroy,
+           through: :case_associations,
+           source: :associated_element,
+           source_type: 'Service'
+
+  has_many :components,
+           dependent: :destroy,
+           through: :case_associations,
+           source: :associated_element,
+           source_type: 'Component'
+
+  has_many :component_groups,
+           dependent: :destroy,
+           through: :case_associations,
+           source: :associated_element,
+           source_type: 'ComponentGroup'
+
+  has_many :clusters,
+           dependent: :destroy,
+           through: :case_associations,
+           source: :associated_element,
+           source_type: 'Cluster'
+
   has_many :maintenance_window_state_transitions
   alias_attribute :transitions, :maintenance_window_state_transitions
 

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -4,6 +4,7 @@ class MaintenanceWindow < ApplicationRecord
 
   default_scope { order(created_at: :desc) }
   belongs_to :case
+  delegate :site, to: :case
 
   has_many :maintenance_window_associations, dependent: :destroy
   has_many :services,
@@ -29,6 +30,8 @@ class MaintenanceWindow < ApplicationRecord
            through: :maintenance_window_associations,
            source: :associated_element,
            source_type: 'Cluster'
+
+  delegate :cluster, to: :case
 
   has_many :maintenance_window_state_transitions
   alias_attribute :transitions, :maintenance_window_state_transitions
@@ -92,10 +95,6 @@ class MaintenanceWindow < ApplicationRecord
     clusters + services + component_groups + components
   end
 
-  def associated_cluster
-    clusters.first || associated_models.first.cluster
-  end
-
   def expected_end
     duration.business_days.after(requested_start)
   end
@@ -131,8 +130,6 @@ class MaintenanceWindow < ApplicationRecord
   end
 
   private
-
-  delegate :site, to: :case
 
   def add_transition_comment(event)
     unless invalid? || legacy_migration_mode

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -8,28 +8,28 @@ class MaintenanceWindow < ApplicationRecord
   belongs_to :component, required: false
   belongs_to :service, required: false
 
-  has_many :case_associations, dependent: :destroy
+  has_many :maintenance_window_associations, dependent: :destroy
   has_many :services,
            dependent: :destroy,
-           through: :case_associations,
+           through: :maintenance_window_associations,
            source: :associated_element,
            source_type: 'Service'
 
   has_many :components,
            dependent: :destroy,
-           through: :case_associations,
+           through: :maintenance_window_associations,
            source: :associated_element,
            source_type: 'Component'
 
   has_many :component_groups,
            dependent: :destroy,
-           through: :case_associations,
+           through: :maintenance_window_associations,
            source: :associated_element,
            source_type: 'ComponentGroup'
 
   has_many :clusters,
            dependent: :destroy,
-           through: :case_associations,
+           through: :maintenance_window_associations,
            source: :associated_element,
            source_type: 'Cluster'
 

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -88,23 +88,12 @@ class MaintenanceWindow < ApplicationRecord
     end
   end
 
-  def associated_model
-    component || service || cluster
-  end
-
-  def associated_model=(model)
-    case model
-    when Cluster
-      self.cluster = model
-    when Component
-      self.component = model
-    when Service
-      self.service = model
-    end
+  def associated_models
+    components + services + clusters
   end
 
   def associated_cluster
-    cluster || associated_model.cluster
+    clusters.first || associated_models.first.cluster
   end
 
   def expected_end

--- a/app/models/maintenance_window/validator.rb
+++ b/app/models/maintenance_window/validator.rb
@@ -4,7 +4,7 @@ class MaintenanceWindow < ApplicationRecord
     def validate(record)
       @record = record
 
-      validate_precisely_one_associated_model
+      validate_at_least_one_associated_model
       validate_requested_period
     end
 
@@ -13,18 +13,22 @@ class MaintenanceWindow < ApplicationRecord
     attr_reader :record
     delegate :requested_start, to: :record
 
-    def validate_precisely_one_associated_model
-      record.errors.add(
-        :base, 'precisely one Cluster, Component, or Service can be under maintenance'
-      ) unless number_associated_models == 1
+    def validate_at_least_one_associated_model
+      unless number_associated_models >= 1
+        record.errors.add(
+          :base, 'at least one Cluster, Component, or Service must be under maintenance'
+        )
+      end
     end
 
     def number_associated_models
-      [
-        record.cluster,
-        record.component,
-        record.service
-      ].select(&:present?).length
+      (
+        record.clusters +
+        record.components +
+        record.services
+      ).tap {
+        |a| p a
+      }.length
     end
 
     def validate_requested_period

--- a/app/models/maintenance_window_association.rb
+++ b/app/models/maintenance_window_association.rb
@@ -1,0 +1,12 @@
+class MaintenanceWindowAssociation < ApplicationRecord
+  belongs_to :maintenance_window
+  belongs_to :associated_element,
+             polymorphic: true
+
+  delegate :site, to: :maintenance_window
+
+  validates :associated_element_id,
+            uniqueness: {
+              scope: [:associated_element_type, :maintenance_window_id],
+            }
+end

--- a/app/services/progress_maintenance_window.rb
+++ b/app/services/progress_maintenance_window.rb
@@ -52,7 +52,7 @@ ProgressMaintenanceWindow = Struct.new(:window) do
   end
 
   def window_details
-    "#{window.associated_model.name} | #{start_date} - #{end_date}"
+    "#{window.decorate.associated_model_names} | #{start_date} - #{end_date}"
   end
 
   def start_date
@@ -89,7 +89,7 @@ ProgressMaintenanceWindow = Struct.new(:window) do
     CaseMailer.maintenance_ending_soon(
       window,
       <<-EOF.squish
-        Maintenance for #{window.associated_model.name} is scheduled to
+        Maintenance for #{window.decorate.associated_model_names} is scheduled to
         end at #{window.expected_end.to_formatted_s(:short)}. You have
         less than an hour to make any final changes.
       EOF

--- a/app/views/cases/_case_maintenance_details.html.erb
+++ b/app/views/cases/_case_maintenance_details.html.erb
@@ -1,7 +1,7 @@
 <ul>
   <% kase.maintenance_windows.unfinished.map(&:decorate).each do |mw| %>
     <li>
-      <%= mw.scheduled_period %> (<%= mw.state %>)
+      <%= mw.scheduled_period %>
       <% contents = render 'cases/associations/group_contents', items: mw.associated_models do %>
         <p>This maintenance window affects the following components:</p>
       <% end %>

--- a/app/views/cases/_case_maintenance_details.html.erb
+++ b/app/views/cases/_case_maintenance_details.html.erb
@@ -1,0 +1,23 @@
+<ul>
+  <% kase.maintenance_windows.unfinished.map(&:decorate).each do |mw| %>
+    <li>
+      <%= mw.scheduled_period %> (<%= mw.state %>)
+      <% contents = render 'cases/associations/group_contents', items: mw.associated_models do %>
+        <p>This maintenance window affects the following components:</p>
+      <% end %>
+      <i
+        class="fa fa-sitemap"
+        data-html="true"
+        data-content="<%= contents.squish %>"
+        data-toggle="popover"
+        data-trigger="hover"
+        data-delay='{"hide": 1500}'
+      ></i>
+    </li>
+  <% end %>
+</ul>
+<%= link_to 'Manage on cluster dashboard',
+            cluster_maintenance_windows_path(kase.cluster),
+            class: 'btn btn-primary ml-2 btn-sm',
+            role: 'button'
+%>

--- a/app/views/cases/_case_state_controls.html.erb
+++ b/app/views/cases/_case_state_controls.html.erb
@@ -11,8 +11,8 @@
                     confirm: 'Are you sure you want to resolve this support case?'
                 }
     %>
-  <% elsif @case.open? && @case.cr_in_progress? %>
-    <p class="small">This case cannot be resolved as the change request is incomplete.</p>
+  <% elsif @case.open? %>
+    <p class="small" id="unresolvable-reason"><%= @case.unresolvable_reason %></p>
   <% end %>
 <% end %>
 

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -80,6 +80,14 @@
           <%= render 'cases/escalation_controls' %>
         </td>
       </tr>
+      <% unless @case.maintenance_windows.unfinished.empty? %>
+        <tr>
+          <th>Pending maintenance</th>
+          <td colspan="3" id="maintenance-details">
+            <%= render 'cases/case_maintenance_details', kase: @case %>
+          </td>
+        </tr>
+      <% end %>
       <%= render 'cases/fields_or_requests_row', kase: @case %>
       <%= render 'cases/time_worked_row' %>
       <tr>

--- a/app/views/components/index.html.erb
+++ b/app/views/components/index.html.erb
@@ -13,7 +13,6 @@
               <th>Name</th>
               <th>Support type</th>
               <th></th>
-              <th></th>
             </tr>
           </thead>
 
@@ -26,9 +25,6 @@
                 </td>
                 <td width='30%'>
                   <%= component.readable_support_type.capitalize %>
-                </td>
-                <td width='10%'>
-                  <%= component.start_maintenance_request_link %>
                 </td>
                 <td width='20%'>
                   <%= component.change_support_type_button %>

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -3,50 +3,23 @@
   raise "Unknown action: #{action}" unless [:request, :confirm].include?(action)
   action = action.to_s.inquiry
 
-  case_label = if action.confirm?
-                 'Associated Case'
-               else
-                 'Case to associate this maintenance with'
-               end
 %>
 
 <%= render 'partials/tabs', activate: :maintenance do %>
   <%= form_for maintenance_window,
-    url: request.original_fullpath,
+    url: path,
     html: { class: 'card-body' } do |f| %>
 
-    <% if action.request? %>
-
       <h4>
-        Requesting maintenance for <%= maintenance_window.associated_model.decorate.links %>
-        <% if maintenance_window.associated_model.is_a? Cluster %>
-        (whole cluster)
-        <% end %>
+        <%= action.request? ? 'Requesting m' : 'M' %>aintenance for support case <%= maintenance_window.case.case_link %>
       </h4>
 
-      <% if maintenance_window.associated_model.is_a? Cluster %>
-        <p class="p-3 alert alert-warning">
-          <i class="fa fa-warning"></i>
-          Not what you want? Try selecting a
-          <%= link_to 'component', cluster_components_path, class: 'alert-link' %>
-          or a
-          <%= link_to 'service', cluster_services_path, class: 'alert-link' %>
-          from this cluster.
-        </p>
-      <% end %>
+    <div class="card">
+      <div class="card-body">
+        <h5>Affected components</h5>
 
-    <% end %>
-
-    <div class="form-group">
-      <%= f.label :case_id, case_label, 'data-test': 'case-select-label' %>
-      <%= f.collection_select(
-        :case_id,
-        maintenance_window.associated_cluster.cases.active.decorate,
-        :id,
-        :case_select_details,
-        {},
-        maintenance_window.case_attributes(action)
-      ) %>
+        <%= render 'cases/associations/association_info', kase: maintenance_window.case %>
+      </div>
     </div>
 
     <div class="form-group" data-test="duration-input-group">

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -27,12 +27,12 @@
       <% if action.request? %>
         <div class="col-6">
           <% if maintenance_window.case.clusters.length > 0 %>
-            <p class="p-3 alert alert-warning">
+            <p class="p-3 alert alert-warning mt-3">
               <i class="fa fa-2x fa-pull-left fa-warning" aria-hidden="true"></i>
               You are requesting maintenance on an entire cluster.
             </p>
           <% end %>
-          <p class="p-3 alert alert-info">
+          <p class="p-3 alert alert-info mt-3">
             <i class="fa fa-2x fa-info fa-pull-left" aria-hidden="true"></i>
             To change the components affected by this maintenance request,
             <%=

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -14,9 +14,6 @@
   <%= form_for maintenance_window,
     url: request.original_fullpath,
     html: { class: 'card-body' } do |f| %>
-    <%= f.hidden_field :cluster_id %>
-    <%= f.hidden_field :component_id %>
-    <%= f.hidden_field :service_id %>
 
     <% if action.request? %>
 

--- a/app/views/maintenance_windows/_form.html.erb
+++ b/app/views/maintenance_windows/_form.html.erb
@@ -14,12 +14,35 @@
         <%= action.request? ? 'Requesting m' : 'M' %>aintenance for support case <%= maintenance_window.case.case_link %>
       </h4>
 
-    <div class="card">
-      <div class="card-body">
-        <h5>Affected components</h5>
+    <div class="row">
+      <div class="col-6">
+        <div class="card">
+          <div class="card-body">
+            <h5>Affected components</h5>
 
-        <%= render 'cases/associations/association_info', kase: maintenance_window.case %>
+            <%= render 'cases/associations/association_info', kase: maintenance_window.case %>
+          </div>
+        </div>
       </div>
+      <% if action.request? %>
+        <div class="col-6">
+          <% if maintenance_window.case.clusters.length > 0 %>
+            <p class="p-3 alert alert-warning">
+              <i class="fa fa-2x fa-pull-left fa-warning" aria-hidden="true"></i>
+              You are requesting maintenance on an entire cluster.
+            </p>
+          <% end %>
+          <p class="p-3 alert alert-info">
+            <i class="fa fa-2x fa-info fa-pull-left" aria-hidden="true"></i>
+            To change the components affected by this maintenance request,
+            <%=
+              link_to "return to case #{maintenance_window.case.display_id}",
+                      case_path(maintenance_window.case)
+            %> and set the appropriate associations, then
+            start the maintenance request again.
+          </p>
+        </div>
+      <% end %>
     </div>
 
     <div class="form-group" data-test="duration-input-group">

--- a/app/views/maintenance_windows/confirm.html.erb
+++ b/app/views/maintenance_windows/confirm.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:subtitle) { 'Confirm Maintenance' } %>
 <%= render 'maintenance_windows/form',
   maintenance_window: maintenance_window,
-  action: :confirm
+  action: :confirm,
+  path: confirm_maintenance_window_path(maintenance_window)
 %>

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -16,7 +16,7 @@
     <tbody>
     <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
       <tr>
-        <td><%= window.associated_model.links %></td>
+        <td><%= window.associated_model_links %></td>
         <td><%= window.scheduled_period %></td>
         <td><%= window.transition_info(:requested) ||
           raw('<em>N/A &mdash; mandatory maintenance</em>')

--- a/app/views/maintenance_windows/index.html.erb
+++ b/app/views/maintenance_windows/index.html.erb
@@ -16,7 +16,9 @@
     <tbody>
     <% @scope.unfinished_related_maintenance_windows.map(&:decorate).each do |window| %>
       <tr>
-        <td><%= window.associated_model_links %></td>
+        <td>
+          <%= render 'partials/association_summary', associations: window.associated_models %>
+        </td>
         <td><%= window.scheduled_period %></td>
         <td><%= window.transition_info(:requested) ||
           raw('<em>N/A &mdash; mandatory maintenance</em>')

--- a/app/views/maintenance_windows/new.html.erb
+++ b/app/views/maintenance_windows/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:subtitle) { 'Request Maintenance' } %>
 <%= render 'maintenance_windows/form',
   maintenance_window: maintenance_window,
-  action: :request
+  action: :request,
+  path: cluster_case_maintenance_path(@case.cluster, @case)
 %>

--- a/app/views/maintenance_windows/transitions/_auto_end.html.erb
+++ b/app/views/maintenance_windows/transitions/_auto_end.html.erb
@@ -1,2 +1,2 @@
-Scheduled maintenance of <%= transition.associated_model.name %> has automatically
+Scheduled maintenance of <%= transition.associated_model_links %> has automatically
 ended.

--- a/app/views/maintenance_windows/transitions/_auto_expire.html.erb
+++ b/app/views/maintenance_windows/transitions/_auto_expire.html.erb
@@ -1,4 +1,4 @@
-Request for maintenance of <%= transition.associated_model.name %> was not confirmed
+Request for maintenance of <%= transition.associated_model_links %> was not confirmed
 before requested start date of <%= transition.requested_start %>; this maintenance can
 no longer occur as requested and must be rescheduled and confirmed on
 <%= link_to 'the cluster dashboard', transition.cluster_dashboard_url %>.

--- a/app/views/maintenance_windows/transitions/_auto_start.html.erb
+++ b/app/views/maintenance_windows/transitions/_auto_start.html.erb
@@ -1,3 +1,2 @@
-Scheduled maintenance of <%= transition.associated_model.name %> has automatically
-started; this <%= transition.associated_model.readable_model_name %> is now under
-maintenance until <%= transition.expected_end %>.
+Scheduled maintenance of <%= transition.associated_model_links %> has automatically
+started; these are now under maintenance until <%= transition.expected_end %>.

--- a/app/views/maintenance_windows/transitions/_cancel.html.erb
+++ b/app/views/maintenance_windows/transitions/_cancel.html.erb
@@ -1,2 +1,2 @@
-Request for maintenance of <%= transition.associated_model.name %> cancelled by
+Request for maintenance of <%= transition.associated_model_links %> cancelled by
 <%= transition.window.cancelled_by.name %>.

--- a/app/views/maintenance_windows/transitions/_confirm.html.erb
+++ b/app/views/maintenance_windows/transitions/_confirm.html.erb
@@ -1,3 +1,3 @@
-Request for maintenance of <%= transition.associated_model.name %> confirmed by
+Request for maintenance of <%= transition.associated_model_links %> confirmed by
 <%= transition.window.confirmed_by.name %>; this maintenance has been scheduled from
 <%= transition.requested_start %> until <%= transition.expected_end %>.

--- a/app/views/maintenance_windows/transitions/_end.html.erb
+++ b/app/views/maintenance_windows/transitions/_end.html.erb
@@ -1,1 +1,1 @@
-Maintenance of <%= transition.associated_model.name %> ended by <%= transition.window.ended_by.name %>.
+Maintenance of <%= transition.associated_model_links %> ended by <%= transition.window.ended_by.name %>.

--- a/app/views/maintenance_windows/transitions/_extend_duration.html.erb
+++ b/app/views/maintenance_windows/transitions/_extend_duration.html.erb
@@ -1,4 +1,3 @@
 <%= transition.window.user_facing_state.capitalize %> maintenance of
-<%= transition.associated_model.name %> has been extended. This
-<%= transition.associated_model.readable_model_name %> will now be under maintenance
+<%= transition.associated_model_links %> has been extended. These will now be under maintenance
 from <%= transition.requested_start %> until <%= transition.expected_end %>.

--- a/app/views/maintenance_windows/transitions/_mandate.html.erb
+++ b/app/views/maintenance_windows/transitions/_mandate.html.erb
@@ -1,3 +1,3 @@
-Maintenance for <%= transition.associated_model.name %> has been scheduled from
+Maintenance for <%= transition.associated_model_links %> has been scheduled from
 <%= transition.requested_start %> until <%= transition.expected_end %> by <%= transition.window.confirmed_by.name %>;
 this maintenance is mandatory.

--- a/app/views/maintenance_windows/transitions/_reject.html.erb
+++ b/app/views/maintenance_windows/transitions/_reject.html.erb
@@ -1,2 +1,2 @@
-Request for maintenance of <%= transition.associated_model.name %> rejected by
+Request for maintenance of <%= transition.associated_model_links %> rejected by
 <%= transition.window.rejected_by.name %>.

--- a/app/views/maintenance_windows/transitions/_request.html.erb
+++ b/app/views/maintenance_windows/transitions/_request.html.erb
@@ -1,4 +1,4 @@
-Maintenance requested for <%= transition.associated_model.name %> from
+Maintenance requested for <%= transition.associated_model_links %> from
 <%= transition.requested_start %> until <%= transition.expected_end %> by <%= transition.window.requested_by.name %>;
 to proceed this maintenance must be confirmed on
 <%= link_to 'the cluster dashboard', transition.cluster_dashboard_url %>.

--- a/app/views/partials/_association_summary.html.erb
+++ b/app/views/partials/_association_summary.html.erb
@@ -1,0 +1,14 @@
+<%= associations.first.decorate.links %>
+<% if associations.length > 1 %>
+  <% contents = render 'cases/associations/group_contents', items: associations do %>
+    <p>Affected components:</p>
+  <% end %>
+  <span
+    class="and-more"
+    data-html="true"
+    data-content="<%= contents.squish %>"
+    data-toggle="popover"
+    data-trigger="hover"
+    data-delay='{"hide": 1500}'
+  >+ <%= associations.length - 1 %> more</span>
+<% end %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -20,20 +20,7 @@
     %></td>
   <td>
     <%= render 'partials/table_cell_link', url: url do %>
-      <%= kase.associations.first.decorate.links %>
-      <% if kase.associations.length > 1 %>
-        <% contents = render 'cases/associations/group_contents', items: kase.associations do %>
-          <p>Affected components:</p>
-        <% end %>
-        <span
-          class="and-more"
-          data-html="true"
-          data-content="<%= contents.squish %>"
-          data-toggle="popover"
-          data-trigger="hover"
-          data-delay='{"hide": 1500}'
-        >+ <%= kase.associations.length - 1 %> more</span>
-      <% end %>
+      <%= render 'partials/association_summary', associations: kase.associations %>
     <% end %>
   </td>
   <% if kase.resolved? || kase.closed? %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -17,9 +17,6 @@
             <%= service.cluster_part_icons %>
           </td>
           <td width='30%'><%= service.readable_support_type.capitalize %></td>
-          <td width='10%'>
-            <%= service.start_maintenance_request_link %>
-          </td>
           <td width='20%'>
             <%= service.change_support_type_button %>
           </td>

--- a/db/data/20180710175002_migrate_legacy_mw_associations.rb
+++ b/db/data/20180710175002_migrate_legacy_mw_associations.rb
@@ -1,0 +1,37 @@
+class MigrateLegacyMwAssociations < ActiveRecord::Migration[5.2]
+
+  class MaintenanceWindow < ApplicationRecord
+    # Minimal set of relationships required for this migration to function.
+    belongs_to :service, required: false
+    belongs_to :component, required: false
+    belongs_to :cluster, required: false
+
+    has_many :maintenance_window_associations
+    has_many :services,
+             through: :maintenance_window_associations,
+             source: :associated_element,
+             source_type: 'Service'
+
+    has_many :components,
+             through: :maintenance_window_associations,
+             source: :associated_element,
+             source_type: 'Component'
+
+    has_many :clusters,
+             through: :maintenance_window_associations,
+             source: :associated_element,
+             source_type: 'Cluster'
+  end
+
+  def up
+    MaintenanceWindow.all.each do |mw|
+      mw.services << mw.service if mw.service.present? && !mw.services.include?(mw.service)
+      mw.components << mw.component if mw.component.present? && !mw.components.include?(mw.component)
+      mw.clusters << mw.cluster if mw.cluster.present? && !mw.clusters.include?(mw.cluster)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180629112014)
+DataMigrate::Data.define(version: 20180710175002)

--- a/db/migrate/20180710144340_support_multiple_associations_to_maintenance_windows.rb
+++ b/db/migrate/20180710144340_support_multiple_associations_to_maintenance_windows.rb
@@ -1,0 +1,18 @@
+class SupportMultipleAssociationsToMaintenanceWindows < ActiveRecord::Migration[5.2]
+  def change
+    create_table :maintenance_window_associations do |t|
+      t.references :maintenance_window,
+                   index: true,
+                   null: false,
+                   foreign_key: true
+      t.references :associated_element,
+                   polymorphic: true,
+                   index: { name: 'index_mw_associations_by_assoc_element'},
+                   null: false
+    end
+
+    add_index :maintenance_window_associations, [:maintenance_window_id, :associated_element_id, :associated_element_type],
+              name: 'index_mw_associations_uniqueness',
+              unique: true
+  end
+end

--- a/db/migrate/20180710181058_remove_legacy_mw_associations.rb
+++ b/db/migrate/20180710181058_remove_legacy_mw_associations.rb
@@ -1,0 +1,4 @@
+class RemoveLegacyMwAssociations < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/migrate/20180710181058_remove_legacy_mw_associations.rb
+++ b/db/migrate/20180710181058_remove_legacy_mw_associations.rb
@@ -1,4 +1,11 @@
 class RemoveLegacyMwAssociations < ActiveRecord::Migration[5.2]
   def change
+    remove_index :maintenance_windows, :cluster_id
+    remove_index :maintenance_windows, :component_id
+    remove_index :maintenance_windows, :service_id
+
+    remove_column :maintenance_windows, :cluster_id, :integer
+    remove_column :maintenance_windows, :component_id, :integer
+    remove_column :maintenance_windows, :service_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_10_144340) do
+ActiveRecord::Schema.define(version: 2018_07_10_181058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -330,17 +330,11 @@ ActiveRecord::Schema.define(version: 2018_07_10_144340) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "case_id", null: false
-    t.bigint "cluster_id"
-    t.bigint "component_id"
-    t.bigint "service_id"
     t.text "state", default: "new", null: false
     t.datetime "requested_start", null: false
     t.integer "duration", null: false
     t.boolean "maintenance_ending_soon_email_sent", default: false
     t.index ["case_id"], name: "index_maintenance_windows_on_case_id"
-    t.index ["cluster_id"], name: "index_maintenance_windows_on_cluster_id"
-    t.index ["component_id"], name: "index_maintenance_windows_on_component_id"
-    t.index ["service_id"], name: "index_maintenance_windows_on_service_id"
   end
 
   create_table "notes", force: :cascade do |t|
@@ -445,9 +439,6 @@ ActiveRecord::Schema.define(version: 2018_07_10_144340) do
   add_foreign_key "maintenance_window_state_transitions", "maintenance_windows"
   add_foreign_key "maintenance_window_state_transitions", "users"
   add_foreign_key "maintenance_windows", "cases"
-  add_foreign_key "maintenance_windows", "clusters"
-  add_foreign_key "maintenance_windows", "components"
-  add_foreign_key "maintenance_windows", "services"
   add_foreign_key "notes", "clusters"
   add_foreign_key "services", "clusters"
   add_foreign_key "services", "service_types"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_02_135826) do
+ActiveRecord::Schema.define(version: 2018_07_10_144340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -303,6 +303,15 @@ ActiveRecord::Schema.define(version: 2018_07_02_135826) do
     t.index ["user_id"], name: "index_logs_on_user_id"
   end
 
+  create_table "maintenance_window_associations", force: :cascade do |t|
+    t.bigint "maintenance_window_id", null: false
+    t.string "associated_element_type", null: false
+    t.bigint "associated_element_id", null: false
+    t.index ["associated_element_type", "associated_element_id"], name: "index_mw_associations_by_assoc_element"
+    t.index ["maintenance_window_id", "associated_element_id", "associated_element_type"], name: "index_mw_associations_uniqueness", unique: true
+    t.index ["maintenance_window_id"], name: "index_maintenance_window_associations_on_maintenance_window_id"
+  end
+
   create_table "maintenance_window_state_transitions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "maintenance_window_id", null: false
@@ -432,6 +441,7 @@ ActiveRecord::Schema.define(version: 2018_07_02_135826) do
   add_foreign_key "issues", "categories"
   add_foreign_key "issues", "service_types"
   add_foreign_key "logs", "components"
+  add_foreign_key "maintenance_window_associations", "maintenance_windows"
   add_foreign_key "maintenance_window_state_transitions", "maintenance_windows"
   add_foreign_key "maintenance_window_state_transitions", "users"
   add_foreign_key "maintenance_windows", "cases"

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ApplicationDecorator do
       let(:component) { create(:component, name: 'mycomponent') }
 
       it 'includes correct icon when has requested maintenance window' do
-        window = create(:requested_maintenance_window, component: component)
+        window = create(:requested_maintenance_window, components: [component])
         display_id = window.case.display_id
 
         expect(subject).to include(
@@ -48,7 +48,7 @@ RSpec.describe ApplicationDecorator do
       end
 
       it 'includes correct icon when has confirmed maintenance window' do
-        window = create(:confirmed_maintenance_window, component: component)
+        window = create(:confirmed_maintenance_window, components: [component])
         display_id = window.case.display_id
 
         expect(subject).to include(
@@ -62,7 +62,7 @@ RSpec.describe ApplicationDecorator do
       end
 
       it 'includes correct icon when has in progress maintenance window' do
-        window = create(:maintenance_window, state: :started, component: component)
+        window = create(:maintenance_window, state: :started, components: [component])
         display_id = window.case.display_id
 
         expect(subject).to include(
@@ -79,14 +79,14 @@ RSpec.describe ApplicationDecorator do
       end
 
       it 'gives nothing when only has finished maintenance window' do
-        create(:ended_maintenance_window, component: component)
+        create(:ended_maintenance_window, components: [component])
         expect(subject).to be_empty
       end
 
       it 'includes icon for every unfinished maintenance window' do
-        create(:requested_maintenance_window, component: component)
-        create(:maintenance_window, state: :started, component: component)
-        create(:ended_maintenance_window, component: component)
+        create(:requested_maintenance_window, components: [component])
+        create(:maintenance_window, state: :started, components: [component])
+        create(:ended_maintenance_window, components: [component])
 
         expect(subject).to match(/<i .*<i /)
       end

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -1,33 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationDecorator do
-  describe '#start_maintenance_request_link' do
-    subject { component.decorate.start_maintenance_request_link }
-    let(:component) { create(:component) }
-
-    before :each do
-      allow(h).to receive(:current_user).and_return(user)
-    end
-
-    context 'when admin' do
-      let(:user) { create(:admin) }
-
-      it 'gives link to request maintenance page for object' do
-        expect(subject).to eq(
-          h.link_to h.raw(h.icon 'wrench', interactive: true),
-          h.new_component_maintenance_window_path(component),
-          title: 'Start request for maintenance of this component'
-        )
-      end
-    end
-
-    context 'when contact' do
-      let(:user) { create(:contact) }
-
-      it { is_expected.to be nil }
-    end
-  end
-
   describe '#cluster_part_icons' do
     describe 'maintenance icons' do
       subject { component.decorate.cluster_part_icons }

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -82,49 +82,4 @@ RSpec.describe MaintenanceWindowDecorator do
       end
     end
   end
-
-  describe '#confirm_path' do
-    subject { window.decorate.confirm_path }
-    let :window do
-      create(
-        :maintenance_window,
-        clusters: associated_model.readable_model_name == 'cluster' ? [associated_model] : [],
-        services: associated_model.readable_model_name == 'service' ? [associated_model] : [],
-        components: associated_model.readable_model_name == 'component' ? [associated_model] : []
-      )
-    end
-
-    context 'when associated model is cluster' do
-      let(:associated_model) { create(:cluster) }
-
-      it do
-        is_expected.to eq h.confirm_cluster_maintenance_window_path(
-          id: window.id,
-          cluster_id: associated_model.id
-        )
-      end
-    end
-
-    context 'when associated model is component' do
-      let(:associated_model) { create(:component) }
-
-      it do
-        is_expected.to eq h.confirm_cluster_maintenance_window_path(
-          id: window.id,
-          cluster_id: associated_model.cluster.id
-        )
-      end
-    end
-
-    context 'when associated model is service' do
-      let(:associated_model) { create(:service) }
-
-      it do
-        is_expected.to eq h.confirm_cluster_maintenance_window_path(
-          id: window.id,
-          cluster_id: associated_model.cluster.id
-        )
-      end
-    end
-  end
 end

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe MaintenanceWindowDecorator do
       context "when #{state}" do
         let(:state) { state }
 
-        it 'just returns formatted time range for maintenance' do
-          expect(subject.scheduled_period).to eq expected_time_range
+        it 'includes state' do
+          expect(subject.scheduled_period).to include "(#{state})"
         end
       end
     end

--- a/spec/decorators/maintenance_window_decorator_spec.rb
+++ b/spec/decorators/maintenance_window_decorator_spec.rb
@@ -86,7 +86,12 @@ RSpec.describe MaintenanceWindowDecorator do
   describe '#confirm_path' do
     subject { window.decorate.confirm_path }
     let :window do
-      create(:maintenance_window, associated_model: associated_model)
+      create(
+        :maintenance_window,
+        clusters: associated_model.readable_model_name == 'cluster' ? [associated_model] : [],
+        services: associated_model.readable_model_name == 'service' ? [associated_model] : [],
+        components: associated_model.readable_model_name == 'component' ? [associated_model] : []
+      )
     end
 
     context 'when associated model is cluster' do
@@ -104,9 +109,9 @@ RSpec.describe MaintenanceWindowDecorator do
       let(:associated_model) { create(:component) }
 
       it do
-        is_expected.to eq h.confirm_component_maintenance_window_path(
+        is_expected.to eq h.confirm_cluster_maintenance_window_path(
           id: window.id,
-          component_id: associated_model.id
+          cluster_id: associated_model.cluster.id
         )
       end
     end
@@ -115,9 +120,9 @@ RSpec.describe MaintenanceWindowDecorator do
       let(:associated_model) { create(:service) }
 
       it do
-        is_expected.to eq h.confirm_service_maintenance_window_path(
+        is_expected.to eq h.confirm_cluster_maintenance_window_path(
           id: window.id,
-          service_id: associated_model.id
+          cluster_id: associated_model.cluster.id
         )
       end
     end

--- a/spec/factories/maintenance_window.rb
+++ b/spec/factories/maintenance_window.rb
@@ -7,7 +7,14 @@ FactoryBot.define do
     duration 1
 
     after(:build) do |mw|
-      unless mw.components || mw.services || mw.clusters
+      unless mw.components.present? || mw.services.present? || mw.clusters.present?
+        # This could also be a Cluster or Service; but one of these must be
+        # associated and is the item under maintenance.
+        mw.components << create(:component)
+      end
+    end
+    before(:create) do |mw|
+      unless mw.components.present? || mw.services.present? || mw.clusters.present?
         # This could also be a Cluster or Service; but one of these must be
         # associated and is the item under maintenance.
         mw.components << create(:component)

--- a/spec/factories/maintenance_window.rb
+++ b/spec/factories/maintenance_window.rb
@@ -1,23 +1,25 @@
 
 FactoryBot.define do
   factory :maintenance_window do
-    association :case # Avoid conflict with case keyword.
+    association :case, factory: :case_with_component # Avoid conflict with case keyword.
     created_at 7.days.ago
     requested_start 1.days.from_now.at_midnight
     duration 1
 
     after(:build) do |mw|
       unless mw.components.present? || mw.services.present? || mw.clusters.present?
-        # This could also be a Cluster or Service; but one of these must be
-        # associated and is the item under maintenance.
-        mw.components << create(:component)
+        mw.components = mw.case.components
+        mw.services = mw.case.services
+        mw.component_groups = mw.case.component_groups
+        mw.clusters = mw.case.clusters
       end
     end
     before(:create) do |mw|
       unless mw.components.present? || mw.services.present? || mw.clusters.present?
-        # This could also be a Cluster or Service; but one of these must be
-        # associated and is the item under maintenance.
-        mw.components << create(:component)
+        mw.components = mw.case.components
+        mw.services = mw.case.services
+        mw.component_groups = mw.case.component_groups
+        mw.clusters = mw.case.clusters
       end
     end
 

--- a/spec/factories/maintenance_window.rb
+++ b/spec/factories/maintenance_window.rb
@@ -6,10 +6,12 @@ FactoryBot.define do
     requested_start 1.days.from_now.at_midnight
     duration 1
 
-    # This could also be a Cluster or Service; but one of these must be
-    # associated and is the item under maintenance.
-    component do
-      create(:component) unless cluster || service || associated_model
+    after(:build) do |mw|
+      unless mw.components || mw.services || mw.clusters
+        # This could also be a Cluster or Service; but one of these must be
+        # associated and is the item under maintenance.
+        mw.components << create(:component)
+      end
     end
 
     # For these factories to create a MaintenanceWindow in a particular state,
@@ -56,7 +58,7 @@ FactoryBot.define do
   end
 
   factory :maintenance_window_state_transition do
-    maintenance_window
+    maintenance_window { build(:maintenance_window) }
     to :requested
     event :request
     association :user, factory: :admin

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Case page', type: :feature do
     create(:open_case, cluster: cluster, subject: 'Open case', assignee: assignee, tier_level: 3)
   end
 
-  let (:mw) { create(:maintenance_window, case: open_case) }
+  let(:mw) { create(:maintenance_window, case: open_case, clusters: [cluster]) }
 
   let(:comment_form_class) { '#new_case_comment' }
   let(:comment_button_text) { 'Add new comment' }

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe 'Case page', type: :feature do
           visit cluster_case_path(cluster,subject, as: user)
 
           request_link = find('a', text: 'Request maintenance')
-          expect(request_link[:href]).to eq new_cluster_maintenance_window_path(cluster, case_id: open_case.id)
+          expect(request_link[:href]).to eq new_cluster_case_maintenance_path(cluster, open_case)
         end
 
         context 'as a contact' do

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -288,13 +288,19 @@ RSpec.describe 'Case page', type: :feature do
           )
         }
 
-        it 'does not allow case to be resolved' do
+        before(:each) do
           visit cluster_case_path(open_case.cluster, open_case, as: admin)
+        end
 
+        it 'does not allow case to be resolved' do
           state_controls = find('#case-state-controls')
           expect(state_controls).to have_text 'outstanding maintenance window.'
           expect(state_controls).not_to have_text 'Resolve this case'
+        end
 
+        it 'shows maintenance details' do
+          details = find('#maintenance-details')
+          expect(details).to have_text("(#{state})")
         end
       end
     end
@@ -310,13 +316,22 @@ RSpec.describe 'Case page', type: :feature do
           )
         }
 
+        before(:each) do
+          visit cluster_case_path(open_case.cluster, open_case, as: admin)
+        end
+
         it 'allows case to be resolved' do
           visit cluster_case_path(open_case.cluster, open_case, as: admin)
 
           state_controls = find('#case-state-controls')
           expect(state_controls).not_to have_text 'outstanding maintenance window.'
           expect(state_controls.find('a')).to have_text 'Resolve this case'
+        end
 
+        it 'does not show maintenance details' do
+          expect do
+            find('#maintenance-details')
+          end.to raise_error Capybara::ElementNotFound
         end
       end
     end

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe 'Case page', type: :feature do
 
         it 'shows maintenance details' do
           details = find('#maintenance-details')
-          expect(details).to have_text("(#{state})")
+          expect(details).to have_text("(#{state == 'started' ? 'in progress' : state})")
         end
       end
     end

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -21,18 +21,8 @@ RSpec.describe 'cluster tabs', type: :feature do
     context 'with an admin user' do
       let(:user) { create(:admin) }
 
-      it 'has a dropdown menu for maintenance tab' do
-        expect(maintenance_tab).to match_css('.dropdown')
-        expect(maintenance_tab.first('div')).to match_css('.dropdown-menu')
-      end
-
       it 'has a link to the existing maintenance' do
         path = cluster_maintenance_windows_path(cluster)
-        expect(maintenance_tab).to have_link(href: path)
-      end
-
-      it 'has a link to request maintenance' do
-        path = new_cluster_maintenance_window_path(cluster)
         expect(maintenance_tab).to have_link(href: path)
       end
 
@@ -61,18 +51,9 @@ RSpec.describe 'cluster tabs', type: :feature do
 
     context 'with a contact user' do
 
-      it 'does not have dropdown menu for maintenance tab' do
-        expect(maintenance_tab).not_to match_css('.dropdown')
-      end
-
       it 'has a link to the existing maintenance' do
         path = cluster_maintenance_windows_path(cluster)
         expect(maintenance_tab).to have_link(href: path)
-      end
-
-      it 'does not have a link to request maintenance' do
-        path = new_cluster_maintenance_window_path(cluster)
-        expect(maintenance_tab).not_to have_link(href: path)
       end
 
       it 'does not have a Documents tab' do

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -246,7 +246,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     end
 
     it 'can cancel requested maintenance' do
-      window = create(:requested_maintenance_window, cluster: cluster)
+      window = create(:requested_maintenance_window, clusters: [cluster])
 
       visit cluster_maintenance_windows_path(cluster, as: user)
       click_button(cancel_button_text)
@@ -259,7 +259,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     end
 
     it 'can end started maintenance' do
-      window = create(:started_maintenance_window, cluster: cluster)
+      window = create(:started_maintenance_window, clusters: [cluster])
 
       visit cluster_maintenance_windows_path(cluster, as: user)
       click_button(end_button_text)
@@ -272,7 +272,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     end
 
     it 'cannot see end button for non-started maintenance' do
-      create(:confirmed_maintenance_window, cluster: cluster)
+      create(:confirmed_maintenance_window, clusters: [cluster])
 
       visit cluster_maintenance_windows_path(cluster, as: user)
 
@@ -280,7 +280,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     end
 
     it 'cannot see reject button' do
-      create(:requested_maintenance_window, cluster: cluster)
+      create(:requested_maintenance_window, clusters: [cluster])
 
       visit cluster_maintenance_windows_path(cluster, as: user)
 
@@ -292,7 +292,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         window = create(
           :maintenance_window,
           state: state,
-          cluster: cluster,
+          clusters: [cluster],
           duration: 1
         )
         original_duration = window.duration
@@ -315,7 +315,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     end
 
     it 'cannot see extend form for non-confirmed/started maintenance' do
-      create(:requested_maintenance_window, cluster: cluster)
+      create(:requested_maintenance_window, clusters: [cluster])
 
       visit cluster_maintenance_windows_path(cluster, as: user)
 
@@ -358,7 +358,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         let :window do
           create(
             :requested_maintenance_window,
-            service: service,
+            services: [service],
             case: support_case,
           )
         end
@@ -372,7 +372,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         let :window do
           create(
             :expired_maintenance_window,
-            service: service,
+            services: [service],
             case: support_case,
           )
         end
@@ -393,7 +393,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'can reject requested maintenance' do
       window = create(
         :requested_maintenance_window,
-        component: component,
+        components: [component],
         case: support_case
       )
 
@@ -411,7 +411,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'cannot see cancel button' do
       create(
         :requested_maintenance_window,
-        component: component,
+        components: [component],
         case: support_case
       )
 
@@ -423,7 +423,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'cannot see end button' do
       create(
         :started_maintenance_window,
-        component: component,
+        components: [component],
         case: support_case
       )
 
@@ -435,7 +435,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'cannot see extend form' do
       create(
         :started_maintenance_window,
-        component: component,
+        components: [component],
         case: support_case
       )
 
@@ -448,7 +448,7 @@ RSpec.feature "Maintenance windows", type: :feature do
       subject do
         create(
             :requested_maintenance_window,
-            cluster: cluster,
+            clusters: [cluster],
             case: support_case
         )
       end
@@ -467,7 +467,7 @@ RSpec.feature "Maintenance windows", type: :feature do
     let! :window do
       create(
         :requested_maintenance_window,
-        cluster: cluster,
+        clusters: [cluster],
         case: support_case
       )
     end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.shared_examples 'maintenance form error handling' do |form_action|
   it 're-renders form with error when invalid requested_start entered' do
-    original_path = current_path
     requested_start_in_past = Time.zone.local(2016, 9, 20, 13)
 
     expect do
@@ -11,7 +10,6 @@ RSpec.shared_examples 'maintenance form error handling' do |form_action|
       click_button submit_button_text
     end.not_to change(MaintenanceWindow, :all)
 
-    expect(current_path).to eq(original_path)
     expect(
       find('.alert')
     ).to have_text("Unable to #{form_action} this maintenance")
@@ -33,27 +31,13 @@ end
 
 RSpec.shared_examples 'confirmation form' do
   before :each do
-    visit confirm_service_maintenance_window_path(
+    visit confirm_maintenance_window_path(
       window,
-      service_id: service.id,
       as: user
     )
   end
 
   include_examples 'maintenance form error handling', 'confirm'
-
-  it 'cannot change Case for requested maintenance' do
-    case_select = test_element('case-select')
-
-    expect(case_select).to be_disabled
-    expect(case_select[:title]).to match(/Case.*cannot be changed/)
-  end
-
-  it 'includes correct Case select label' do
-    case_select_label = test_element('case-select-label')
-
-    expect(case_select_label).to have_text('Associated Case')
-  end
 
   it 'cannot change duration for requested maintenance' do
     duration_input = test_element('duration-input-group').find('input')
@@ -120,37 +104,27 @@ RSpec.feature "Maintenance windows", type: :feature do
     let(:cluster) { create(:cluster) }
     let!(:component) { create(:component, cluster: cluster) }
 
-    let :component_maintenance_path do
-      new_component_maintenance_window_path(component)
-    end
-
-    it 'can navigate to maintenance request form from Cluster dashboard Components tab' do
-      visit cluster_components_path(cluster, as: user)
-
-      component_maintenance_link = page.find_link(
-        href: component_maintenance_path
-      )
-      component_maintenance_link.click
-
-      expect(current_path).to eq(component_maintenance_path)
-    end
-
     describe 'maintenance request form' do
       include ActiveSupport::Testing::TimeHelpers
 
       let! :cluster_case do
-        create(:case, cluster: cluster, subject: 'Some case')
+        create(
+          :open_case,
+          cluster: cluster,
+          subject: 'Some case',
+          components: [component]
+        )
       end
 
       before :each do
-        visit new_component_maintenance_window_path(component, as: user)
+        visit new_cluster_case_maintenance_path(cluster, cluster_case, as: user)
       end
 
       include_examples 'maintenance form error handling', 'request'
       include_examples 'maintenance form initially valid'
 
-      it 'displays the component for which maintenance is being requested' do
-        expect(find('h4').text).to eq "Requesting maintenance for #{component.name} (#{cluster.name})"
+      it 'displays the case for which maintenance is being requested' do
+        expect(find('h4').text).to eq "Requesting maintenance for support case #{cluster_case.display_id}"
       end
 
       it 'uses correct default values' do
@@ -160,9 +134,8 @@ RSpec.feature "Maintenance windows", type: :feature do
         travel_to a_distant_friday do
           # Visit page again now we have mocked the time so correct default
           # `requested_start` based on current time is used.
-          visit new_component_maintenance_window_path(component, as: user)
+          visit new_cluster_case_maintenance_path(cluster, cluster_case, as: user)
 
-          select cluster_case.subject
           click_button 'Request Maintenance'
 
           new_window = cluster_case.maintenance_windows.first
@@ -171,29 +144,7 @@ RSpec.feature "Maintenance windows", type: :feature do
         end
       end
 
-      it 'includes correct Case select label' do
-        case_select_label = test_element('case-select-label')
-
-        expect(case_select_label).to have_text('Case to associate')
-      end
-
-      it 'can request maintenance in association with any Case for Cluster' do
-        select cluster_case.subject
-        fill_in 'Duration', with: 2
-        fill_in_datetime_selects 'requested-start', with: valid_requested_start
-        click_button 'Request Maintenance'
-
-        new_window = cluster_case.maintenance_windows.first
-        expect(new_window).to be_requested
-        expect(new_window.requested_by).to eq user
-        expect(new_window.duration).to eq 2
-        expect(new_window.requested_start).to eq valid_requested_start
-        expect(current_path).to eq(cluster_maintenance_windows_path(cluster))
-        expect(find('.alert')).to have_text('Maintenance requested')
-      end
-
       it 'can mandate maintenance' do
-        select cluster_case.subject
         fill_in 'Duration', with: 2
         fill_in_datetime_selects 'requested-start', with: valid_requested_start
         check 'mandatory'
@@ -210,14 +161,11 @@ RSpec.feature "Maintenance windows", type: :feature do
       end
 
       it 're-renders form with error when invalid duration entered' do
-        original_path = current_path
-
         expect do
           fill_in 'Duration', with: -1
           click_button 'Request Maintenance'
         end.not_to change(MaintenanceWindow, :all)
 
-        expect(current_path).to eq(original_path)
         expect(
           find('.alert')
         ).to have_text('Unable to request this maintenance')
@@ -246,7 +194,10 @@ RSpec.feature "Maintenance windows", type: :feature do
     end
 
     it 'can cancel requested maintenance' do
-      window = create(:requested_maintenance_window, clusters: [cluster])
+      window = create(
+        :requested_maintenance_window,
+        clusters: [cluster]
+      )
 
       visit cluster_maintenance_windows_path(cluster, as: user)
       click_button(cancel_button_text)
@@ -321,14 +272,6 @@ RSpec.feature "Maintenance windows", type: :feature do
 
       expect(page).not_to have_button(extend_button_text)
     end
-
-    context 'when maintenance is for the entire cluster' do
-      it 'shows the entire-cluster-warning message' do
-        visit new_cluster_maintenance_window_path(cluster_id: cluster, as: user)
-
-        expect(find('p.alert-warning').text).to match 'Not what you want? Try selecting a component or a service from this cluster.'
-      end
-    end
   end
 
   context 'when user is contact' do
@@ -340,15 +283,14 @@ RSpec.feature "Maintenance windows", type: :feature do
     it 'can navigate to confirmation form for requested maintenance' do
       window = create(
         :requested_maintenance_window,
-        component: component,
         case: support_case
       )
 
-      visit cluster_maintenance_windows_path(component.cluster, as: user)
+      visit cluster_maintenance_windows_path(cluster, as: user)
       click_link(confirm_button_link_text)
 
-      expected_path = confirm_component_maintenance_window_path(
-        window, component_id: component
+      expected_path = confirm_maintenance_window_path(
+        window
       )
       expect(current_path).to eq expected_path
     end
@@ -442,24 +384,6 @@ RSpec.feature "Maintenance windows", type: :feature do
       visit cluster_maintenance_windows_path(cluster, as: user)
 
       expect(page).not_to have_button(extend_button_text)
-    end
-
-    context 'when maintenance is for the entire cluster' do
-      subject do
-        create(
-            :requested_maintenance_window,
-            clusters: [cluster],
-            case: support_case
-        )
-      end
-
-      it 'does not show the entire-cluster-warning message' do
-        visit confirm_cluster_maintenance_window_path(id: subject.id, cluster_id: cluster.id, as: user)
-
-        expect do
-          find('p.alert-warning')
-        end.to raise_error(Capybara::ElementNotFound)
-      end
     end
   end
 

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -169,9 +169,23 @@ RSpec.feature "Maintenance windows", type: :feature do
         expect(new_window.confirmed_by).to eq user
         expect(new_window.duration).to eq 2
         expect(new_window.requested_start).to eq valid_requested_start
-        expect(current_path).to eq(cluster_maintenance_windows_path(cluster))
+        expect(current_path).to eq(cluster_case_path(cluster, cluster_case))
         expect(find('.alert')).to have_text('Maintenance scheduled')
-        expect(page).to have_text(/N\/A.*mandatory maintenance/)
+        expect(page).to have_text('this maintenance is mandatory')
+      end
+
+      it 'can request maintenance' do
+        fill_in 'Duration', with: 2
+        fill_in_datetime_selects 'requested-start', with: valid_requested_start
+        click_button 'Request Maintenance'
+
+        new_window = cluster_case.maintenance_windows.first
+        expect(new_window).to be_requested
+        expect(new_window.duration).to eq 2
+        expect(new_window.requested_start).to eq valid_requested_start
+        expect(current_path).to eq(cluster_case_path(cluster, cluster_case))
+        expect(find('.alert')).to have_text('Maintenance requested')
+        expect(page).not_to have_text('this maintenance is mandatory')
       end
 
       it 're-renders form with error when invalid duration entered' do

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -199,14 +199,14 @@ RSpec.describe Cluster, type: :model do
     subject { create(:cluster) }
 
     it 'gives unfinished maintenance windows for Cluster and parts' do
-      create(:requested_maintenance_window, cluster: subject, id: 1)
-      create(:confirmed_maintenance_window, cluster: subject, id: 2)
-      create(:ended_maintenance_window, cluster: subject, id: 3)
+      create(:requested_maintenance_window, clusters: [subject], id: 1)
+      create(:confirmed_maintenance_window, clusters: [subject], id: 2)
+      create(:ended_maintenance_window, clusters: [subject], id: 3)
 
       component = create(:component, cluster: subject)
-      create(:requested_maintenance_window, component: component, id: 4)
-      create(:confirmed_maintenance_window, component: component, id: 5)
-      create(:ended_maintenance_window, component: component, id: 6)
+      create(:requested_maintenance_window, components: [component], id: 4)
+      create(:confirmed_maintenance_window, components: [component], id: 5)
+      create(:ended_maintenance_window, components: [component], id: 6)
 
       resulting_window_ids = subject.unfinished_related_maintenance_windows.map(&:id)
 
@@ -214,8 +214,8 @@ RSpec.describe Cluster, type: :model do
     end
 
     it 'gives maintenance windows with newest first' do
-      create(:requested_maintenance_window, cluster: subject, id: 1, created_at: 2.days.ago)
-      create(:confirmed_maintenance_window, cluster: subject, id: 2, created_at: 1.day.ago)
+      create(:requested_maintenance_window, clusters: [subject], id: 1, created_at: 2.days.ago)
+      create(:confirmed_maintenance_window, clusters: [subject], id: 2, created_at: 1.day.ago)
 
       resulting_window_ids = subject.unfinished_related_maintenance_windows.map(&:id)
 

--- a/spec/models/maintenance_window/validator_spec.rb
+++ b/spec/models/maintenance_window/validator_spec.rb
@@ -55,40 +55,12 @@ RSpec.describe MaintenanceWindow, type: :model do
       subject do
         build(
           :maintenance_window,
-          cluster: cluster,
-          component: component,
-          service: service
+          components: [component].compact,
+          services: [service].compact
         )
       end
-      let(:cluster) { nil }
-      let(:component) { nil }
-      let(:service) { nil }
 
-      context 'when single associated model given' do
-        let(:cluster) { create(:cluster) }
-
-        it { is_expected.to be_valid }
-      end
-
-      context 'when no associated model given' do
-        it { is_expected.to be_invalid }
-      end
-
-      context 'when both Cluster and Component associated' do
-        let(:cluster) { create(:cluster) }
-        let(:component) { create(:component) }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context 'when both Cluster and Service associated' do
-        let(:cluster) { create(:cluster) }
-        let(:service) { create(:service) }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context 'when both Component and Service associated' do
+      context 'when Component and Service from different clusters associated' do
         let(:component) { create(:component) }
         let(:service) { create(:service) }
 

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe MaintenanceWindow, type: :model do
         expected_start = subject.requested_start.to_formatted_s(:short)
         expected_cluster_dashboard_url =
           Rails.application.routes.url_helpers.cluster_maintenance_windows_url(
-            subject.components.first.cluster
+            subject.cluster
         )
         text_regex = Regexp.new <<~REGEX.squish
           maintenance of some_component.*was not confirmed before requested
@@ -82,7 +82,7 @@ RSpec.describe MaintenanceWindow, type: :model do
         expected_end = subject.expected_end.to_formatted_s(:short)
         expected_cluster_dashboard_url =
           Rails.application.routes.url_helpers.cluster_maintenance_windows_url(
-            subject.components.first.cluster
+            subject.cluster
         )
         text_regex = Regexp.new <<~REGEX.squish
           requested.*some_component.*#{expected_start}.*#{expected_end}.*by
@@ -342,18 +342,10 @@ RSpec.describe MaintenanceWindow, type: :model do
   end
 
   describe '#associated_cluster' do
-    it 'gives cluster when associated model is cluster' do
-      cluster = create(:cluster)
-      window = create(:maintenance_window, clusters: [cluster])
+    it 'inherits cluster from case' do
+      window = create(:maintenance_window)
 
-      expect(window.associated_cluster).to eq(cluster)
-    end
-
-    it "gives associated model's cluster when associated model is not cluster" do
-      component = create(:component)
-      window = create(:maintenance_window, components: [component])
-
-      expect(window.associated_cluster).to eq(component.cluster)
+      expect(window.cluster).to eq(window.case.cluster)
     end
   end
 

--- a/spec/services/progress_maintenance_window_spec.rb
+++ b/spec/services/progress_maintenance_window_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ProgressMaintenanceWindow do
         state: state,
         requested_start: requested_start,
         duration: 1,
-        component: component,
+        components: [component],
         id: 123
       )
     end
@@ -78,7 +78,7 @@ RSpec.describe ProgressMaintenanceWindow do
       start_date = window.requested_start.to_formatted_s(:short)
       end_date = window.expected_end.to_formatted_s(:short)
       full_expected_message = <<~EOF.squish
-        Maintenance window #{window.id} (#{component.name} | #{start_date} -
+        Maintenance window #{window.id} (#{component.name} (#{component.readable_model_name}) | #{start_date} -
         #{end_date}): #{expected}
       EOF
       expect(message).to eq full_expected_message


### PR DESCRIPTION
This PR brings maintenance windows in line with `Case`s in allowing associations with multiple cluster parts, component groups and `Cluster`s.

The sole way to create a `MaintenanceWindow` now is through a `Case`. Having set the appropriate associations on a `Case`, admins can now request (or mandate) maintenance, and the `MaintenanceWindow` generated will inherit the associated components of the `Case` *at the time of creation*.

It's no longer possible to create a maintenance window from a component or service dashboard.

It *is* now possible to create a maintenance window for, or which includes, a component group.

Pending maintenance windows associated with a case are now displayed on the case page. (A 'pending' MW is one that is not cancelled, rejected or ended - note that means *expired* windows are included.) It is no longer possible to resolve a case with any pending maintenance windows - they need to first be cancelled, rejected or ended.

Trello: https://trello.com/c/mK8JOVWh/371-allow-multiple-associations-for-a-maintenancewindow and https://trello.com/c/zMaJD4qx/372-make-the-only-way-to-create-a-maintenancewindow-be-via-case.

Closes #233.