### PR TITLE
Don't use `sudo` to invoke `docker` unless it's needed.

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,3 +1,4 @@
+require 'etc'
 
 namespace :alces do
   namespace :data do
@@ -52,7 +53,7 @@ namespace :alces do
         # container.
         Dir.chdir(sso_repo) do
           sso_docker_command = <<~SH.squish
-            sudo docker-compose run --rm sso bin/rails runner
+            #{docker_requires_sudo? ? 'sudo' : ''} docker-compose run --rm sso bin/rails runner
             '#{sso_script_path}' --trace
           SH
 
@@ -80,6 +81,15 @@ namespace :alces do
           end
         RUBY
       end.join("\n")
+    end
+
+    private
+
+    def docker_requires_sudo?
+      docker_group = Etc.getgrnam('docker')
+      current_user = Etc.getlogin
+
+      !docker_group.mem.include? current_user
     end
   end
 end


### PR DESCRIPTION
"Needed", in this case, equates to "user is not a member of the `docker` group" which is the standard way of allowing non-root Docker access, at least on Debian-based systems.

@atoghill You might want to add your user to the `docker` group in your VM, but this PR shouldn't make any difference to you.