### PR TITLE
Allow admins to edit case subject

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -82,6 +82,16 @@ class CasesController < ApplicationController
     end
   end
 
+  UPDATABLE_FIELDS = [:subject].freeze
+
+  def update
+   change_action 'Support case %s updated.' do |kase|
+      kase.update(  # update! doesn't work here :( But we call save! later anyway
+        params.require(:case).permit(UPDATABLE_FIELDS)
+      )
+    end
+  end
+
   def close
     charge_params = params.require(:credit_charge)
                           .permit(:amount)

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -18,7 +18,6 @@ class CasesController < ApplicationController
     else
       not_found unless @scope.cases.include? @case
       @comment = @case.case_comments.new
-      @title = "#{@case.display_id}: #{@case.subject}"
     end
   end
 

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -17,6 +17,7 @@ module Audited
     ADMIN_ONLY_CARDS = %w(time_worked)
 
     def change_card(date, user, change)
+      p change
       field = change[0]
       from, to = *change[1]
 
@@ -97,6 +98,18 @@ module Audited
 
     def tier_level_details
       'Tier Change'
+    end
+
+    def subject_text(from, to)
+      "Changed the subject of this case from '#{from}' to '#{to}'."
+    end
+
+    def subject_type
+      'pencil-square-o'
+    end
+
+    def subject_details
+      'Subject Change'
     end
   end
 end

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -17,7 +17,6 @@ module Audited
     ADMIN_ONLY_CARDS = %w(time_worked)
 
     def change_card(date, user, change)
-      p change
       field = change[0]
       from, to = *change[1]
 

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -24,6 +24,16 @@ class CaseMailer < ApplicationMailer
     SlackNotifier.assignee_notification(@case, @assignee)
   end
 
+  def change_subject(my_case, old_val, new_val)
+    @case = my_case
+    @old = old_val
+    @new = new_val
+    mail(
+      cc: @case.email_recipients,
+      subject: @case.email_reply_subject
+    )
+  end
+
   def comment(comment)
     @comment = comment
     @case = @comment.case

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -65,7 +65,7 @@ class Case < ApplicationRecord
 
   end
 
-  audited only: [:assignee_id, :time_worked, :tier_level], on: [ :update ]
+  audited only: [:assignee_id, :subject, :time_worked, :tier_level], on: [ :update ]
   has_associated_audits
 
   validates :display_id, uniqueness: true

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -9,6 +9,7 @@ class CasePolicy < ApplicationPolicy
   alias_method :set_commenting?, :admin?
   alias_method :edit_associations?, :admin?
   alias_method :edit?, :admin?
+  alias_method :update?, :admin?
 
   def redirect_to_canonical_path?
     true

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -8,6 +8,7 @@ class CasePolicy < ApplicationPolicy
   alias_method :set_time?, :admin?
   alias_method :set_commenting?, :admin?
   alias_method :edit_associations?, :admin?
+  alias_method :edit?, :admin?
 
   def redirect_to_canonical_path?
     true

--- a/app/views/case_mailer/change_subject.html.erb
+++ b/app/views/case_mailer/change_subject.html.erb
@@ -1,0 +1,5 @@
+<h3><%= @case.display_id %> <%= @case.ticket_subject %></h3>
+
+<p>
+  The subject of this case has been changed from '<%= @old %>' to '<%= @new %>'.
+</p>

--- a/app/views/case_mailer/change_subject.text.erb
+++ b/app/views/case_mailer/change_subject.text.erb
@@ -1,0 +1,3 @@
+<%= @case.display_id %> <%= @case.ticket_subject %>
+
+The subject of this case has been changed from '<%= @old %>' to '<%= @new %>'.

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,7 +1,31 @@
 <% content_for :title do %>
   <div class="card title-card">
     <div class="card-body">
-      <h1><%= @case.display_id %>: <%= @case.subject %></h1>
+      <h1>
+        <% if policy(@case).edit? %>
+          <div class="case-subject-edit collapse show">
+            <%= @case.display_id %>: <%= @case.subject %>
+            <button class="btn btn-link" data-toggle="collapse" data-target=".case-subject-edit">
+              <i class="fa fa-2x fa-pencil"></i>
+            </button>
+          </div>
+          <div class="case-subject-edit collapse">
+            <%= form_for @case do |f| %>
+              <div class="form-row align-items-center">
+                <div class="col">
+                  <%= f.text_field :subject, class: 'form-control form-control-lg' %>
+                </div>
+                <div class="col-auto">
+                  <%= f.submit 'Change subject', class: 'btn btn-primary mb-2' %>
+                  <a class="btn btn-secondary mb-2" data-toggle="collapse" data-target=".case-subject-edit" tabindex="1">
+                    Cancel
+                  </a>
+                </div>
+              </div>
+          <% end %>
+          </div>
+        <% end %>
+      </h1>
     </div>
   </div>
 <% end %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -5,7 +5,7 @@
         <% if policy(@case).edit? %>
           <div class="case-subject-edit collapse show">
             <%= @case.display_id %>: <%= @case.subject %>
-            <button class="btn btn-link" data-toggle="collapse" data-target=".case-subject-edit">
+            <button class="btn btn-link" data-toggle="collapse" data-target=".case-subject-edit" id="case-subject-edit">
               <i class="fa fa-2x fa-pencil"></i>
             </button>
           </div>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -22,8 +22,10 @@
                   </a>
                 </div>
               </div>
-          <% end %>
+            <% end %>
           </div>
+        <% else %>
+          <%= @case.subject %>
         <% end %>
       </h1>
     </div>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,3 +1,10 @@
+<% content_for :title do %>
+  <div class="card title-card">
+    <div class="card-body">
+      <h1><%= @case.display_id %>: <%= @case.subject %></h1>
+    </div>
+  </div>
+<% end %>
 <%= render 'partials/tabs', activate: :cases do %>
   <div class='table-responsive'>
     <table class="table case-table">

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -5,7 +5,13 @@
         <% if policy(@case).edit? %>
           <div class="case-subject-edit collapse show">
             <%= @case.display_id %>: <%= @case.subject %>
-            <button class="btn btn-link" data-toggle="collapse" data-target=".case-subject-edit" id="case-subject-edit">
+            <button
+              class="btn btn-link"
+              data-toggle="collapse"
+              data-target=".case-subject-edit"
+              id="case-subject-edit"
+              title="Edit subject"
+            >
               <i class="fa fa-2x fa-pencil"></i>
             </button>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,14 +28,16 @@
     <%= render 'partials/nav_bar' %>
     <div class='page-content'>
 
-      <% if @title %>
-          <div class="card title-card">
-            <div class="card-body">
-              <h1><%= @title %></h1>
-              <% if content_for? :subtitle %>
-                <p class="lead" style="font-size: 18px;">
-                  <%= yield :subtitle %>
-                </p>
+      <% if content_for? :title %>
+        <%= yield :title %>
+      <% elsif @title %>
+        <div class="card title-card">
+          <div class="card-body">
+            <h1><%= @title %></h1>
+            <% if content_for? :subtitle %>
+              <p class="lead" style="font-size: 18px;">
+                <%= yield :subtitle %>
+              </p>
             <% end %>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,7 +113,7 @@ Rails.application.routes.draw do
     end
 
     resources :clusters, only: [] do
-      cases.call(only: []) do
+      cases.call(only: [:update]) do
         # Admin-only pages relating to cases belong here.
         resource :change_request, only: [:new, :edit], path: 'change-request'
         resource :case_associations, only: [:edit], as: 'associations', path: 'associations'

--- a/spec/features/case/edit_spec.rb
+++ b/spec/features/case/edit_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe 'Case editing', type: :feature do
   context 'as an admin' do
     let(:user) { create(:admin) }
 
+    let(:emails) { ActionMailer::Base.deliveries }
+
+    before(:each) do
+      emails.clear
+    end
+
     it 'allows editing case subject' do
       find('#case-subject-edit').click
       fill_in 'case[subject]', with: 'New subject'
@@ -35,6 +41,9 @@ RSpec.describe 'Case editing', type: :feature do
       kase.reload
 
       expect(kase.subject).to eq 'New subject'
+
+      expect(emails.count).to eq 1
+      expect(emails[0].subject).to have_text 'New subject'
     end
   end
 

--- a/spec/features/case/edit_spec.rb
+++ b/spec/features/case/edit_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Case editing', type: :feature do
+
+  let(:kase) { create(:open_case, subject: 'Original subject') }
+
+  before(:each) do
+    visit cluster_case_path(kase.cluster, kase, as: user)
+  end
+
+  context 'as a non-admin' do
+    let(:user) { create(:contact, site: kase.site) }
+
+    it 'does not show subject edit button' do
+      expect do
+        find('#case-subject-edit')
+      end.to raise_error Capybara::ElementNotFound
+    end
+
+  end
+
+  context 'as an admin' do
+    let(:user) { create(:admin) }
+
+    it 'allows editing case subject' do
+      find('#case-subject-edit').click
+      fill_in 'case[subject]', with: 'New subject'
+      click_button 'Change subject'
+
+      expect(find('.alert-success')).to have_text "Support case #{kase.display_id} updated."
+      kase.reload
+
+      expect(kase.subject).to eq 'New subject'
+    end
+  end
+
+
+
+end

--- a/spec/features/case/edit_spec.rb
+++ b/spec/features/case/edit_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'Case editing', type: :feature do
       click_button 'Change subject'
 
       expect(find('.alert-success')).to have_text "Support case #{kase.display_id} updated."
+
+      expect(find('.event-card')).to \
+        have_text 'Changed the subject of this case from \'Original subject\' to \'New subject\''
+
       kase.reload
 
       expect(kase.subject).to eq 'New subject'


### PR DESCRIPTION
This PR allows admins to edit the subject of a `Case` after it has been created.

Admins will now see an "edit" button (pencil icon) next to the title of a `Case`. Clicking it will reveal an input field for them to alter the title. Doing so will generate an email and an event card in the case history.

I've also tried to implement this in a generic enough way that editing other fields will be an easy and logical follow-on, which might also help if we decide to do #396.

One half of the remnant of #72.

Trello: https://trello.com/c/kIiobw6i/393-allow-admins-to-change-subject-of-cases