### PR TITLE
'Other' Service and Issues

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -50,7 +50,7 @@ class CasesController < ApplicationController
     @case = Case.new(my_params.merge(user: current_user))
     authorize @case
 
-    if service_id.present? && service_id.positive?
+    if service_id.present? && service_id.to_i.positive?
       @case.services << Service.find(service_id)
     end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -50,7 +50,8 @@ class CasesController < ApplicationController
     @case = Case.new(my_params.merge(user: current_user))
     authorize @case
 
-    if service_id.present? && service_id.to_i.positive?
+    not_injected_service = service_id&.to_i&.positive?
+    if service_id.present? && not_injected_service
       @case.services << Service.find(service_id)
     end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -50,7 +50,7 @@ class CasesController < ApplicationController
     @case = Case.new(my_params.merge(user: current_user))
     authorize @case
 
-    if service_id.present?
+    if service_id.present? && service_id.positive?
       @case.services << Service.find(service_id)
     end
 

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -40,6 +40,9 @@ class ClusterDecorator < ApplicationDecorator
       name: name,
       components: components.map(&:case_form_json),
       services: services.map(&:case_form_json).tap { |services|
+        # We inject an 'Other' Service, to allow Users to create Issues they do
+        # not think are associated to any existing Service via the usual Case
+        # form drill-down process.
         services << other_service_json if other_service_json
       },
       supportType: support_type,

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -40,7 +40,7 @@ class ClusterDecorator < ApplicationDecorator
       name: name,
       components: components.map(&:case_form_json),
       services: services.map(&:case_form_json).tap { |services|
-        services << other_service_json
+        services << other_service_json if other_service_json
       },
       supportType: support_type,
       chargingInfo: charging_info,
@@ -112,7 +112,8 @@ class ClusterDecorator < ApplicationDecorator
   end
 
   def other_service_json
-    {
+    return unless IssuesJsonBuilder.other_service_issues.present?
+    @other_service_json ||= {
       id: -1,
       name: 'Other / N/A',
       supportType: 'managed'
@@ -122,8 +123,12 @@ class ClusterDecorator < ApplicationDecorator
   class IssuesJsonBuilder < ServiceDecorator::IssuesJsonBuilder
     private
 
-    def applicable_issues
+    def self.other_service_issues
       Issue.where(requires_component: false, requires_service: false).decorate.reject(&:special?)
+    end
+
+    def applicable_issues
+      self.class.other_service_issues
     end
   end
 

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -116,11 +116,20 @@ class ClusterDecorator < ApplicationDecorator
 
   def other_service_json
     return unless IssuesJsonBuilder.other_service_issues.present?
-    @other_service_json ||= {
+    @other_service_json ||=
+      other_service
+      .decorate
+      .case_form_json
+      .merge(IssuesJsonBuilder.build_for(self))
+  end
+
+  def other_service
+    Service.new(
       id: -1,
       name: 'Other or N/A',
-      supportType: 'managed'
-    }.merge(IssuesJsonBuilder.build_for(self))
+      support_type: 'managed',
+      service_type: ServiceType.new
+    )
   end
 
   class IssuesJsonBuilder < ServiceDecorator::IssuesJsonBuilder

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -115,7 +115,7 @@ class ClusterDecorator < ApplicationDecorator
     return unless IssuesJsonBuilder.other_service_issues.present?
     @other_service_json ||= {
       id: -1,
-      name: 'Other / N/A',
+      name: 'Other or N/A',
       supportType: 'managed'
     }.merge(IssuesJsonBuilder.build_for(self))
   end

--- a/db/data/20180727161526_create_other_issues.rb
+++ b/db/data/20180727161526_create_other_issues.rb
@@ -1,0 +1,24 @@
+class CreateOtherIssues < ActiveRecord::Migration[5.2]
+  def up
+    # We create 2 'Other' Services, both requiring and not requiring a Service.
+    # This serves two purposes:
+    #
+    # - practical purpose: it is simpler to make this simple data change,
+    # rather than the alternative approach, which would be to add the ability
+    # for an Issue to optionally require a Service, and handle this throughout
+    # Flight Center from now on;
+    #
+    # - domain model purpose: conceptually these can also be considered
+    # slightly different things, since when a User selects the former they have
+    # classified their problem as related to a specific Service, and decided it
+    # can't be classified as an available Issue, whereas the latter means they
+    # have instead classified their problem as not related to any available
+    # Service.
+    Issue.create!(name: 'Other', requires_service: true)
+    Issue.create!(name: 'Other', requires_service: false)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180725154347)
+DataMigrate::Data.define(version: 20180727161526)

--- a/spec/decorators/cluster_decorator_spec.rb
+++ b/spec/decorators/cluster_decorator_spec.rb
@@ -25,23 +25,60 @@ RSpec.describe ClusterDecorator do
       ).tap do |cluster|
         cluster.components = [create(:component, cluster: cluster)]
         cluster.services = [create(:service, cluster: cluster)]
-        cluster.cases = [
-          create(:case)
-        ]
       end.decorate
     end
 
+    let :standard_expected_services_json do
+      subject.services.map(&:case_form_json)
+    end
+
     it 'gives correct JSON' do
-      expect(subject.case_form_json).to eq(
+      expect(subject.case_form_json).to match(
         id: 1,
         name: 'Some Cluster',
         components: subject.components.map(&:case_form_json),
-        services: subject.services.map(&:case_form_json),
+        services: array_including(standard_expected_services_json),
         supportType: 'managed',
         chargingInfo: '£1000',
         motd: 'Some MOTD',
         motdHtml: h.simple_format('Some MOTD')
       )
+    end
+
+    context 'when issue with `requires_service: false` exists' do
+      let! :issue do
+        create(:issue, requires_service: false, name: 'Other')
+      end
+
+      it "includes additional injected 'Other' Service" do
+        injected_service_id = -1
+
+        result = subject.case_form_json
+        services = result[:services]
+
+        expect(services).to match(
+          array_including(
+            hash_including({
+              id: injected_service_id,
+              name: 'Other / N/A',
+              supportType: 'managed',
+            })
+          )
+        )
+        injected_service = services.find {|s| s[:id] == injected_service_id}
+        expect(injected_service[:issues]).to match(
+          array_including(issue.decorate.case_form_json)
+        )
+      end
+    end
+
+    context 'when issue with `requires_service: false` does not exist' do
+      it 'does not include additional injected Service' do
+        result = subject.case_form_json
+        services = result[:services]
+
+        expect(services).to eq(standard_expected_services_json)
+      end
     end
   end
 end

--- a/spec/decorators/cluster_decorator_spec.rb
+++ b/spec/decorators/cluster_decorator_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ClusterDecorator do
           array_including(
             hash_including({
               id: injected_service_id,
-              name: 'Other / N/A',
+              name: 'Other or N/A',
               supportType: 'managed',
             })
           )


### PR DESCRIPTION
This PR adds an injected 'Other' Service, along with 2 'Other' Issues - one which `requires_service` and one which doesn't. These are the first minimal changes to address https://github.com/alces-software/alces-flight-center/issues/361 - whether and how much these changes improve the situation discussed there remains to be seen.

The core of these changes is the 'Other' Service injection from the experimental branch linked in that issue (thanks @jamesremuscat!); also included is test coverage for this change, fixing of existing tests, the addition of the Issues needed to work with this change, and some other tidying/refactoring to hopefully make this change clearer and more robust.

Trello: https://trello.com/c/EUGNoYqY/410-add-other-service-and-issue-to-facilitate-tier-3-ticket-creation.