### PR TITLE
Use case resolution date for credit reporting

### DIFF
--- a/app/decorators/credit_charge_decorator.rb
+++ b/app/decorators/credit_charge_decorator.rb
@@ -6,16 +6,16 @@ class CreditChargeDecorator < ApplicationDecorator
     link_text = "#{kase.display_id} - #{kase.subject}"
 
     h.render 'clusters/credit_charge_entry',
-             amount: -object.amount,
-             date: object.created_at do
-      h.link_to link_text, h.case_path(kase), class: h.credit_value_class(-object.amount)
+             amount: -amount,
+             date: effective_date do
+      h.link_to link_text, h.case_path(kase), class: h.credit_value_class(-amount)
     end
   end
 
   def event_card
     h.render 'cases/event',
              admin_only: false,
-             date: created_at,
+             date: effective_date,
              name: user.name,
              text:  "A charge of #{h.pluralize(amount, 'credit')} was added for this case.",
              type: 'usd',

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -326,6 +326,13 @@ class Case < ApplicationRecord
     change_request.present? && !change_request.finalised?
   end
 
+  def resolution_date
+    # NB This assumes that each case will only ever be resolved once
+    # If we decide to allow reopening cases then we'll want this to be e.g.
+    # transitions.where(event: 'resolve').last
+    transitions.find_by_event('resolve')&.created_at
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/credit_charge.rb
+++ b/app/models/credit_charge.rb
@@ -7,4 +7,19 @@ class CreditCharge < CreditEvent
     greater_than_or_equal_to: 0,
     only_integer: true,
   }
+
+  validates :effective_date, presence: true
+
+  before_save :set_effective_date
+
+  private
+
+  def set_effective_date
+    return if effective_date
+
+    self.effective_date =
+      self.case.resolution_date ||
+      self.case.completed_at ||
+      self.case.created_at
+  end
 end

--- a/app/models/credit_charge.rb
+++ b/app/models/credit_charge.rb
@@ -1,25 +1,31 @@
 class CreditCharge < CreditEvent
   belongs_to :case
   delegate :site, to: :case
-  attr_readonly :case
+  attr_readonly :case, :effective_date
 
   validates :amount, numericality: {
     greater_than_or_equal_to: 0,
     only_integer: true,
   }
 
-  validates :effective_date, presence: true
+  validates :effective_date, presence: true, if: :persisted?
 
   before_save :set_effective_date
+
+
+  scope :in_period, lambda { |start_date, end_date|
+    where(effective_date: start_date..end_date)
+  }
 
   private
 
   def set_effective_date
     return if effective_date
 
-    self.effective_date =
+    self.effective_date = Time.zone.local_to_utc(
       self.case.resolution_date ||
       self.case.completed_at ||
       self.case.created_at
+    )
   end
 end

--- a/app/models/credit_deposit.rb
+++ b/app/models/credit_deposit.rb
@@ -7,4 +7,10 @@ class CreditDeposit < CreditEvent
     greater_than_or_equal_to: 1,
     only_integer: true,
   }
+
+  # When we add `effective_date`s to deposits, this and the equivalent method in
+  # CreditCharge can be pulled up into CreditEvent
+  scope :in_period, lambda { |start_date, end_date|
+    where(created_at: start_date..end_date)
+  }
 end

--- a/app/models/credit_event.rb
+++ b/app/models/credit_event.rb
@@ -11,7 +11,4 @@ class CreditEvent < ApplicationRecord
 
   attr_readonly :user, :amount
 
-  scope :in_period, lambda { |start_date, end_date|
-    where(created_at: start_date..end_date)
-  }
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,6 +1,9 @@
 
 Time::DATE_FORMATS[:long] = lambda do |time|
-  time.strftime("%A #{time.day.ordinalize} %B, %Y, %H:%M%P")
+  time.strftime("%A, #{time.day.ordinalize} %B %Y, %H:%M%P")
+end
+Date::DATE_FORMATS[:long] = lambda do |time|
+  time.strftime("%A, #{time.day.ordinalize} %B %Y")
 end
 
 Time::DATE_FORMATS[:short] = "%a %d %b %H:%M"

--- a/db/data/20180724162117_add_effective_dates_to_credit_charges.rb
+++ b/db/data/20180724162117_add_effective_dates_to_credit_charges.rb
@@ -1,0 +1,12 @@
+class AddEffectiveDatesToCreditCharges < ActiveRecord::Migration[5.2]
+  def up
+    CreditCharge.all.each do |cc|
+      cc.send(:set_effective_date)
+      cc.save!
+    end
+  end
+
+  def down
+    # pass
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180716101913)
+DataMigrate::Data.define(version: 20180724162117)

--- a/db/migrate/20180724142635_add_effective_date_to_credit_charge.rb
+++ b/db/migrate/20180724142635_add_effective_date_to_credit_charge.rb
@@ -1,0 +1,5 @@
+class AddEffectiveDateToCreditCharge < ActiveRecord::Migration[5.2]
+  def change
+    add_column :credit_charges, :effective_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_19_092649) do
+ActiveRecord::Schema.define(version: 2018_07_24_142635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 2018_07_19_092649) do
     t.bigint "case_id", null: false
     t.bigint "user_id", null: false
     t.integer "amount", null: false
+    t.date "effective_date"
     t.index ["case_id"], name: "index_credit_charges_on_case_id"
     t.index ["user_id"], name: "index_credit_charges_on_user_id"
   end


### PR DESCRIPTION
This PR adds an `effective_date` to the `CreditCharge`s associated with cases, which is set to the date of resolution of the associated `Case` at the point the `CreditCharge` is created.

For cases with no resolution date (e.g. old cases that were resolved before we started tracking state in Flight Center) the RT-derived `completed_at` date is used, and failing that, the `created_at` date of the case. This is consistent with [the logic we used to update these dates at the last release](https://github.com/alces-software/alces-flight-center/blob/master/db/data/20180703094017_adjust_credit_charge_creation_dates.rb).

We then use the `effective_date` to filter and display `CreditCharge`s for a `Cluster`.

Fixes #388.

Trello: https://trello.com/c/fCQDbGtv/391-credit-reporting-should-use-date-of-case-resolution-not-of-case-closing