### PR TITLE
Prevent potentially infinite Slack notifications

### DIFF
--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -45,7 +45,7 @@ class ClustersController < ApplicationController
       id = cluster_check.id
 
       unless Component.find_by_id(params["#{id}-component"]).nil?
-        @new_log = @cluster.logs.build(
+        new_log = @cluster.logs.build(
           details: params["#{id}-comment"],
           component_id: params["#{id}-component"],
           engineer: current_user
@@ -58,12 +58,12 @@ class ClustersController < ApplicationController
         user: current_user,
         result: params["#{id}-result"],
         comment: params["#{id}-comment"],
-        log_id: @new_log ? @new_log.id : nil
+        log_id: new_log ? new_log.id : nil
       )
 
       if result.save
-        if @new_log
-          SlackNotifier.log_notification(@new_log) if @new_log.save
+        if new_log
+          SlackNotifier.log_notification(new_log) if new_log.save
         end
 
         flash[:success] = 'Cluster check results successfully saved.'


### PR DESCRIPTION
This should cull the amount of notifications that Slack receives per cluster check result log to a maximum of one. Woops.

[Trello](https://trello.com/c/htJSIkNI/425-prevent-potentially-infinite-slack-notifications-for-cluster-check-result-logs)
