### PR TITLE
Sentry configuration enhancements

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,11 @@
+class SentryJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(event)
+    Raven.send_event(event)
+  end
+end
+
 
 if ENV.has_key?('SENTRY_DSN')
   Raven.configure do |config|
@@ -5,5 +13,9 @@ if ENV.has_key?('SENTRY_DSN')
 
     # Do not send any filtered parameters to Sentry.
     config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+
+    config.async = lambda { |event|
+      SentryJob.perform_later(event.to_hash)
+    }
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -17,5 +17,7 @@ if ENV.has_key?('SENTRY_DSN')
     config.async = lambda { |event|
       SentryJob.perform_later(event.to_hash)
     }
+
+    config.release = Rails.application.config.version
   end
 end


### PR DESCRIPTION
This PR makes two changes to our Sentry configuration:

- We now set the value of `release` to the Flight Center version number (taken from `ENV['FC_VERSION']`)
- Exceptions are submitted asynchronously to Sentry via our Resque/Redis instance. Hopefully this will mean that exceptions no longer cross threads and appear where they shouldn't (see Trello card linked below).

No changes were necessary to the Redis or Resque configuration. Sentry tasks will be picked up by the existing Resque worker process.

Trello: https://trello.com/c/wC2DpSaQ/390-use-async-jobs-to-send-errors-to-sentry