### PR TITLE
Utilise Markdown code styling for Command column (Cluster Checks)

### DIFF
--- a/app/views/clusters/enter_check_results.html.erb
+++ b/app/views/clusters/enter_check_results.html.erb
@@ -38,7 +38,7 @@
                       <td style="width: 20%;"><%= cluster_check.check.name %></td>
                       <td class="markdown" style="width: 20%;">
                         <code>
-                          <%= cluster_check.check.command %>
+                          <%= cluster_check.check.command || 'N/A' %>
                         </code>
                       </td>
                       <td style="width: 60%;">

--- a/app/views/clusters/enter_check_results.html.erb
+++ b/app/views/clusters/enter_check_results.html.erb
@@ -36,10 +36,10 @@
                     <% cluster_check_id = cluster_check.id %>
                     <tr class="case-highlight">
                       <td style="width: 20%;"><%= cluster_check.check.name %></td>
-                      <td style="width: 20%;">
-                        <p style="color: #ea3ea6; font-style: italic;">
+                      <td class="markdown" style="width: 20%;">
+                        <code>
                           <%= cluster_check.check.command %>
-                        </p>
+                        </code>
                       </td>
                       <td style="width: 60%;">
                         <%= render 'partials/markdown_editor_layout',


### PR DESCRIPTION
The Command column within the cluster check result submission form is now wrapped in a `<code>` block so that it utilises the fancier Markdown code styling.

Example:

<img src="https://user-images.githubusercontent.com/36155339/43784332-c79007c0-9a5b-11e8-8058-2002e2e1e0d6.png" width="200" height="150">

[Trello](https://trello.com/c/USAEAjkZ/421-utilise-markdown-code-styling-for-the-cluster-check-command-column-within-the-result-submission-form)