### PR TITLE
Use correct Rails incantation to validate that CR charge >= 0.

### DIFF
--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -29,8 +29,8 @@ class ChangeRequest < ApplicationRecord
   validates :credit_charge,
             presence: true,
             numericality: {
-                only_integer: true,
-                minimum: 0
+              only_integer: true,
+              greater_than_or_equal_to: 0,
             }
 
   validates :description, presence: true

--- a/spec/models/change_request_spec.rb
+++ b/spec/models/change_request_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe ChangeRequest, type: :model do
     end
   end
 
+  it do
+    is_expected.to validate_numericality_of(:credit_charge)
+      .only_integer
+      .is_greater_than_or_equal_to(0)
+  end
+
 end


### PR DESCRIPTION
Fixes #414.