### PR TITLE
Don't initialise `collapse`s on page transition.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,10 +26,5 @@ function enablePopovers() {
   $('[data-toggle="popover"]').popover();
 }
 
-function enableCollapses() {
-  $('.collapse').collapse();
-}
-
 document.addEventListener('turbolinks:load', enableTooltips);
 document.addEventListener('turbolinks:load', enablePopovers);
-document.addEventListener('turbolinks:load', enableCollapses);


### PR DESCRIPTION
We don't need to initialise the Bootstrap `Collapse`s used by the cluster tree, since they are initialised individually by the `_init_cluster_tree` function. Doing so was interacting badly with the Flight chrome navbar which also uses a `.collapse`.

Fixes #449.