### PR TITLE
Consistent date entry fields

### DIFF
--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -1,10 +1,31 @@
 function initialiseDatepicker() {
-  $("#datepicker").datepicker({
+  // Having a datepicker defined for each use case separately isn't necessary
+  // as there are methods you can call to handle changing the disabled days for
+  // example. However for now this offers the ability for easier individual
+  // customisation if we need it.
+
+  $("#restricted-datepicker").datepicker({
     format: "yyyy-mm-dd",
     endDate: '+0d',
     daysOfWeekDisabled: [0,6],
     todayHighlight: true,
     todayBtn: "linked",
+    orientation: "bottom"
+  });
+
+  $("#credit-datepicker").datepicker({
+    format: "yyyy-mm-dd",
+    endDate: '+0d',
+    todayHighlight: true,
+    todayBtn: "linked",
+    orientation: "bottom"
+  });
+
+  $("#maintenance-datepicker").datepicker({
+    format: "yyyy-mm-dd",
+    todayHighlight: true,
+    todayBtn: "linked",
+    autoclose: true,
     orientation: "bottom"
   });
 }

--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -23,6 +23,7 @@ function initialiseDatepicker() {
 
   $("#maintenance-datepicker").datepicker({
     format: "yyyy-mm-dd",
+    startDate: '-0d',
     todayHighlight: true,
     todayBtn: "linked",
     autoclose: true,

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -17,6 +17,7 @@ class MaintenanceWindowsController < ApplicationController
     event = mandatory? ? :mandate : :request
     action = mandatory? ? :schedule : :request
     @case = Case.find_from_id!(params[:case_id])
+    @date = params['maintenance_window']['requested_start']
 
     handle_form_submission(action: action, template: :new) do
       @maintenance_window = MaintenanceWindow.new(

--- a/app/controllers/maintenance_windows_controller.rb
+++ b/app/controllers/maintenance_windows_controller.rb
@@ -1,5 +1,6 @@
 class MaintenanceWindowsController < ApplicationController
   decorates_assigned :maintenance_window
+  before_action :format_requested_start_fields, only: [:create, :confirm_submit]
 
   def new
     @case = Case.find_from_id!(params[:case_id])
@@ -8,6 +9,7 @@ class MaintenanceWindowsController < ApplicationController
         maintenance_window_case_params(@case)
       )
     )
+    @date = default_requested_start
     authorize @maintenance_window
   end
 
@@ -32,6 +34,7 @@ class MaintenanceWindowsController < ApplicationController
 
   def confirm
     @maintenance_window = MaintenanceWindow.find(params[:id])
+    @date = @maintenance_window.requested_start
     authorize @maintenance_window
 
     # Validate window as if it was confirmed without changes up front, so can
@@ -158,5 +161,12 @@ class MaintenanceWindowsController < ApplicationController
     window.state = :confirm
     window.validate
     window.state = original_state
+  end
+
+  def format_requested_start_fields
+    year, month, day = params['maintenance_window']['requested_start'].split('-')
+    params['maintenance_window']['requested_start(1i)'] = year
+    params['maintenance_window']['requested_start(2i)'] = month
+    params['maintenance_window']['requested_start(3i)'] = day
   end
 end

--- a/app/views/clusters/_deposit_form.html.erb
+++ b/app/views/clusters/_deposit_form.html.erb
@@ -21,13 +21,15 @@
         <div class="col">
           <label>
             Effective date
-            <%= date_field :credit_deposit,
-                           :effective_date,
-                           class: 'form-control',
-                           max: Date.today,
-                           required: true,
-                           value: Date.today
-            %>
+            <div class="input-group date">
+              <input type="text"
+                     id="credit-datepicker"
+                     name="credit_deposit[effective_date]"
+                     class="form-control"
+                     required="true"
+                     value="<%= Date.today %>">
+              </input>
+            </div>
           </label>
         </div>
       </div>

--- a/app/views/clusters/view_checks.html.erb
+++ b/app/views/clusters/view_checks.html.erb
@@ -11,7 +11,7 @@
     <div class="col-sm-12">
       <div class="input-group date col-sm-3" style="float: right;">
         <input type="text"
-               id="datepicker"
+               id="restricted-datepicker"
                class="form-control"
                value="<%= @date %>"
                onchange="dateChanged(this.value)"

--- a/app/views/partials/_date_time_select.html.erb
+++ b/app/views/partials/_date_time_select.html.erb
@@ -14,7 +14,7 @@
       <input type="text"
              id="maintenance-datepicker"
              name="maintenance_window[requested_start]"
-             class="form-control"
+             class="form-control <%= model.bootstrap_valid_class('requested_start') %>"
              value=<%= @date %>
            />
     </div>

--- a/app/views/partials/_date_time_select.html.erb
+++ b/app/views/partials/_date_time_select.html.erb
@@ -10,9 +10,14 @@
 <label for="<%= helper.id(:day) %>"><%= helper.label %></label>
 <div class="form-group" data-test="<%= datetime_field_name %>">
   <div class="row datetime-select">
-    <%= helper.select(:year) %>
-    <%= helper.select(:month) %>
-    <%= helper.select(:day) %>
+    <div class="input-group date col-sm-2">
+      <input type="text"
+             id="maintenance-datepicker"
+             name="maintenance_window[requested_start]"
+             class="form-control"
+             value=<%= @date %>
+           />
+    </div>
     <div class="col-md-1">&mdash;</div>
     <%= helper.select(:hour) %>
     <div>:</div>

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples 'maintenance form error handling' do |form_action|
     ).to have_text("Unable to #{form_action} this maintenance")
     invalidated_selects =
       requested_start_element.all('select', class: 'is-invalid')
-    expect(invalidated_selects.length).to eq(5)
+    expect(invalidated_selects.length).to eq(2)
     invalid_feedback = requested_start_element.find('.invalid-feedback')
     expect(invalid_feedback).to have_text('Cannot be in the past')
   end
@@ -82,10 +82,8 @@ RSpec.feature "Maintenance windows", type: :feature do
   let(:extend_button_text) { 'Extend' }
 
   def fill_in_datetime_selects(identifier, with:)
-    select with.year.to_s, from: "#{identifier}-datetime-select-year"
-    month_name = with.strftime('%B')
-    select month_name, from: "#{identifier}-datetime-select-month"
-    select with.day.to_s, from: "#{identifier}-datetime-select-day"
+    date = "#{with.year}-#{with.month}-#{with.day}"
+    fill_in('maintenance-datepicker', with: date)
     select with.hour.to_s, from: "#{identifier}-datetime-select-hour"
   end
 


### PR DESCRIPTION
Date selection is now consistent for all three areas that require it; viewing check results, depositing credits and making a maintenance request. 

There are three separate definitions for the date picker, one for each use case. While these are not wholly necessary it might be useful for easier individual customisation. However it is also possible to alter many of the date picker options via helper methods.

Another thing to note is that the boxes for selecting the time are unchanged within the maintenance request form as the date picker only supports choosing the date. There is a Trello [card](https://trello.com/c/1yyrqJ63/233-consider-upgrading-date-picker-to-a-date-and-time-picker) for potentially upgrading the date picker to one that can handle both the date and the time.

[Trello](https://trello.com/c/F864pLRC/396-make-date-entry-fields-consistent)