### PR TITLE
Request changes to change requests

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -79,6 +79,12 @@ class ChangeRequestsController < ApplicationController
     end
   end
 
+  def request_changes
+    change_action_and_email 'Change request %s has been sent back for adjustments.' do |cr|
+      cr.request_changes!(current_user)
+    end
+  end
+
   def preview
     @cr = @case.change_request || @case.build_change_request
     @cr.update(cr_params)

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -80,7 +80,7 @@ class ChangeRequestsController < ApplicationController
   end
 
   def request_changes
-    change_action_and_email 'Change request %s has been sent back for adjustments.' do |cr|
+    change_action_and_email 'Further changes requested on change request %s.' do |cr|
       cr.request_changes!(current_user)
     end
   end

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -74,7 +74,7 @@ class ChangeRequestsController < ApplicationController
   end
 
   def cancel
-    change_action 'Change request cancelled.' do |cr|
+    change_action 'Change request %s cancelled.' do |cr|
       cr.cancel!(current_user)
     end
   end

--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -24,7 +24,7 @@ class ChangeRequestStateTransitionDecorator < ApplicationDecorator
     when 'cancel'
       'has been cancelled.'
     when 'request_changes'
-      'has been sent back for adjustments'
+      'has had further changes requested.'
     end
   end
 

--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -23,6 +23,8 @@ class ChangeRequestStateTransitionDecorator < ApplicationDecorator
       'is now complete.'
     when 'cancel'
       'has been cancelled.'
+    when 'request_changes'
+      'has been sent back for adjustments'
     end
   end
 

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -23,6 +23,7 @@ class ChangeRequest < ApplicationRecord
     event(:cancel) { transition draft: :cancelled }
     event(:decline) { transition awaiting_authorisation: :declined }
     event(:authorise) { transition awaiting_authorisation: :in_progress }
+    event(:request_changes) { transition awaiting_authorisation: :draft }
     event(:handover) { transition in_progress: :in_handover }
     event(:complete) { transition in_handover: :completed }
 

--- a/app/models/change_request_state_transition.rb
+++ b/app/models/change_request_state_transition.rb
@@ -15,7 +15,7 @@ class ChangeRequestStateTransition < ApplicationRecord
     case event&.to_sym
     when :propose, :handover, :cancel
       errors.add(:user, 'must be an admin') unless user&.admin?
-    when :authorise, :decline, :complete
+    when :authorise, :decline, :complete, :request_changes
       errors.add(:user, 'must be a contact') unless user&.contact?
     end
   end

--- a/app/policies/change_request_policy.rb
+++ b/app/policies/change_request_policy.rb
@@ -10,6 +10,7 @@ class ChangeRequestPolicy < ApplicationPolicy
   alias_method :authorise?, :contact?
   alias_method :decline?, :contact?
   alias_method :complete?, :contact?
+  alias_method :request_changes?, :contact?
 
   class Scope < Scope
     def resolve

--- a/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
+++ b/app/views/change_requests/state_controls/_awaiting_authorisation.html.erb
@@ -10,6 +10,19 @@
               role: 'button'
   %>
 <% end %>
+<% if my_policy.request_changes? %>
+  <%= link_to 'Request changes',
+              request_changes_case_change_request_path(cr.case),
+              class: 'btn btn-warning form-control mb-2',
+              data: {
+                  confirm: 'Are you sure you want to request changes for this
+                  change request? If so press OK and detail the required
+                  changes in the comment section for the case.'.squish
+              },
+              method: 'post',
+              role: 'button'
+  %>
+<% end %>
 <% if my_policy.decline? %>
   <%= link_to 'Decline',
               decline_case_change_request_path(cr.case),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,7 @@ Rails.application.routes.draw do
           post :authorise
           post :decline
           post :complete
+          post :request_changes
         end
       end
 

--- a/spec/features/change_request/show_spec.rb
+++ b/spec/features/change_request/show_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'Change request view', type: :feature do
     cr.reload
     expect(cr.state).to eq 'draft'
     expect(find('.alert').text).to have_text(
-      "Change request #{kase.display_id} has been sent back for adjustments."
+      "Further changes requested on change request #{kase.display_id}."
     )
   end
 

--- a/spec/features/change_request/show_spec.rb
+++ b/spec/features/change_request/show_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'Change request view', type: :feature do
     as(admin) { click_link('Cancel') }
     cr.reload
     expect(cr.state).to eq 'cancelled'
-    expect(find('.alert').text).to have_text('Change request cancelled.')
+    expect(find('.alert').text).to have_text("Change request #{kase.display_id} cancelled.")
   end
 
   it 'transitions back to draft upon requesting changes' do

--- a/spec/models/change_request_state_transition_spec.rb
+++ b/spec/models/change_request_state_transition_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ChangeRequestStateTransition, type: :model do
   end
 
   ADMIN_EVENTS = %w(propose cancel handover).freeze
-  NON_ADMIN_EVENTS = %w(authorise decline complete).freeze
+  NON_ADMIN_EVENTS = %w(authorise decline complete request_changes).freeze
 
   let(:event) { 'propose' }
   let(:user) { create(:admin) }


### PR DESCRIPTION
With this PR a contact is now able to request changes to an active change request. This will return the CR to the `draft` state from which an admin can go in and make adjustments before submitting it for authorisation again.

As discussed in #486 the contact will then need to detail the changes they want in the comment section of the associated case.

[Trello](https://trello.com/c/NescjX8O/422-allow-users-to-request-changes-to-a-change-request)