### PR TITLE
Don't die horribly if there's an AWS error retrieving documents.

### DIFF
--- a/app/models/cluster/documents_retriever.rb
+++ b/app/models/cluster/documents_retriever.rb
@@ -25,6 +25,8 @@ module Cluster::DocumentsRetriever
           Document.new(name, url)
         end
       end.reject(&:nil?)
+    rescue Aws::S3::Errors::ServiceError
+      []
     end
 
     private


### PR DESCRIPTION
Rather than return a 500 error, better to just return an empty list if we can't access AWS.

Trello: https://trello.com/c/YyJD51D7/424-better-handle-aws-errors