### PR TITLE
Merge the Services and Components tabs into one to save space.

### DIFF
--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -21,15 +21,26 @@ class ClusterDecorator < ApplicationDecorator
       tabs_builder.logs,
       tabs_builder.cases,
       tabs_builder.maintenance,
-      { id: :services, path: h.cluster_services_path(self) },
       {
-        id: :components,
-        dropdown: self.available_component_group_types.map do |t|
+        id: :cluster,
+        dropdown: [
           {
-            text: t.pluralize,
-            path: h.cluster_components_path(self, type: t)
+            text: 'Services',
+            path: h.cluster_services_path(self)
+          },
+          {
+            text: 'Components:',
+            heading: true,
           }
-        end.push(text: 'All', path: h.cluster_components_path(self))
+        ].tap do |comps|
+          comps.push(text: 'All', path: h.cluster_components_path(self))
+          available_component_group_types.each do |t|
+            comps.push(
+              text: t.pluralize,
+              path: h.cluster_components_path(self, type: t)
+            )
+          end
+        end
       },
       notes_tab,
     ].compact

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -25,9 +25,13 @@
   <% if dropdown %>
     <div class='dropdown-menu'>
       <% dropdown.each do |dropitem| %>
-        <%= link_to dropitem[:text],
-                    dropitem[:path],
-                    class: 'dropdown-item' %>
+        <% if dropitem[:heading] %>
+          <h6 class="dropdown-header"><%= dropitem[:text] %></h6>
+        <% else %>
+          <%= link_to dropitem[:text],
+                      dropitem[:path],
+                      class: 'dropdown-item' %>
+        <% end %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
This isn't a long-term solution, but it works for now. If we start adding yet more things to the tab bar we'll want to do something more drastic (like implementing support for nested dropdowns, or some other reorganisation of the site layout).

Trello: https://trello.com/c/6DUMY2Ls/415-reorganise-cluster-dashboard-tabs