### PR TITLE
Filter case index page

### DIFF
--- a/app/assets/javascripts/cluster_tree.js
+++ b/app/assets/javascripts/cluster_tree.js
@@ -131,5 +131,28 @@ document.addEventListener('turbolinks:load',
     $('.cluster-tree').each(
       _init_cluster_tree
     );
+
+    // Allow cluster tree to work within a dropdown
+    // https://stackoverflow.com/a/25253002
+    $('.dropdown-menu .cluster-tree').on('click', function(event){
+      let events = $._data(document, 'events') || {};
+      events = events.click || [];
+      for(let i = 0; i < events.length; i++) {
+        if(events[i].selector) {
+
+          //Check if the clicked element matches the event selector
+          if($(event.target).is(events[i].selector)) {
+            events[i].handler.call(event.target, event);
+          }
+
+          // Check if any of the clicked element parents matches the
+          // delegated event selector (Emulating propagation)
+          $(event.target).parents(events[i].selector).each(function(){
+            events[i].handler.call(this, event);
+          });
+        }
+      }
+      event.stopPropagation(); //Always stop propagation
+    });
   }
 );

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -152,3 +152,11 @@ table {
     }
   }
 }
+
+a.filter {
+  cursor: pointer;
+
+  &.filter-inactive {
+    color: black;
+  }
+}

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -92,3 +92,11 @@ td {
 th * {
   font-weight: normal;
 }
+
+
+.associations-filter {
+  max-height: 25rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-left: 1.5rem;
+}

--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -89,3 +89,6 @@ td {
   text-decoration: none;
 }
 
+th * {
+  font-weight: normal;
+}

--- a/app/assets/stylesheets/clusters.scss
+++ b/app/assets/stylesheets/clusters.scss
@@ -36,6 +36,8 @@ li.credit-charge-entry {
 
 
 .cluster-tree {
+  min-width: 15rem;
+
   .form-check {
     width: 100%;
 

--- a/app/assets/stylesheets/clusters.scss
+++ b/app/assets/stylesheets/clusters.scss
@@ -65,7 +65,7 @@ li.credit-charge-entry {
 
   button.btn-collapse {
     position: absolute;
-    left: -5rem;
+    left: -3.25rem;
     padding: 0 0.25rem;
     width: 1.5rem;
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -165,6 +165,7 @@ class CasesController < ApplicationController
   end
 
   def index_action(show_resolved:)
+    @cases = show_resolved ? @scope.cases.inactive : @scope.cases.active
     @show_resolved = show_resolved
     render :index
   end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -6,7 +6,8 @@ class CasesController < ApplicationController
   ]
 
   def index
-    @cases = filtered_cases
+    @filters = case_filters
+    @cases = filtered_cases(@filters)
     render :index
   end
 
@@ -186,9 +187,9 @@ class CasesController < ApplicationController
     end
   end
 
-  def filtered_cases
+  def filtered_cases(filters)
     @scope.cases.filter(
-      case_filters
+      filters
     )
   end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -195,11 +195,11 @@ class CasesController < ApplicationController
     results = scope_results
     first_assoc = association_filter.shift
     if first_assoc
-      results = scope_results.associated_with(*first_assoc)
+      results = scope_results.associated_with(*first_assoc.split('-'))
     end
 
     association_filter.each do |assoc|
-      results = results.or(scope_results.associated_with(assoc.split('-')))
+      results = results.or(scope_results.associated_with(*assoc.split('-')))
     end
 
     results.filter(

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -211,7 +211,7 @@ class CasesController < ApplicationController
     {
       active: case_filters,
       ranges: {
-        assigned_to: @scope.cases.map(&:assignee).uniq.compact.sort
+        assigned_to: @scope.cases.map(&:assignee).uniq.compact.sort_by { |u| u.name }
       },
     }
   end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -194,19 +194,12 @@ class CasesController < ApplicationController
   end
 
   def case_filters
-    default_filters.merge(
-      params.permit(
-        :state,
-        state: []  # Allow state to be a singleton or array
-      ).to_h
-    )
+    params.permit(
+      :state,
+      state: []  # Allow state to be a singleton or array
+    ).to_h
   end
 
-  def default_filters
-    {
-      'state' => 'open',
-    }
-  end
 
   def filters_spec
     {

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -6,8 +6,8 @@ class CasesController < ApplicationController
   ]
 
   def index
-    @filters = case_filters
-    @cases = filtered_cases(@filters)
+    @filters = filters_spec
+    @cases = filtered_cases(@filters[:active])
     render :index
   end
 
@@ -205,6 +205,13 @@ class CasesController < ApplicationController
   def default_filters
     {
       'state' => 'open',
+    }
+  end
+
+  def filters_spec
+    {
+      active: case_filters,
+      values: {},
     }
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -196,15 +196,23 @@ class CasesController < ApplicationController
   def case_filters
     params.permit(
       :state,
-      state: []  # Allow state to be a singleton or array
-    ).to_h
+      :assigned_to,
+      {
+        state: [],
+        assigned_to: [],
+      }
+    ).to_h.tap { |filters|
+      filters[:assigned_to]&.map! { |a| a == "" ? nil : User.find(a) }
+    }
   end
 
 
   def filters_spec
     {
       active: case_filters,
-      values: {},
+      ranges: {
+        assigned_to: @scope.cases.map(&:assignee).uniq.compact.sort
+      },
     }
   end
 end

--- a/app/decorators/cluster_part_decorator.rb
+++ b/app/decorators/cluster_part_decorator.rb
@@ -19,6 +19,14 @@ class ClusterPartDecorator < ApplicationDecorator
     "#{name} (#{type_name})"
   end
 
+  def scope_cases_path(**args)
+    h.cluster_cases_path(cluster, **args, associations: ["#{model_name}-#{id}"])
+  end
+
+  def new_scope_case_path
+    h.new_cluster_case_path(cluster)
+  end
+
   private
 
   def render_change_support_type_button(

--- a/app/decorators/component_decorator.rb
+++ b/app/decorators/component_decorator.rb
@@ -18,6 +18,7 @@ class ComponentDecorator < ClusterPartDecorator
       tabs_builder.logs,
       tabs_builder.asset_record,
       tabs_builder.maintenance,
+      tabs_builder.read_only_cases,
       { id: :expansions, path: h.component_component_expansions_path(self) },
     ]
   end

--- a/app/decorators/component_group_decorator.rb
+++ b/app/decorators/component_group_decorator.rb
@@ -17,7 +17,8 @@ class ComponentGroupDecorator < ClusterPartDecorator
   def tabs
     [
       { id: :components, path: h.component_group_components_path(self) },
-      tabs_builder.asset_record
+      tabs_builder.asset_record,
+      tabs_builder.read_only_cases
     ]
   end
 

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -13,7 +13,7 @@ class ServiceDecorator < ClusterPartDecorator
   end
 
   def tabs
-    [tabs_builder.overview, tabs_builder.maintenance]
+    [tabs_builder.overview, tabs_builder.read_only_cases, tabs_builder.maintenance]
   end
 
   def case_form_json

--- a/app/helpers/tabs_builder.rb
+++ b/app/helpers/tabs_builder.rb
@@ -58,7 +58,7 @@ class TabsBuilder
   def resolved_cases_entry
     {
       text: 'Resolved',
-      path: scope.resolved_scope_cases_path,
+      path: scope.scope_cases_path(state: %w(resolved closed)),
     }
   end
 end

--- a/app/helpers/tabs_builder.rb
+++ b/app/helpers/tabs_builder.rb
@@ -10,10 +10,16 @@ class TabsBuilder
   end
 
   def cases
+    read_only_cases.tap { |roc|
+      nce = new_case_entry
+      roc[:dropdown].unshift(new_case_entry) if nce
+    }
+  end
+
+  def read_only_cases
     {
       id: :cases, path: scope.scope_cases_path,
       dropdown: [
-        new_case_entry,
         current_cases_entry,
         resolved_cases_entry,
       ].compact

--- a/app/helpers/tabs_builder.rb
+++ b/app/helpers/tabs_builder.rb
@@ -51,7 +51,7 @@ class TabsBuilder
   def current_cases_entry
     {
       text: "Current (#{scope.cases.active.size})",
-      path: scope.scope_cases_path,
+      path: scope.scope_cases_path(state: 'open'),
     }
   end
 

--- a/app/models/all_sites.rb
+++ b/app/models/all_sites.rb
@@ -4,6 +4,10 @@ class AllSites
     Case.all
   end
 
+  def clusters
+    Cluster.all
+  end
+
   def readable_model_name
     'All Sites'
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -136,12 +136,12 @@ class Case < ApplicationRecord
   scope :assigned_to, ->(user) { where(assignee: user) }
   scope :not_assigned_to, ->(user) { where.not(assignee: user).or(where(assignee: nil)) }
 
-  scope :associated_with, lambda { |arg_array|
+  scope :associated_with, lambda { |type, id|
     joins(:case_associations)
       .where(
         case_associations: {
-          associated_element_type: arg_array[0],
-          associated_element_id: arg_array[1],
+          associated_element_type: type,
+          associated_element_id: id,
         }
       )
   }

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -1,6 +1,7 @@
 class Case < ApplicationRecord
   include AdminConfig::Case
   include HasStateMachine
+  include Filterable
 
   default_scope { order(created_at: :desc) }
 
@@ -126,7 +127,8 @@ class Case < ApplicationRecord
   after_create :send_new_case_email
   after_update :maybe_send_new_assignee_email
 
-  scope :active, -> { where(state: 'open') }
+  scope :state, ->(state) { where(state: state) }
+  scope :active, -> { state('open') }
   scope :inactive, -> { where.not(state: 'open') }
 
   scope :assigned_to, ->(user) { where(assignee: user) }

--- a/app/models/component_group.rb
+++ b/app/models/component_group.rb
@@ -13,6 +13,9 @@ class ComponentGroup < ApplicationRecord
   has_many :maintenance_window_associations, as: :associated_element
   has_many :maintenance_windows, through: :maintenance_window_associations
 
+  has_many :case_associations, as: :associated_element
+  has_many :cases, through: :case_associations
+
   validates :name, presence: true
 
   validates_associated :cluster, :asset_record_fields

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -1,0 +1,13 @@
+module Filterable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def filter(filtering_params)
+      results = self.where(nil)
+      filtering_params.each do |key, value|
+        results = results.public_send(key, value) if value.present?
+      end
+      results
+    end
+  end
+end

--- a/app/views/case_associations/_cluster_part.html.erb
+++ b/app/views/case_associations/_cluster_part.html.erb
@@ -22,7 +22,7 @@
         name="associations[]"
         type="checkbox"
         value="<%= dom_id %>"
-        <%= selected.include?(part) ? 'checked' : '' %>
+        <%= selected.include?(part) || selected.include?(dom_id) ? 'checked' : '' %>
       />
     </div>
   </div>

--- a/app/views/case_associations/_cluster_part.html.erb
+++ b/app/views/case_associations/_cluster_part.html.erb
@@ -22,7 +22,7 @@
         name="associations[]"
         type="checkbox"
         value="<%= dom_id %>"
-        <%= kase.associations.include?(part) ? 'checked' : '' %>
+        <%= selected.include?(part) ? 'checked' : '' %>
       />
     </div>
   </div>
@@ -32,7 +32,7 @@
         <%= render 'case_associations/cluster_part',
                    dom_id: "#{child.model_name}-#{child.id}",
                    part: child,
-                   kase: kase,
+                   selected: selected,
                    parent: "#{dom_id}",
                    children: child.respond_to?(:components) ? child.components : []
         %>

--- a/app/views/case_associations/_cluster_tree.html.erb
+++ b/app/views/case_associations/_cluster_tree.html.erb
@@ -1,0 +1,43 @@
+<%
+  dom_id = "Cluster-#{cluster.id}"
+  fake = Struct.new(:name, :fa_icon, :type_name)
+%>
+<ul class="fa-ul cluster-tree" data-target="#cluster-tree-summary">
+  <li>
+    <div class="cluster-part">
+      <i class="fa-li fa <%= cluster.fa_icon %>" title="<%= cluster.type_name %>"></i>
+      <div class="form-check form-check-inline">
+        <label class="form-check-label" for="#<%= dom_id %>">
+          <%= cluster.name %> (Entire cluster)
+        </label>
+        <input
+          class="form-check-input"
+          data-cluster="true"
+          id="<%= dom_id %>"
+          name="associations[]"
+          type="checkbox"
+          value="<%= dom_id %>"
+          <%= selected.include?(cluster) ? 'checked' : '' %>
+          />
+      </div>
+    </div>
+    <ul class="fa-ul">
+      <%=
+        render 'case_associations/cluster_part',
+               part: fake.new('Services', 'fa-gears', 'Services'),
+               dom_id: 'all-services',
+               selected: selected,
+               children: cluster.services,
+               parent: dom_id
+      %>
+      <%=
+        render 'case_associations/cluster_part',
+               part: fake.new('Components', 'fa-cubes', 'Components'),
+               dom_id: 'all-components',
+               selected: selected,
+               children: cluster.component_groups,
+               parent: dom_id
+      %>
+    </ul>
+  </li>
+</ul>

--- a/app/views/case_associations/_cluster_tree.html.erb
+++ b/app/views/case_associations/_cluster_tree.html.erb
@@ -4,6 +4,15 @@
 %>
 <ul class="fa-ul cluster-tree" data-target="<%= local_assigns.fetch(:target, '') %>">
   <li>
+    <button
+      class="btn btn-sm btn-primary btn-collapse"
+      id="#<%= "#{dom_id}-expand" %>"
+      type="button"
+      data-toggle="collapse"
+      data-target="#<%= "#{dom_id}-children" %>"
+      aria-expanded="false"
+      aria-controls="#<%= "#{dom_id}-children" %>"
+    ></button>
     <div class="cluster-part">
       <i class="fa-li fa <%= cluster.fa_icon %>" title="<%= cluster.type_name %>"></i>
       <div class="form-check form-check-inline">
@@ -21,7 +30,7 @@
           />
       </div>
     </div>
-    <ul class="fa-ul">
+    <ul class="fa-ul collapse" id="<%= "#{dom_id}-children" %>">
       <%=
         render 'case_associations/cluster_part',
                part: fake.new('Services', 'fa-gears', 'Services'),

--- a/app/views/case_associations/_cluster_tree.html.erb
+++ b/app/views/case_associations/_cluster_tree.html.erb
@@ -2,7 +2,7 @@
   dom_id = "Cluster-#{cluster.id}"
   fake = Struct.new(:name, :fa_icon, :type_name)
 %>
-<ul class="fa-ul cluster-tree" data-target="#cluster-tree-summary">
+<ul class="fa-ul cluster-tree" data-target="<%= local_assigns.fetch(:target, '') %>">
   <li>
     <div class="cluster-part">
       <i class="fa-li fa <%= cluster.fa_icon %>" title="<%= cluster.type_name %>"></i>

--- a/app/views/case_associations/_cluster_tree.html.erb
+++ b/app/views/case_associations/_cluster_tree.html.erb
@@ -34,7 +34,7 @@
       <%=
         render 'case_associations/cluster_part',
                part: fake.new('Services', 'fa-gears', 'Services'),
-               dom_id: "all-services-#{cluster.id}",
+               dom_id: "allservices-#{cluster.id}",
                selected: selected,
                children: cluster.services,
                parent: dom_id
@@ -42,7 +42,7 @@
       <%=
         render 'case_associations/cluster_part',
                part: fake.new('Components', 'fa-cubes', 'Components'),
-               dom_id: "all-components-#{cluster.id}",
+               dom_id: "allcomponents-#{cluster.id}",
                selected: selected,
                children: cluster.component_groups,
                parent: dom_id

--- a/app/views/case_associations/_cluster_tree.html.erb
+++ b/app/views/case_associations/_cluster_tree.html.erb
@@ -34,7 +34,7 @@
       <%=
         render 'case_associations/cluster_part',
                part: fake.new('Services', 'fa-gears', 'Services'),
-               dom_id: "all-services=#{cluster.id}",
+               dom_id: "all-services-#{cluster.id}",
                selected: selected,
                children: cluster.services,
                parent: dom_id

--- a/app/views/case_associations/_cluster_tree.html.erb
+++ b/app/views/case_associations/_cluster_tree.html.erb
@@ -34,7 +34,7 @@
       <%=
         render 'case_associations/cluster_part',
                part: fake.new('Services', 'fa-gears', 'Services'),
-               dom_id: 'all-services',
+               dom_id: "all-services=#{cluster.id}",
                selected: selected,
                children: cluster.services,
                parent: dom_id
@@ -42,7 +42,7 @@
       <%=
         render 'case_associations/cluster_part',
                part: fake.new('Components', 'fa-cubes', 'Components'),
-               dom_id: 'all-components',
+               dom_id: "all-components-#{cluster.id}",
                selected: selected,
                children: cluster.component_groups,
                parent: dom_id

--- a/app/views/case_associations/edit.html.erb
+++ b/app/views/case_associations/edit.html.erb
@@ -11,7 +11,8 @@
               <%=
                 render 'case_associations/cluster_tree',
                        selected: @case.associations,
-                       cluster: @case.cluster
+                       cluster: @case.cluster,
+                       target: '#cluster-tree-summary'
               %>
             </div>
           </div>

--- a/app/views/case_associations/edit.html.erb
+++ b/app/views/case_associations/edit.html.erb
@@ -1,7 +1,3 @@
-<%
-  dom_id = "Cluster-#{@case.cluster.id}"
-  fake = Struct.new(:name, :fa_icon, :type_name)
-%>
 <div class="card">
   <div class="card-body container-fluid">
     <div class="row">
@@ -12,45 +8,11 @@
         <div class="col-sm-push-12 col-sm-12 col-md-6">
           <div class="card">
             <div class="card-body">
-              <ul class="fa-ul cluster-tree" data-target="#cluster-tree-summary">
-                <li>
-                  <div class="cluster-part">
-                    <i class="fa-li fa <%= @case.cluster.fa_icon %>" title="<%= @case.cluster.type_name %>"></i>
-                    <div class="form-check form-check-inline">
-                      <label class="form-check-label" for="#<%= dom_id %>">
-                        <%= @case.cluster.name %> (Entire cluster)
-                      </label>
-                      <input
-                        class="form-check-input"
-                        data-cluster="true"
-                        id="<%= dom_id %>"
-                        name="associations[]"
-                        type="checkbox"
-                        value="<%= dom_id %>"
-                        <%= @case.associations.include?(@case.cluster) ? 'checked' : '' %>
-                      />
-                    </div>
-                  </div>
-                  <ul class="fa-ul">
-                    <%=
-                      render 'case_associations/cluster_part',
-                             part: fake.new('Services', 'fa-gears', 'Services'),
-                             dom_id: 'all-services',
-                             kase: @case,
-                             children: @case.cluster.services,
-                             parent: dom_id
-                    %>
-                    <%=
-                      render 'case_associations/cluster_part',
-                             part: fake.new('Components', 'fa-cubes', 'Components'),
-                             dom_id: 'all-components',
-                             kase: @case,
-                             children: @case.cluster.component_groups,
-                             parent: dom_id
-                    %>
-                  </ul>
-                </li>
-              </ul>
+              <%=
+                render 'case_associations/cluster_tree',
+                       selected: @case.associations,
+                       cluster: @case.cluster
+              %>
             </div>
           </div>
           <button class="btn btn-link" onclick="window.scrollTo(0,0); return false;">Back to top</button>

--- a/app/views/cases/filters/_assigned_to.html.erb
+++ b/app/views/cases/filters/_assigned_to.html.erb
@@ -1,0 +1,12 @@
+<div class="form-group">
+  <label class="form-label" for="filter_assigned_to">Show cases assigned to:</label>
+  <select class="form-control" name="assigned_to[]" id="filter_assigned_to" multiple>
+    <% filters[:ranges][:assigned_to].each do |assignee| %>
+      <option value="<%= assignee.id %>" <%= filters[:active]["assigned_to"]&.include?(assignee) ? 'selected' : '' %>>
+        <%= assignee.name %>
+      </option>
+    <% end %>
+    <option value="" <%= filters[:active]["assigned_to"]&.include?(nil) ? 'selected' : '' %>>Nobody</option>
+  </select>
+</div>
+<input class="btn btn-primary btn-small" type="submit" value="Apply"/>

--- a/app/views/cases/filters/_assigned_to.html.erb
+++ b/app/views/cases/filters/_assigned_to.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <label class="form-label" for="filter_assigned_to">Show cases assigned to:</label>
-  <select class="form-control" name="assigned_to[]" id="filter_assigned_to" multiple>
+  <select class="form-control" name="assigned_to[]" id="filter_assigned_to" multiple onclick="event.stopPropagation();">
     <% filters[:ranges][:assigned_to].each do |assignee| %>
       <option value="<%= assignee.id %>" <%= filters[:active]["assigned_to"]&.include?(assignee) ? 'selected' : '' %>>
         <%= assignee.name %>
@@ -9,4 +9,3 @@
     <option value="" <%= filters[:active]["assigned_to"]&.include?(nil) ? 'selected' : '' %>>Nobody</option>
   </select>
 </div>
-<input class="btn btn-primary btn-small" type="submit" value="Apply"/>

--- a/app/views/cases/filters/_associations.html.erb
+++ b/app/views/cases/filters/_associations.html.erb
@@ -5,7 +5,7 @@
 
     <%= render 'case_associations/cluster_tree',
                cluster: cluster.decorate,
-               selected: filters[:associations] || []
+               selected: filters[:active][:associations] || []
     %>
 
   <% end %>

--- a/app/views/cases/filters/_associations.html.erb
+++ b/app/views/cases/filters/_associations.html.erb
@@ -1,6 +1,6 @@
 <% clusters = (@scope.instance_of?(Cluster)) ? [@scope] : @scope.clusters %>
 <p>Show cases affecting:</p>
-<div class="mr-5 ml-5">
+<div class="mr-2 ml-2 associations-filter">
   <% clusters.each do |cluster| %>
 
     <%= render 'case_associations/cluster_tree',

--- a/app/views/cases/filters/_associations.html.erb
+++ b/app/views/cases/filters/_associations.html.erb
@@ -1,0 +1,12 @@
+<% clusters = (@scope.instance_of?(Cluster)) ? [@scope] : @scope.clusters %>
+<p>Show cases affecting:</p>
+<div class="mr-5 ml-5">
+  <% clusters.each do |cluster| %>
+
+    <%= render 'case_associations/cluster_tree',
+               cluster: cluster.decorate,
+               selected: filters[:associations] || []
+    %>
+
+  <% end %>
+</div>

--- a/app/views/cases/filters/_filter_for.html.erb
+++ b/app/views/cases/filters/_filter_for.html.erb
@@ -9,7 +9,7 @@
   >
     <i class="fa fa-filter"></i>
   </a>
-  <div class="dropdown-menu dropdown-menu-right">
+  <div class="dropdown-menu dropdown-menu-right" data-display="static">
     <div class="px-3 py-1">
       <%= render("cases/filters/#{name}", filters: filters) %>
       <input class="btn btn-primary btn-sm" type="submit" value="Apply"/>

--- a/app/views/cases/filters/_filter_for.html.erb
+++ b/app/views/cases/filters/_filter_for.html.erb
@@ -1,5 +1,5 @@
 <div class="dropdown">
-  <%= caption %>
+  <b><%= caption %></b>
   <a
     aria-haspopup="true"
     class="filter <%= filters[:active].include?(name) ? 'filter-active' : 'filter-inactive' %>"

--- a/app/views/cases/filters/_filter_for.html.erb
+++ b/app/views/cases/filters/_filter_for.html.erb
@@ -1,12 +1,18 @@
-<a
-  class="filter <%= filters[:active].include?(name) ? 'filter-active' : 'filter-inactive' %>"
-  data-container="#filter-form"
-  data-content="<%= render("cases/filters/#{name}", filters: @filters).gsub(/\n/, '') %>"
-  data-toggle="popover"
-  data-trigger="click focus"
-  data-html="true"
-  tabindex="0"
-  title="<%= title %>"
->
-  <i class="fa fa-filter"></i>
-</a>
+<div class="dropdown">
+  <%= caption %>
+  <a
+    aria-haspopup="true"
+    class="filter <%= filters[:active].include?(name) ? 'filter-active' : 'filter-inactive' %>"
+    data-toggle="dropdown"
+    title="<%= title %>"
+    tabindex=""
+  >
+    <i class="fa fa-filter"></i>
+  </a>
+  <div class="dropdown-menu dropdown-menu-right">
+    <div class="px-3 py-1">
+      <%= render("cases/filters/#{name}", filters: @filters) %>
+      <input class="btn btn-primary btn-sm" type="submit" value="Apply"/>
+    </div>
+  </div>
+</div>

--- a/app/views/cases/filters/_filter_for.html.erb
+++ b/app/views/cases/filters/_filter_for.html.erb
@@ -11,8 +11,13 @@
   </a>
   <div class="dropdown-menu dropdown-menu-right">
     <div class="px-3 py-1">
-      <%= render("cases/filters/#{name}", filters: @filters) %>
+      <%= render("cases/filters/#{name}", filters: filters) %>
       <input class="btn btn-primary btn-sm" type="submit" value="Apply"/>
+      <%=
+        link_to 'Clear all filters',
+                @scope.decorate.scope_cases_path,
+                class: 'btn btn-danger btn-sm'
+      %>
     </div>
   </div>
 </div>

--- a/app/views/cases/filters/_filter_for.html.erb
+++ b/app/views/cases/filters/_filter_for.html.erb
@@ -1,0 +1,12 @@
+<a
+  class="filter <%= filters[:active].include?(name) ? 'filter-active' : 'filter-inactive' %>"
+  data-container="#filter-form"
+  data-content="<%= render("cases/filters/#{name}", filters: @filters).gsub(/\n/, '') %>"
+  data-toggle="popover"
+  data-trigger="click focus"
+  data-html="true"
+  tabindex="0"
+  title="<%= title %>"
+>
+  <i class="fa fa-filter"></i>
+</a>

--- a/app/views/cases/filters/_state.html.erb
+++ b/app/views/cases/filters/_state.html.erb
@@ -1,0 +1,11 @@
+<form class="form">
+  <div class="form-group">
+    <label class="form-label" for="filter_state">Show cases with state:</label>
+    <select class="form-control" name="state[]" id="filter_state" multiple>
+      <option value="open" <%= filters[:active]["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
+      <option value="resolved" <%= filters[:active]["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
+      <option value="closed" <%= filters[:active]["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
+    </select>
+  </div>
+  <input class="btn btn-primary btn-small" type="submit" value="Apply" />
+</form>

--- a/app/views/cases/filters/_state.html.erb
+++ b/app/views/cases/filters/_state.html.erb
@@ -1,11 +1,9 @@
-<form class="form">
-  <div class="form-group">
-    <label class="form-label" for="filter_state">Show cases with state:</label>
-    <select class="form-control" name="state[]" id="filter_state" multiple>
-      <option value="open" <%= filters[:active]["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
-      <option value="resolved" <%= filters[:active]["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
-      <option value="closed" <%= filters[:active]["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
-    </select>
-  </div>
-  <input class="btn btn-primary btn-small" type="submit" value="Apply" />
-</form>
+<div class="form-group">
+  <label class="form-label" for="filter_state">Show cases with state:</label>
+  <select class="form-control" name="state[]" id="filter_state" multiple>
+    <option value="open" <%= filters[:active]["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
+    <option value="resolved" <%= filters[:active]["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
+    <option value="closed" <%= filters[:active]["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
+  </select>
+</div>
+<input class="btn btn-primary btn-small" type="submit" value="Apply" />

--- a/app/views/cases/filters/_state.html.erb
+++ b/app/views/cases/filters/_state.html.erb
@@ -1,9 +1,8 @@
 <div class="form-group">
   <label class="form-label" for="filter_state">Show cases with state:</label>
-  <select class="form-control" name="state[]" id="filter_state" multiple>
+  <select class="form-control" name="state[]" id="filter_state" multiple onclick="event.stopPropagation();">
     <option value="open" <%= filters[:active]["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
     <option value="resolved" <%= filters[:active]["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
     <option value="closed" <%= filters[:active]["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
   </select>
 </div>
-<input class="btn btn-primary btn-small" type="submit" value="Apply" />

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,14 +1,13 @@
 <%
-  cases = @show_resolved ? @scope.cases.inactive : @scope.cases.active
   empty_message = "No #{@show_resolved ? 'resolved or closed' : 'open'} cases"
 %>
 <%= content_for(:subtitle) do
-  "#{cases.length} #{@show_resolved ? 'Resolved' : 'Open'}
-  #{'Case'.pluralize(cases.length)}"
+  "#{@cases.length} #{@show_resolved ? 'Resolved' : 'Open'}
+  #{'Case'.pluralize(@cases.length)}"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
   <%= render 'partials/table',
-      collection: cases,
+      collection: @cases,
       message: empty_message do %>
     <thead>
       <tr class="nowrap">
@@ -26,13 +25,13 @@ end %>
     </thead>
 
     <tbody class="assigned-cases">
-      <% cases.assigned_to(current_user).decorate.each do |c| %>
+      <% @cases.assigned_to(current_user).decorate.each do |c| %>
         <%= render 'partials/case_table_row', kase: c, scope: @scope %>
       <% end %>
     </tbody>
 
     <tbody>
-      <% cases.not_assigned_to(current_user).decorate.each do |c| %>
+      <% @cases.not_assigned_to(current_user).decorate.each do |c| %>
         <%= render 'partials/case_table_row', kase: c, scope: @scope %>
       <% end %>
     </tbody>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -7,9 +7,9 @@
     <div class="form-group">
       <label class="form-label" for="filter_state">Show cases with state:</label>
       <select class="form-control" name="state[]" id="filter_state" multiple>
-        <option value="open" <%= @filters["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
-        <option value="resolved" <%= @filters["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
-        <option value="closed" <%= @filters["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
+        <option value="open" <%= @filters[:active]["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
+        <option value="resolved" <%= @filters[:active]["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
+        <option value="closed" <%= @filters[:active]["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
       </select>
     </div>
     <input class="btn btn-primary btn-small" type="submit" value="Apply" />
@@ -30,7 +30,7 @@ end %>
         <th>
           State
           <a
-            class="filter <%= @filters.include?('state') ? 'filter-active' : '' %>"
+            class="filter <%= @filters[:active].include?('state') ? 'filter-active' : '' %>"
             data-content="<%= content_for(:state_filter).gsub(/\n/, '') %>"
             data-toggle="popover"
             data-trigger="click focus"

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -6,46 +6,62 @@
   "Showing #{@cases.length} #{'case'.pluralize(@cases.length)}"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
-  <%= render 'partials/table',
-      collection: @cases,
-      message: empty_message do %>
-    <thead>
-      <tr class="nowrap">
-        <th>ID</th>
-        <th>Date</th>
-        <th>
-          State
-          <a
-            class="filter <%= @filters[:active].include?('state') ? 'filter-active' : 'filter-inactive' %>"
-            data-content="<%= render('cases/filters/state', filters: @filters).gsub(/\n/, '') %>"
-            data-toggle="popover"
-            data-trigger="click focus"
-            data-html="true"
-            tabindex="0"
-            title="Filter by case state"
-          >
-            <i class="fa fa-filter"></i>
-          </a>
-        </th>
-        <th>Creator</th>
-        <th>Subject</th>
-        <th>Assigned to</th>
-        <th>Affected components</th>
-        <th>Credit usage</th>
-      </tr>
-    </thead>
+  <form class="form" id="filter-form">
+    <%= render 'partials/table',
+        collection: @cases,
+        message: empty_message do %>
+      <thead>
+        <tr class="nowrap">
+          <th>ID</th>
+          <th>Date</th>
+          <th>
+            State
+            <a
+              class="filter <%= @filters[:active].include?('state') ? 'filter-active' : 'filter-inactive' %>"
+              data-container="#filter-form"
+              data-content="<%= render('cases/filters/state', filters: @filters).gsub(/\n/, '') %>"
+              data-toggle="popover"
+              data-trigger="click focus"
+              data-html="true"
+              tabindex="0"
+              title="Filter by case state"
+            >
+              <i class="fa fa-filter"></i>
+            </a>
+          </th>
+          <th>Creator</th>
+          <th>Subject</th>
+          <th>
+            Assigned to
+            <a
+              class="filter <%= @filters[:active].include?('assigned_to') ? 'filter-active' : 'filter-inactive' %>"
+              data-container="#filter-form"
+              data-content="<%= render('cases/filters/assigned_to', filters: @filters).gsub(/\n/, '') %>"
+              data-toggle="popover"
+              data-trigger="click focus"
+              data-html="true"
+              tabindex="0"
+              title="Filter by assignee"
+            >
+              <i class="fa fa-filter"></i>
+            </a></th>
+          <th>Affected components</th>
+          <th>Credit usage</th>
+        </tr>
+      </thead>
 
-    <tbody class="assigned-cases">
-      <% @cases.assigned_to(current_user).decorate.each do |c| %>
-        <%= render 'partials/case_table_row', kase: c, scope: @scope %>
-      <% end %>
-    </tbody>
+      <tbody class="assigned-cases">
+        <% @cases.assigned_to(current_user).decorate.each do |c| %>
+          <%= render 'partials/case_table_row', kase: c, scope: @scope %>
+        <% end %>
+      </tbody>
 
-    <tbody>
-      <% @cases.not_assigned_to(current_user).decorate.each do |c| %>
-        <%= render 'partials/case_table_row', kase: c, scope: @scope %>
-      <% end %>
-    </tbody>
-  <% end %>
+      <tbody>
+        <% @cases.not_assigned_to(current_user).decorate.each do |c| %>
+          <%= render 'partials/case_table_row', kase: c, scope: @scope %>
+        <% end %>
+      </tbody>
+    <% end %>
+  </form>
 <% end %>
 

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -23,7 +23,9 @@ end %>
           <th>
             <%= render 'cases/filters/filter_for', caption: 'Assigned to', name: 'assigned_to', filters: @filters, title: 'Filter by assignee' %>
           </th>
-          <th>Affected components</th>
+          <th>
+            <%= render 'cases/filters/filter_for', caption: 'Affected components', name: 'associations', filters: @filters, title: 'Filter by component' %>
+          </th>
           <th>Credit usage</th>
         </tr>
       </thead>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -30,7 +30,7 @@ end %>
         <th>
           State
           <a
-            class="filter <%= @filters[:active].include?('state') ? 'filter-active' : '' %>"
+            class="filter <%= @filters[:active].include?('state') ? 'filter-active' : 'filter-inactive' %>"
             data-content="<%= content_for(:state_filter).gsub(/\n/, '') %>"
             data-toggle="popover"
             data-trigger="click focus"

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,6 +1,21 @@
 <%
   empty_message = 'No cases match the criteria you have specified.'
 %>
+
+<%= content_for(:state_filter) do %>
+  <form class="form">
+    <div class="form-group">
+      <label class="form-label" for="filter_state">Show cases with state:</label>
+      <select class="form-control" name="state[]" id="filter_state" multiple>
+        <option value="open" <%= @filters["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
+        <option value="resolved" <%= @filters["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
+        <option value="closed" <%= @filters["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
+      </select>
+    </div>
+    <input class="btn btn-primary btn-small" type="submit" value="Apply" />
+  </form>
+<% end %>
+
 <%= content_for(:subtitle) do
   "Showing #{@cases.length} #{'case'.pluralize(@cases.length)}"
 end %>
@@ -12,7 +27,20 @@ end %>
       <tr class="nowrap">
         <th>ID</th>
         <th>Date</th>
-        <th>State</th>
+        <th>
+          State
+          <a
+            class="filter <%= @filters.include?('state') ? 'filter-active' : '' %>"
+            data-content="<%= content_for(:state_filter).gsub(/\n/, '') %>"
+            data-toggle="popover"
+            data-trigger="click focus"
+            data-html="true"
+            tabindex="0"
+            title="Filter by case state"
+          >
+            <i class="fa fa-filter"></i>
+          </a>
+        </th>
         <th>Creator</th>
         <th>Subject</th>
         <th>Assigned to</th>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -9,20 +9,19 @@ end %>
   <form class="form" id="filter-form">
     <%= render 'partials/table',
         collection: @cases,
-        message: empty_message do %>
+        message: empty_message,
+        responsive: false do %>
       <thead>
         <tr class="nowrap">
           <th>ID</th>
           <th>Date</th>
           <th>
-            State
-            <%= render 'cases/filters/filter_for', name: 'state', filters: @filters, title: 'Filter by case state' %>
+            <%= render 'cases/filters/filter_for', caption: 'State', name: 'state', filters: @filters, title: 'Filter by case state' %>
           </th>
           <th>Creator</th>
           <th>Subject</th>
           <th>
-            Assigned to
-            <%= render 'cases/filters/filter_for', name: 'assigned_to', filters: @filters, title: 'Filter by assignee' %>
+            <%= render 'cases/filters/filter_for', caption: 'Assigned to', name: 'assigned_to', filters: @filters, title: 'Filter by assignee' %>
           </th>
           <th>Affected components</th>
           <th>Credit usage</th>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,9 +1,8 @@
 <%
-  empty_message = "No #{@show_resolved ? 'resolved or closed' : 'open'} cases"
+  empty_message = 'No cases match the criteria you have specified.'
 %>
 <%= content_for(:subtitle) do
-  "#{@cases.length} #{@show_resolved ? 'Resolved' : 'Open'}
-  #{'Case'.pluralize(@cases.length)}"
+  "Showing #{@cases.length} #{'case'.pluralize(@cases.length)}"
 end %>
 <%= render 'partials/tabs', activate: :cases do %>
   <%= render 'partials/table',
@@ -18,9 +17,7 @@ end %>
         <th>Subject</th>
         <th>Assigned to</th>
         <th>Affected components</th>
-        <% if @show_resolved %>
-          <th>Credit usage</th>
-        <% end %>
+        <th>Credit usage</th>
       </tr>
     </thead>
 

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -2,20 +2,6 @@
   empty_message = 'No cases match the criteria you have specified.'
 %>
 
-<%= content_for(:state_filter) do %>
-  <form class="form">
-    <div class="form-group">
-      <label class="form-label" for="filter_state">Show cases with state:</label>
-      <select class="form-control" name="state[]" id="filter_state" multiple>
-        <option value="open" <%= @filters[:active]["state"]&.include?('open') ? 'selected' : '' %>>Open</option>
-        <option value="resolved" <%= @filters[:active]["state"]&.include?('resolved') ? 'selected' : '' %>>Resolved</option>
-        <option value="closed" <%= @filters[:active]["state"]&.include?('closed') ? 'selected' : '' %>>Closed</option>
-      </select>
-    </div>
-    <input class="btn btn-primary btn-small" type="submit" value="Apply" />
-  </form>
-<% end %>
-
 <%= content_for(:subtitle) do
   "Showing #{@cases.length} #{'case'.pluralize(@cases.length)}"
 end %>
@@ -31,7 +17,7 @@ end %>
           State
           <a
             class="filter <%= @filters[:active].include?('state') ? 'filter-active' : 'filter-inactive' %>"
-            data-content="<%= content_for(:state_filter).gsub(/\n/, '') %>"
+            data-content="<%= render('cases/filters/state', filters: @filters).gsub(/\n/, '') %>"
             data-toggle="popover"
             data-trigger="click focus"
             data-html="true"

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -16,35 +16,14 @@ end %>
           <th>Date</th>
           <th>
             State
-            <a
-              class="filter <%= @filters[:active].include?('state') ? 'filter-active' : 'filter-inactive' %>"
-              data-container="#filter-form"
-              data-content="<%= render('cases/filters/state', filters: @filters).gsub(/\n/, '') %>"
-              data-toggle="popover"
-              data-trigger="click focus"
-              data-html="true"
-              tabindex="0"
-              title="Filter by case state"
-            >
-              <i class="fa fa-filter"></i>
-            </a>
+            <%= render 'cases/filters/filter_for', name: 'state', filters: @filters, title: 'Filter by case state' %>
           </th>
           <th>Creator</th>
           <th>Subject</th>
           <th>
             Assigned to
-            <a
-              class="filter <%= @filters[:active].include?('assigned_to') ? 'filter-active' : 'filter-inactive' %>"
-              data-container="#filter-form"
-              data-content="<%= render('cases/filters/assigned_to', filters: @filters).gsub(/\n/, '') %>"
-              data-toggle="popover"
-              data-trigger="click focus"
-              data-html="true"
-              tabindex="0"
-              title="Filter by assignee"
-            >
-              <i class="fa fa-filter"></i>
-            </a></th>
+            <%= render 'cases/filters/filter_for', name: 'assigned_to', filters: @filters, title: 'Filter by assignee' %>
+          </th>
           <th>Affected components</th>
           <th>Credit usage</th>
         </tr>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -23,7 +23,5 @@
       <%= render 'partials/association_summary', associations: kase.associations %>
     <% end %>
   </td>
-  <% if kase.resolved? || kase.closed? %>
-    <td><%= render 'partials/table_cell_link', url: url, cell_content: kase.credit_charge&.amount %></td>
-  <% end %>
+  <td><%= render 'partials/table_cell_link', url: url, cell_content: kase.credit_charge&.amount %></td>
 </tr>

--- a/app/views/partials/_table.html.erb
+++ b/app/views/partials/_table.html.erb
@@ -1,9 +1,8 @@
+<div class='table-responsive'>
+  <table class="table">
+    <%= yield %>
+  </table>
+</div>
 <% if collection.empty? %>
-  <div style="text-align: center"><em><%= message %></em></div>
-<% else %>
-  <div class='table-responsive'>
-    <table class="table">
-      <%= yield %>
-    </table>
-  </div>
+  <p class="text-center"><em><%= message %></em></p>
 <% end %>

--- a/app/views/partials/_table.html.erb
+++ b/app/views/partials/_table.html.erb
@@ -1,6 +1,4 @@
-<% is_responsive = local_assigns.fetch(:responsive, true)
-p local_assigns
-%>
+<% is_responsive = local_assigns.fetch(:responsive, true) %>
 
 <div class='table<%= is_responsive ? '-responsive' : '' %>'>
   <table class="table">

--- a/app/views/partials/_table.html.erb
+++ b/app/views/partials/_table.html.erb
@@ -1,4 +1,8 @@
-<div class='table-responsive'>
+<% is_responsive = local_assigns.fetch(:responsive, true)
+p local_assigns
+%>
+
+<div class='table<%= is_responsive ? '-responsive' : '' %>'>
   <table class="table">
     <%= yield %>
   </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,10 +69,7 @@ Rails.application.routes.draw do
   cases = Proc.new do |**params, &block|
     params[:only] = Array.wrap(params[:only]).concat [:index]
     resources :cases, **params do
-      collection do
-        get :resolved
-      end
-      block.call if block
+      block&.call
     end
   end
 

--- a/spec/features/case/index_spec.rb
+++ b/spec/features/case/index_spec.rb
@@ -81,4 +81,64 @@ RSpec.describe 'Cases table', type: :feature do
       include_examples 'open cases table rendered'
     end
   end
+
+  describe 'filtering' do
+    let(:component1) { create(:component, cluster: cluster) }
+    let(:component2) { create(:component, cluster: cluster) }
+
+    let!(:component_case_1) {
+      create(
+        :open_case,
+        cluster: cluster,
+        components: [component1],
+        subject: 'CC1',
+        assignee: admin
+      )
+    }
+    let!(:component_case_2) {
+      create(
+        :open_case,
+        cluster: cluster,
+        components: [component2],
+        subject: 'CC2',
+        assignee: admin
+      )
+    }
+    let!(:component_case_3) {
+      create(
+        :open_case,
+        cluster: cluster,
+        components: [component1],
+        subject: 'CC3'
+      )
+    }
+
+    it 'filters by assignee' do
+      visit cases_path(assigned_to: [admin], as: contact)
+      cases = all('tr').map(&:text)
+      expect(cases).to have_text('CC1')
+      expect(cases).to have_text('CC2')
+      expect(cases).not_to have_text('CC3')
+    end
+
+    it 'filters by association' do
+      visit cases_path(associations: ["Component-#{component1.id}"], as: contact)
+      cases = all('tr').map(&:text)
+      expect(cases).to have_text('CC1')
+      expect(cases).not_to have_text('CC2')
+      expect(cases).to have_text('CC3')
+    end
+
+    it 'works with multiple active filters' do
+      visit cases_path(
+        assigned_to: [admin],
+        associations: ["Component-#{component1.id}"],
+        as: contact
+      )
+      cases = all('tr').map(&:text)
+      expect(cases).to have_text('CC1')
+      expect(cases).not_to have_text('CC2')
+      expect(cases).not_to have_text('CC3')
+    end
+  end
 end

--- a/spec/features/case/index_spec.rb
+++ b/spec/features/case/index_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Cases table', type: :feature do
     let(:user) { contact }
 
     context 'when visit site cases dashboard' do
-      let(:path) { cases_path(as: user) }
+      let(:path) { cases_path(state: 'open', as: user) }
 
       include_examples 'open cases table rendered'
     end
@@ -74,7 +74,7 @@ RSpec.describe 'Cases table', type: :feature do
     let(:user) { admin }
 
     context 'when visit site cases dashboard' do
-      let(:path) { site_cases_path(site, as: user) }
+      let(:path) { site_cases_path(site, state: 'open', as: user) }
 
       # At least for now, want to render open Cases table on Site dashboard the
       # same for both admins as contacts.

--- a/spec/features/case/index_spec.rb
+++ b/spec/features/case/index_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe 'Cases table', type: :feature do
       include_examples 'open cases table rendered'
     end
 
-    context 'when visit archive cases page' do
-      it 'renders table of all resolved or closed Cases' do
-        visit resolved_cases_path(as: user)
+    context 'when applying state filter to cases page' do
+      it 'renders table of all cases with given states' do
+        visit cases_path(state: %w(resolved closed), as: user)
 
         cases = all('tr').map(&:text)
         expect(cases).not_to have_text('Open case')

--- a/spec/helpers/tabs_builder_spec.rb
+++ b/spec/helpers/tabs_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TabsBuilder do
         let(:user) { build_stubbed(:admin) }
 
         it 'contains a link to the site cases' do
-          expect(subject).to include(site_cases_path(scope))
+          expect(subject).to include(site_cases_path(scope, state: 'open'))
         end
 
         it 'includes a link to the new case page for the site' do
@@ -28,7 +28,7 @@ RSpec.describe TabsBuilder do
         let(:user) { build_stubbed(:contact) }
 
         it 'contains a link to the cases page' do
-          expect(subject).to include(cases_path)
+          expect(subject).to include(cases_path(state: 'open'))
         end
 
         it 'includes a link to the new case page' do


### PR DESCRIPTION
This PR adds the ability to filter the cases index page by state, assignee or association. It also replaces the separate `/resolved` cases index page with an appropriate filter query.

Filters are combined with `and`. Individual filter options are combined with `or`. For example: 

```
(assigned_to Ruan OR Andrew) 
AND 
(state Resolved OR Closed)
```

We reuse the cluster tree component to filter by component/service associations. For admins on the "all cases for all sites" page, this can also be used to filter by cluster (though at some point we'll run into URL length limit problems, since its method of doing so is by setting a filter for each cluster component - but it works for now).

Trello: https://trello.com/c/5XYwNUyb/368-add-filters-to-case-index-page

(Sidebar: the Trello card suggested that "site" was a possible value to filter by. However, we don't display site in the case table, and it's already possible to filter by site by going to the specific site's case index, so that hasn't been done with this work.)