### PR TITLE
Remove junk audits created by a previous data migration.

### DIFF
--- a/db/data/20180716101913_delete_audits_caused_by_migration.rb
+++ b/db/data/20180716101913_delete_audits_caused_by_migration.rb
@@ -1,0 +1,13 @@
+class DeleteAuditsCausedByMigration < ActiveRecord::Migration[5.2]
+  def up
+    # These audits were created by the SetNewCaseAssociations migration.
+    # They're harmless - the funky associated_type means they're never going to
+    # be used by anything - but no need to have them lying around in the database
+    # taking up space.
+    Audited::Audit.where(associated_type: 'SetNewCaseAssociations::Case').delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180710175002)
+DataMigrate::Data.define(version: 20180716101913)


### PR DESCRIPTION
As title.