### PR TITLE
Remove unneeded MOTD presence validation

### DIFF
--- a/app/javascript/Cluster.elm
+++ b/app/javascript/Cluster.elm
@@ -47,13 +47,16 @@ type Id
 
 decoder : D.Decoder Cluster
 decoder =
-    D.field "motd" D.string
+    D.field "motd" (D.nullable D.string)
         |> D.andThen decodeWithMotd
 
 
-decodeWithMotd : String -> D.Decoder Cluster
-decodeWithMotd motd =
+decodeWithMotd : Maybe String -> D.Decoder Cluster
+decodeWithMotd maybeMotd =
     let
+        motd =
+            Maybe.withDefault "" maybeMotd
+
         serviceDecoder =
             Service.decoder motd
     in

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -36,7 +36,6 @@ class Cluster < ApplicationRecord
   validates :canonical_name, presence: true
   validate :validate_all_cluster_parts_advice, if: :advice?
   validates :shortcode, presence: true, uniqueness: true
-  validates_presence_of :motd
 
   before_validation CanonicalNameCreator.new, on: :create
 

--- a/spec/factories/cluster.rb
+++ b/spec/factories/cluster.rb
@@ -10,7 +10,6 @@ FactoryBot.define do
     name 'Hamilton Research Computing Cluster'
     support_type :managed
     shortcode
-    motd 'My MOTD'
 
     factory :managed_cluster do
       support_type :managed

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Cluster, type: :model do
   describe '#valid?' do
     subject { create(:cluster) }
 
-    it { is_expected.to validate_presence_of(:motd) }
-
     context 'when managed cluster' do
       subject do
         create(:managed_cluster)


### PR DESCRIPTION
This was added in
https://github.com/alces-software/alces-flight-center/commit/1c192659,
however prior to being added several Clusters were created with empty
MOTDs. This was then causing these Clusters to be invalid, which in turn
was causing submitting the new Case form for these Clusters to fail.

Since:

a. things have otherwise been working fine with blank Cluster MOTDs
until this validation was added;

b. from a business perspective, Clusters are allowed to not have MOTDs,
since these Clusters were created without a MOTD set,

we have decided to remove this validation.

Also removed this field from the Cluster factory, since this is no
longer required to create a minimal Cluster, which then prompted the
need to handle the case where the MOTD is null in the new Case form (by
these tests failing).

More discussion: https://alces.slack.com/archives/C72GT476Y/p1532949789000171.

Trello: https://trello.com/c/c6CgMcok/412-remove-unneeded-motd-presence-validation.