### PR TITLE
Rename version environment variable to `FC_VERSION`.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,5 +73,5 @@ Rails.application.configure do
   config.slack_channel = ENV['SLACK_CHANNEL']
   config.slack_username = 'Alces Flight Center [Development]'
 
-  config.version = 'Development'
+  config.version = ENV['FC_VERSION'] || 'Development'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -126,5 +126,5 @@ Rails.application.configure do
       ]
     end
 
-  config.version = ENV['VERSION']
+  config.version = ENV['FC_VERSION']
 end

--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -5,12 +5,14 @@ require 'erb'
 class Deployment
   include Rake::DSL
 
-  def initialize(type, version_name, dry_run: false)
-    @remote = type
-    @tag = version_name
-    @dry_run = dry_run
+  VERSION_ENV_VAR = 'FC_VERSION'.freeze
 
-    abort "Must set ENV['VERSION'] within command!" if @tag.nil?
+  def initialize(type, dry_run: false)
+    abort "Must set ENV['#{VERSION_ENV_VAR}'] within command!" unless ENV.include?(VERSION_ENV_VAR)
+    @remote = type
+    @dry_run = dry_run
+    @tag = ENV[VERSION_ENV_VAR]
+
   end
 
   def deploy
@@ -30,7 +32,7 @@ class Deployment
       abort unless input.downcase == 'y'
     end
 
-    dokku_config_set('VERSION', tag, app: app_name, restart: false)
+    dokku_config_set(VERSION_ENV_VAR, tag, app: app_name, restart: false)
     run "git push #{remote} -f #{current_branch}:master"
 
     import_production_backup_to_staging if staging?

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -6,13 +6,13 @@ namespace :alces do
     [:production, :staging].each do |deploy_type|
       desc "Deploy to #{deploy_type}"
       task deploy_type do
-        deploy(deploy_type, ENV['VERSION'])
+        deploy(deploy_type)
       end
 
       namespace deploy_type do
         desc "Output what will happen on deploy to #{deploy_type}, without doing anything"
         task :dry_run do
-          deploy(deploy_type, ENV['VERSION'], dry_run: true)
+          deploy(deploy_type, dry_run: true)
         end
       end
     end
@@ -20,13 +20,13 @@ namespace :alces do
     namespace :production do
       desc "Deploy hotfix release to production"
       task :hotfix do
-        deploy(:hotfix, ENV['VERSION'])
+        deploy(:hotfix)
       end
 
       namespace :hotfix do
         desc 'Output what will happen on hotfix deploy to production, without doing anything'
         task :dry_run do
-          deploy(:hotfix, ENV['VERSION'], dry_run: true)
+          deploy(:hotfix, dry_run: true)
         end
       end
     end


### PR DESCRIPTION
This avoids conflicts with the `VERSION` var used by Rails's database migration tasks.