### PR TITLE
Cancel change request

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -73,6 +73,12 @@ class ChangeRequestsController < ApplicationController
     end
   end
 
+  def cancel
+    change_action 'Change request cancelled.' do |cr|
+      cr.cancel!(current_user)
+    end
+  end
+
   def preview
     @cr = @case.change_request || @case.build_change_request
     @cr.update(cr_params)

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -17,8 +17,10 @@ class ChangeRequest < ApplicationRecord
     state :in_progress
     state :in_handover
     state :completed
+    state :cancelled
 
     event(:propose) { transition draft: :awaiting_authorisation }
+    event(:cancel) { transition draft: :cancelled }
     event(:decline) { transition awaiting_authorisation: :declined }
     event(:authorise) { transition awaiting_authorisation: :in_progress }
     event(:handover) { transition in_progress: :in_handover }
@@ -36,7 +38,7 @@ class ChangeRequest < ApplicationRecord
   validates :description, presence: true
 
   def finalised?
-    completed? || declined?
+    completed? || declined? || cancelled?
   end
 
   private

--- a/app/models/change_request_state_transition.rb
+++ b/app/models/change_request_state_transition.rb
@@ -13,7 +13,7 @@ class ChangeRequestStateTransition < ApplicationRecord
 
   def validate_user_can_initiate
     case event&.to_sym
-    when :propose, :handover
+    when :propose, :handover, :cancel
       errors.add(:user, 'must be an admin') unless user&.admin?
     when :authorise, :decline, :complete
       errors.add(:user, 'must be a contact') unless user&.contact?

--- a/app/policies/change_request_policy.rb
+++ b/app/policies/change_request_policy.rb
@@ -5,6 +5,7 @@ class ChangeRequestPolicy < ApplicationPolicy
   alias_method :update?, :admin?
   alias_method :propose?, :admin?
   alias_method :handover?, :admin?
+  alias_method :cancel?, :admin?
 
   alias_method :authorise?, :contact?
   alias_method :decline?, :contact?

--- a/app/views/change_requests/state_controls/_cancelled.html.erb
+++ b/app/views/change_requests/state_controls/_cancelled.html.erb
@@ -1,0 +1,3 @@
+<p>
+  This change request has been cancelled.
+</p>

--- a/app/views/change_requests/state_controls/_draft.html.erb
+++ b/app/views/change_requests/state_controls/_draft.html.erb
@@ -6,6 +6,17 @@
               role: 'button'
   %>
 <% end %>
+<% if my_policy.cancel? %>
+  <%= link_to 'Cancel',
+              cancel_case_change_request_path(cr.case),
+              class: 'btn btn-danger form-control mb-2',
+              data: {
+                  confirm: 'Are you sure you want to cancel this change request?'
+              },
+              method: 'post',
+              role: 'button'
+  %>
+<% end %>
 <% if my_policy.propose? %>
   <%= link_to 'Submit for authorisation',
               propose_case_change_request_path(cr.case),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
           post :handover
           post :preview
           post :write
+          post :cancel
         end
       end
 

--- a/spec/features/change_request/show_spec.rb
+++ b/spec/features/change_request/show_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Change request view', type: :feature do
 
   EXPECTED_BUTTONS = {
     draft: {
-      admin: ['Edit', 'Submit for authorisation'],
+      admin: ['Edit', 'Cancel', 'Submit for authorisation'],
       contact: [],
       viewer: [],
     },
@@ -29,6 +29,11 @@ RSpec.describe 'Change request view', type: :feature do
       viewer: [],
     },
     completed: {
+      admin: [],
+      contact: [],
+      viewer: [],
+    },
+    cancelled: {
       admin: [],
       contact: [],
       viewer: [],
@@ -117,6 +122,15 @@ RSpec.describe 'Change request view', type: :feature do
     cr.reload
     expect(cr.state).to eq 'declined'
     expect(find('.alert').text).to have_text("Change request #{kase.display_id} declined.")
+  end
+
+  it 'transitions to :cancelled as a final state' do
+    cr = create(:change_request, state: :draft, case: kase)
+
+    as(admin) { click_link('Cancel') }
+    cr.reload
+    expect(cr.state).to eq 'cancelled'
+    expect(find('.alert').text).to have_text('Change request cancelled.')
   end
 
 end

--- a/spec/models/change_request_spec.rb
+++ b/spec/models/change_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ChangeRequest, type: :model do
 
   describe '#finalised?' do
 
-    FINAL_STATES = %w(declined completed).freeze
+    FINAL_STATES = %w(declined completed cancelled).freeze
 
     it 'reports final states as finalised' do
 

--- a/spec/models/change_request_state_transition_spec.rb
+++ b/spec/models/change_request_state_transition_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ChangeRequestStateTransition, type: :model do
     build(:change_request_state_transition, event: event, user: user)
   end
 
-  ADMIN_EVENTS = %w(propose handover).freeze
+  ADMIN_EVENTS = %w(propose cancel handover).freeze
   NON_ADMIN_EVENTS = %w(authorise decline complete).freeze
 
   let(:event) { 'propose' }


### PR DESCRIPTION
This PR implements the ability for an admin to cancel a change request that is in the `:draft` state. When a CR is in this draft state it can be cancelled using the 'Cancel' button found on the right-hand panel of the CR page. Once cancelled it should be possible to resolve the case as long as there are no outstanding maintenance requests.

Currently this is the only way to cancel a CR but if necessary it would be relatively simple to add a similar button to the alert displayed above a case.

[Trello](https://trello.com/c/G184hUhN/405-allow-admins-to-cancel-change-requests-from-draft-state)