### PR TITLE
Don't default to cluster if case associations are empty.

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -164,9 +164,7 @@ class Case < ApplicationRecord
   end
 
   def associations
-    (component_groups + components + services + clusters).tap do |assocs|
-      assocs << cluster if assocs.empty?
-    end
+    (component_groups + components + services + clusters)
   end
 
   def associations=(objects)

--- a/app/views/cases/associations/_association_info.html.erb
+++ b/app/views/cases/associations/_association_info.html.erb
@@ -1,5 +1,9 @@
-<ul class="fa-ul">
-  <% kase.associations.map(&:decorate).each do |item| %>
-    <%= render 'cases/associations/cluster_part', item: item %>
-  <% end %>
-</ul>
+<% if kase.associations.empty? %>
+  <p>None</p>
+<% else %>
+  <ul class="fa-ul">
+    <% kase.associations.map(&:decorate).each do |item| %>
+      <%= render 'cases/associations/cluster_part', item: item %>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/partials/_association_summary.html.erb
+++ b/app/views/partials/_association_summary.html.erb
@@ -1,4 +1,4 @@
-<%= associations.first.decorate.links %>
+<%= associations.first&.decorate&.links || 'None' %>
 <% if associations.length > 1 %>
   <% contents = render 'cases/associations/group_contents', items: associations do %>
     <p>Affected components:</p>

--- a/spec/features/case_associations/edit_spec.rb
+++ b/spec/features/case_associations/edit_spec.rb
@@ -53,6 +53,27 @@ RSpec.describe 'Case association edit form', type: :feature, js: true do
       )
     }
 
+    it 'marks nothing as associated' do
+      cluster_checkbox = checkbox_for[cluster]
+
+      expect(cluster_checkbox).not_to be_checked
+
+      expect(
+        find_all('input[type=checkbox]').map(&:checked?).reduce(false, :|)
+      ).to eq false
+    end
+
+  end
+
+  context 'for a case associated with an entire cluster' do
+    let(:kase) {
+      create(
+        :open_case,
+        cluster: cluster,
+        clusters: [cluster]
+      )
+    }
+
     it 'marks entire cluster as associated' do
       cluster_checkbox = checkbox_for[cluster]
 

--- a/spec/features/case_associations/edit_spec.rb
+++ b/spec/features/case_associations/edit_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe 'Case association edit form', type: :feature, js: true do
   end
 
   context 'for a case with no associations' do
-    # Implicitly: associated with entire cluster
     let(:kase) {
       create(
         :open_case,

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -566,8 +566,9 @@ RSpec.describe Case, type: :model do
         )
       end
 
-      it 'lists cluster as association' do
-        expect(subject.associations).to eq [cluster]
+      it 'lists nothing as associations' do
+        # This used to pretend that the cluster was associated.
+        expect(subject.associations).to eq []
       end
     end
   end


### PR DESCRIPTION
Since we're now allowing cases to be created with no associations via the "Other" pseudoservice/issue, it looks a bit jarring to then be presented with "the entire cluster is affected!!!" the moment you submit.

This removes the default association from `Case`s and adds placeholder "None" text in places that would otherwise be empty as a result.

See https://github.com/alces-software/alces-flight-center/pull/465#issuecomment-409570574 for full justification.

Trello: https://trello.com/c/AowM4v1p/417-dont-default-to-whole-cluster-association-for-cases