### PR TITLE
Markdown preview for change requests

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -73,6 +73,24 @@ class ChangeRequestsController < ApplicationController
     end
   end
 
+  def preview
+    @cr = @case.change_request || @case.build_change_request
+    @cr.update(cr_params)
+
+    authorize @cr, :create?
+
+    render layout: false
+  end
+
+  def write
+    @cr = @case.change_request || @case.build_change_request
+    @cr.update(cr_params)
+
+    authorize @cr, :create?
+
+    render layout: false
+  end
+
   private
 
   def assign_case

--- a/app/policies/change_request_policy.rb
+++ b/app/policies/change_request_policy.rb
@@ -5,7 +5,6 @@ class ChangeRequestPolicy < ApplicationPolicy
   alias_method :update?, :admin?
   alias_method :propose?, :admin?
   alias_method :handover?, :admin?
-  alias_method :create?, :admin?
 
   alias_method :authorise?, :contact?
   alias_method :decline?, :contact?

--- a/app/policies/change_request_policy.rb
+++ b/app/policies/change_request_policy.rb
@@ -5,6 +5,7 @@ class ChangeRequestPolicy < ApplicationPolicy
   alias_method :update?, :admin?
   alias_method :propose?, :admin?
   alias_method :handover?, :admin?
+  alias_method :create?, :admin?
 
   alias_method :authorise?, :contact?
   alias_method :decline?, :contact?

--- a/app/views/change_requests/_form.html.erb
+++ b/app/views/change_requests/_form.html.erb
@@ -6,7 +6,14 @@
       use Markdown to format your text.
     </label>
     <div class="col-sm-9">
-      <%= f.text_area :description, rows: 15, class: 'form-control' %>
+      <%= render 'partials/markdown_editor_layout',
+        activate: 'write',
+        form_builder: f,
+        preview_path: preview_case_change_request_path,
+        write_path: write_case_change_request_path do %>
+
+        <%= render 'markdown_content', form_builder: f %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/change_requests/_markdown_content.html.erb
+++ b/app/views/change_requests/_markdown_content.html.erb
@@ -1,0 +1,9 @@
+<div class="border-bottom mt-2 pb-2 m-0">
+  <div class="form-group">
+    <%= form_builder.text_area :description,
+        class: 'form-control',
+        'data-markdown-content': true,
+        rows: 15
+    %>
+  </div>
+</div>

--- a/app/views/change_requests/preview.html.erb
+++ b/app/views/change_requests/preview.html.erb
@@ -1,0 +1,17 @@
+<%
+  form_builder = nil
+  form_for cr, url: case_change_request_path do |f| form_builder = f end
+%>
+
+<%= render 'partials/markdown_editor_layout',
+  activate: 'preview',
+  form_builder: form_builder,
+  change_request_action: params[:format],
+  preview_path: preview_case_change_request_path,
+  write_path: write_case_change_request_path do %>
+
+  <%= form_builder.hidden_field :description, 'data-markdown-content': true %>
+  <div class="border-bottom p-2">
+    <%= @cr.rendered_description.html_safe %>
+  </div>
+<% end %>

--- a/app/views/change_requests/write.html.erb
+++ b/app/views/change_requests/write.html.erb
@@ -1,0 +1,13 @@
+<%
+  form_builder = nil
+  form_for cr, url: case_change_request_path do |f| form_builder = f end
+%>
+
+<%= render 'partials/markdown_editor_layout',
+  activate: 'write',
+  form_builder: form_builder,
+  preview_path: preview_case_change_request_path,
+  write_path: write_case_change_request_path do %>
+
+  <%= render 'markdown_content', form_builder: form_builder %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,8 @@ Rails.application.routes.draw do
         member do
           post :propose
           post :handover
+          post :preview
+          post :write
         end
       end
 


### PR DESCRIPTION
When creating or editing a change request you can now preview the `Description`. The old textbox has been replaced with a Markdown editor that has a `Write` and `Preview` button, just like in other areas of Flight Center.

[Trello](https://trello.com/c/ZfJqvCZh/363-markdown-preview-for-change-requests)