### PR TITLE
Remove local passwords for users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,4 +97,8 @@ class User < ApplicationRecord
   def site_primary_contact
     @site_primary_contact ||= site&.primary_contact
   end
+
+  def password_optional?
+    true  # since we use SSO for passwords
+  end
 end

--- a/db/migrate/20180719092649_remove_passwords_from_users.rb
+++ b/db/migrate/20180719092649_remove_passwords_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordsFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :encrypted_password, :string, limit: 128, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_10_181058) do
+ActiveRecord::Schema.define(version: 2018_07_19_092649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -406,7 +406,6 @@ ActiveRecord::Schema.define(version: 2018_07_10_181058) do
     t.datetime "updated_at", null: false
     t.string "name", null: false
     t.string "email", null: false
-    t.string "encrypted_password", limit: 128, null: false
     t.string "remember_token", limit: 128, null: false
     t.integer "site_id"
     t.string "confirmation_token", limit: 128

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -28,7 +28,7 @@ namespace :alces do
       User.all.each do |user|
         local_part = user.email.split('@').first
         new_email =  "#{local_part}@example.com"
-        user.update!(email: new_email, password: 'password')
+        user.update!(email: new_email)
       end
     end
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -33,12 +33,10 @@ namespace :alces do
 
     namespace :staging do
       task obfuscate_users: :environment do
-        staging_password = Deployment::Staging.password
-
         User.where.not(role: :admin).each do |user|
           local_part = user.email.split('@').first
           new_email = "center+#{local_part}@alces-software.com"
-          user.update!(email: new_email, password: staging_password)
+          user.update!(email: new_email)
         end
       end
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     site
     name 'A Scientist'
     email
-    password 'definitely_encrypted'
     role :secondary_contact
 
     factory :viewer do

--- a/spec/lib/tasks/deploy_spec.rb
+++ b/spec/lib/tasks/deploy_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe 'alces:deploy:staging:obfuscate_users' do
     create(:admin, name: 'Some Admin', email: 'some.admin@example.com')
   end
 
-  before :each do
-    ENV['STAGING_PASSWORD'] = staging_password
-  end
-
-  let(:staging_password) { 'password123' }
-
   it_behaves_like 'it has prerequisite', :environment
 
   it 'changes contacts to have `center+${local_part}@alces-software.com` emails' do
@@ -25,25 +19,8 @@ RSpec.describe 'alces:deploy:staging:obfuscate_users' do
     expect(contact.reload.email).to eq 'center+some.contact.email@alces-software.com'
   end
 
-  it 'sets contact passwords to STAGING_PASSWORD environment variable' do
-    subject.invoke
-
-    new_email = contact.reload.email
-    expect(
-      User.authenticate(new_email, staging_password)
-    ).to eq(contact)
-  end
-
-  it 'aborts and does not change anything if STAGING_PASSWORD not set' do
-    ENV.delete('STAGING_PASSWORD')
-
-    expect do
-      subject.invoke
-    end.to raise_error(/STAGING_PASSWORD environment variable must be set/)
-  end
-
   it 'does not change admins' do
-    admin.reload # So `updated_at` not at presision finer than database will save.
+    admin.reload # So `updated_at` not at precision finer than database will save.
     original_email = admin.email
     orinal_updated_at = admin.updated_at
 


### PR DESCRIPTION
This PR removes the requirement for users to have local passwords set. These passwords are no longer used since we have adopted Flight SSO.

It also removes the step of changing passwords on staging, for the same reason. (Changing of email addresses still happens.)

Fixes #436.

Trello: https://trello.com/c/Xx2Q2o4f/387-remove-local-password-requirement-for-users