### PR TITLE
Drop "am/pm" suffix from 24-hour times.

### DIFF
--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,6 +1,6 @@
 
 Time::DATE_FORMATS[:long] = lambda do |time|
-  time.strftime("%A, #{time.day.ordinalize} %B %Y, %H:%M%P")
+  time.strftime("%A, #{time.day.ordinalize} %B %Y, %H:%M")
 end
 Date::DATE_FORMATS[:long] = lambda do |time|
   time.strftime("%A, #{time.day.ordinalize} %B %Y")


### PR DESCRIPTION
Fixes #372.