### PR TITLE
Allow admins to edit case issue

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -83,7 +83,7 @@ class CasesController < ApplicationController
     end
   end
 
-  UPDATABLE_FIELDS = [:subject].freeze
+  UPDATABLE_FIELDS = [:subject, :issue_id].freeze
 
   def update
 

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -110,5 +110,18 @@ module Audited
     def subject_details
       'Subject Change'
     end
+
+    def issue_id_text(from, to)
+      "Changed this case's associated issue from '#{Issue.find(from).decorate.label_text}'" \
+      " to '#{Issue.find(to).decorate.label_text}'."
+    end
+
+    def issue_id_type
+      'map-signs'
+    end
+
+    def issue_id_details
+      'Change of Issue'
+    end
   end
 end

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -38,7 +38,8 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def available_issues
-    services.map { |s| s.service_type.issues }.flatten.uniq.map(&:decorate)
+    services.map { |s| s.service_type.issues }.flatten.uniq.map(&:decorate) +
+      Issue.where(requires_component: false, requires_service: false).decorate.reject(&:special?)
   end
 
   private

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -37,6 +37,10 @@ class CaseDecorator < ApplicationDecorator
     commenting.disabled_text
   end
 
+  def available_issues
+    services.map { |s| s.service_type.issues }.flatten.uniq.map(&:decorate)
+  end
+
   private
 
   def commenting

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -38,8 +38,14 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def available_issues
-    services.map { |s| s.service_type.issues }.flatten.uniq.map(&:decorate) +
-      Issue.where(requires_component: false, requires_service: false).decorate.reject(&:special?)
+    services.map { |s| s.service_type.issues }
+            .flatten
+            .uniq
+            .map(&:decorate)
+            .sort_by { |i| i.category&.name || '' } +
+      Issue.where(requires_component: false, requires_service: false)
+        .decorate
+        .reject(&:special?)
   end
 
   private

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -2,6 +2,7 @@ class CaseDecorator < ApplicationDecorator
   delegate_all
   decorates_association :change_request
   decorates_association :cluster
+  decorates_association :issue
 
   def user_facing_state
     model.state.to_s.titlecase
@@ -14,10 +15,6 @@ class CaseDecorator < ApplicationDecorator
       h.pluralize(model.associations.length, 'affected component'),
       "Created by #{user.name}"
     ].join(' | ')
-  end
-
-  def issue_type_text
-    "#{category_text}#{model.issue.name}"
   end
 
   def case_link
@@ -44,10 +41,6 @@ class CaseDecorator < ApplicationDecorator
 
   def commenting
     @commenting ||= CaseCommenting.new(self, current_user)
-  end
-
-  def category_text
-    model.category ? "#{model.category.name}: " : ''
   end
 
 end

--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -21,7 +21,7 @@ class IssueDecorator < ApplicationDecorator
 
   def category_text
     if category.present?
-      "#{category.name} : "
+      "#{category.name}: "
     end
   end
 end

--- a/app/decorators/issue_decorator.rb
+++ b/app/decorators/issue_decorator.rb
@@ -12,4 +12,16 @@ class IssueDecorator < ApplicationDecorator
       tiers: tiers.map(&:case_form_json)
     }
   end
+
+  def label_text
+    "#{category_text}#{name}"
+  end
+
+  private
+
+  def category_text
+    if category.present?
+      "#{category.name} : "
+    end
+  end
 end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -34,6 +34,16 @@ class CaseMailer < ApplicationMailer
     )
   end
 
+  def change_issue_id(my_case, old_val, new_val)
+    @case = my_case
+    @old = Issue.find(old_val).decorate.label_text
+    @new = Issue.find(new_val).decorate.label_text
+    mail(
+      cc: @case.email_recipients,
+      subject: @case.email_reply_subject
+    )
+  end
+
   def comment(comment)
     @comment = comment
     @case = @comment.case

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -65,7 +65,7 @@ class Case < ApplicationRecord
 
   end
 
-  audited only: [:assignee_id, :subject, :time_worked, :tier_level], on: [ :update ]
+  audited only: [:assignee_id, :issue_id, :subject, :time_worked, :tier_level], on: [ :update ]
   has_associated_audits
 
   validates :display_id, uniqueness: true

--- a/app/views/case_mailer/change_issue_id.html.erb
+++ b/app/views/case_mailer/change_issue_id.html.erb
@@ -1,0 +1,5 @@
+<h3><%= @case.display_id %> <%= @case.ticket_subject %></h3>
+
+<p>
+  This case's associated issue has been changed from '<%= @old %>' to '<%= @new %>'.
+</p>

--- a/app/views/case_mailer/change_issue_id.text.erb
+++ b/app/views/case_mailer/change_issue_id.text.erb
@@ -1,0 +1,3 @@
+<%= @case.display_id %> <%= @case.ticket_subject %>
+
+This case's associated issue has been changed from '<%= @old %>' to '<%= @new %>'.

--- a/app/views/cases/_issue_controls.html.erb
+++ b/app/views/cases/_issue_controls.html.erb
@@ -1,0 +1,20 @@
+<% if policy(kase).edit? %>
+  <%= form_for kase do |f| %>
+    <div class="form-group">
+      <div class="input-group">
+        <%=
+          f.select :issue_id,
+                   kase.available_issues.map { |i| [i.label_text, i.id] },
+                   {},
+                   { class: 'form-control' }
+        %>
+        <div class="input-group-append">
+          <%= f.submit 'Change issue', class: 'btn btn-primary btn-sm' %>
+        </div>
+      </div>
+      <p class="small">Associate more services with this case for more options.</p>
+    </div>
+  <% end %>
+<% else %>
+  <%= kase.issue.label_text %>
+<% end %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -110,7 +110,7 @@
       <% end %>
       <tr>
         <th>Issue type</th>
-        <td><%= @case.issue.label_text %></td>
+        <td><%= render 'cases/issue_controls', kase: @case %></td>
       </tr>
       <tr>
         <th>Tier</th>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -110,7 +110,7 @@
       <% end %>
       <tr>
         <th>Issue type</th>
-        <td><%= @case.issue_type_text %></td>
+        <td><%= @case.issue.label_text %></td>
       </tr>
       <tr>
         <th>Tier</th>

--- a/spec/decorators/case_decorator_spec.rb
+++ b/spec/decorators/case_decorator_spec.rb
@@ -35,29 +35,4 @@ RSpec.describe CaseDecorator do
       end.to raise_error(RuntimeError, "Unhandled tier_level: 5")
     end
   end
-
-  describe '#issue_type_text' do
-    let(:issue) { create(:issue, name: 'My issue', category: category) }
-
-    let(:kase) { create(:open_case, issue: issue) }
-
-    subject do
-      kase.decorate.issue_type_text
-    end
-
-    context 'without a category' do
-      let(:category) { nil }
-      it 'returns issue name' do
-        expect(subject).to eq issue.name
-      end
-    end
-
-    context 'with a category' do
-      let(:category) { create(:category, name: 'My Category') }
-      it 'returns combination of category and issue name' do
-        expect(subject).to eq "#{category.name}: #{issue.name}"
-      end
-    end
-
-  end
 end

--- a/spec/decorators/issue_decorator_spec.rb
+++ b/spec/decorators/issue_decorator_spec.rb
@@ -32,4 +32,27 @@ RSpec.describe IssueDecorator do
       )
     end
   end
+
+  describe '#label_text' do
+    let(:issue) { create(:issue, name: 'My issue', category: category) }
+
+    subject do
+      issue.decorate.label_text
+    end
+
+    context 'without a category' do
+      let(:category) { nil }
+      it 'returns issue name' do
+        expect(subject).to eq issue.name
+      end
+    end
+
+    context 'with a category' do
+      let(:category) { create(:category, name: 'My Category') }
+      it 'returns combination of category and issue name' do
+        expect(subject).to eq "#{category.name}: #{issue.name}"
+      end
+    end
+
+  end
 end

--- a/spec/features/case/edit_spec.rb
+++ b/spec/features/case/edit_spec.rb
@@ -3,6 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Case editing', type: :feature do
 
   let(:kase) { create(:open_case, subject: 'Original subject') }
+  let!(:issue) {
+    create(
+      :issue,
+      requires_component: false,
+      requires_service: false,
+      name: 'Some other issue'
+    )
+  }
 
   before(:each) do
     visit cluster_case_path(kase.cluster, kase, as: user)
@@ -14,6 +22,12 @@ RSpec.describe 'Case editing', type: :feature do
     it 'does not show subject edit button' do
       expect do
         find('#case-subject-edit')
+      end.to raise_error Capybara::ElementNotFound
+    end
+
+    it 'does not show issue edit selectbox' do
+      expect do
+        find('#case_issue_id')
       end.to raise_error Capybara::ElementNotFound
     end
 
@@ -44,6 +58,17 @@ RSpec.describe 'Case editing', type: :feature do
 
       expect(emails.count).to eq 1
       expect(emails[0].subject).to have_text 'New subject'
+    end
+
+    it 'allows editing case issue' do
+      expect(kase.issue).not_to eq issue
+
+      select 'Some other issue'
+      click_button 'Change issue'
+      expect(find('.alert-success')).to have_text "Support case #{kase.display_id} updated."
+
+      kase.reload
+      expect(kase.issue).to eq issue
     end
   end
 

--- a/spec/features/case/edit_spec.rb
+++ b/spec/features/case/edit_spec.rb
@@ -67,6 +67,9 @@ RSpec.describe 'Case editing', type: :feature do
       click_button 'Change issue'
       expect(find('.alert-success')).to have_text "Support case #{kase.display_id} updated."
 
+      expect(find('.event-card')).to \
+        have_text 'Changed this case\'s associated issue from \'New user/group\' to \'Some other issue\''
+
       kase.reload
       expect(kase.issue).to eq issue
     end

--- a/spec/features/case/edit_spec.rb
+++ b/spec/features/case/edit_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe 'Case editing', type: :feature do
 
       kase.reload
       expect(kase.issue).to eq issue
+
+      expect(emails.count).to eq 1
+      expect(emails[0].parts.first.body.raw_source).to \
+        have_text 'This case\'s associated issue has been changed from \'New user/group\' to \'Some other issue\''
     end
   end
 


### PR DESCRIPTION
This PR finally fixes #72 by adding the ability for admins to edit the `Issue` associated with a `Case` - with an important restriction.

Admins now see a dropdown list of all `Issue`s that could validly be associated with a `Case`, and can change this as they desire. An entry in the case history feed and an email are generated when they do so. Non-admins (or rather, those without permission to `edit?` a `Case`) see no different.

The restriction is that only `Issue`s against which the current `Case` would be valid are permitted. That is, the only permitted `Issue`s are those which require no specific `Service`, or those which require a `Service` to which the `Case` is currently associated. (Admins are able to add more `Service` associations to broaden the list of available `Issue`s if required.)

Note that, much as we do for display, we're collapsing category and issue down to a single field. That simplifies things considerably since admins don't have to first pick one, then the other (and we don't have to write code that deals with filtering a list of `Issue`s by `:category`).

Trello: https://trello.com/c/WOur7w1m/394-allow-admins-to-change-issue-category-of-cases