### PR TITLE
Validate to prevent a case being made invalid when associations change.

### DIFF
--- a/app/models/case/associated_model_validator.rb
+++ b/app/models/case/associated_model_validator.rb
@@ -40,9 +40,9 @@ class Case
         associated_service_types = services.map(&:service_type)
 
         unless associated_service_types.include?(required_service_type)
-          error = "must be associated with #{required_service_type.name} " \
-            "service but not given one"
-          record.errors.add(:service, error)
+          error = "for issue '#{record.issue.name}' must be associated with " \
+            "#{required_service_type.name} service but not given one"
+          record.errors.add(:case, error)
         end
       end
     end

--- a/spec/features/case_associations/edit_spec.rb
+++ b/spec/features/case_associations/edit_spec.rb
@@ -171,4 +171,38 @@ RSpec.describe 'Case association edit form', type: :feature, js: true do
     end
   end
 
+  unless ENV.fetch('TRAVIS', false)
+    context 'for a case whose issue requires a certain service type' do
+      let :service_type do
+        create(:service_type, name: 'File System')
+      end
+      let :issue do
+        create(:issue, requires_service: true, service_type: service_type)
+      end
+      let :service do
+        create(:service, cluster: cluster, service_type: service_type)
+      end
+      let(:kase) {
+        create(
+          :open_case,
+          cluster: cluster,
+          services: [service, service_1],
+          issue: issue
+        )
+      }
+
+      it 'does not allow removing the association' do
+        expect(checkbox_for[service]).to be_checked
+        checkbox_for[service].click
+        click_button 'Save'
+
+        kase.reload
+        expect(kase.associations).to include(service, service_1)
+        expect(find('.alert-danger')).to have_text \
+          "for issue '#{issue.name}' must be associated with " \
+                "#{service_type.name} service but not given one"
+      end
+    end
+  end
+
 end

--- a/spec/models/case/associated_model_validator_spec.rb
+++ b/spec/models/case/associated_model_validator_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Case, type: :model do
         it 'should be invalid' do
           expect(subject).to be_invalid
           expect(subject.errors.messages).to match(
-            service: [/must be.*File System.*but not given one/]
+            case: [/for issue.*must be.*File System.*but not given one/]
           )
         end
       end


### PR DESCRIPTION
The majority of `Issue`s require that a `Case` be associated with a certain type of `Service`. However, it is currently possible to change the associations of a `Case` to remove the required `Service`, leaving an invalid `Case` in the database.

This PR validates the new associations on a `Case` before making the change permanent.

This will require porting to the 2018.5 release branch too.

Trello: https://trello.com/c/pYAhuSPt/418-dont-allow-removing-a-case-association-required-by-its-issue