### PR TITLE
Set Sentry error context for rails-admin controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,6 @@ class ApplicationController < RootController
   helper_method :case_url
   helper_method :case_path
 
-  before_action :set_sentry_raven_context
   before_action :assign_current_user
   before_action :assign_scope
   before_action :assign_title
@@ -66,18 +65,6 @@ class ApplicationController < RootController
     cookies['flight_sso'] && JsonWebToken.decode(cookies['flight_sso'])
   rescue JWT::DecodeError
     false
-  end
-
-  def set_sentry_raven_context
-    if current_user
-      Raven.user_context(
-        id: current_user.id,
-        email: current_user.email,
-        name: current_user.name,
-        site: current_user.site&.name,
-      )
-    end
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
   end
 
   def assign_current_user

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -7,4 +7,20 @@ class RootController < ActionController::Base
   include Clearance::Controller
 
   protect_from_forgery with: :exception
+
+  before_action :set_sentry_raven_context
+
+  private
+
+  def set_sentry_raven_context
+    if current_user
+      Raven.user_context(
+        id: current_user.id,
+        email: current_user.email,
+        name: current_user.name,
+        site: current_user.site&.name,
+      )
+    end
+    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  end
 end


### PR DESCRIPTION
After extracting the RootController, for all controllers which will be
used by our app to inherit from (including those which come from other
Gems like rails-admin), the extra Sentry Raven context which we set in
the ApplicationController was no longer being applied to these other
controllers. This was then causing errors like
https://sentry.io/alces-software-ltd/alces-flight-center/issues/626456706
to not include this additional identifying context, such as the User who
triggered the exception.

The straightforward fix for this is to just extract setting this context
up a level to the RootController as well.

(Not actually manually tested this yet, since that would require a deploy to staging I think. It _should_ be trivial enough to Just Work, but you can never tell with Ruby. Possibly worth us making a note somewhere to check/keep an eye on this once it gets deployed).

Trello: https://trello.com/c/G1Gp9GyQ/414-have-extra-sentry-context-be-set-for-rails-admin-exceptions