### PR TITLE
Display the number of resolved cases

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -109,6 +109,10 @@ class Cluster < ApplicationRecord
     cluster_checks.length
   end
 
+  def resolved_cases
+    self.cases.where(state: 'resolved').count
+  end
+
   private
 
   def validate_all_cluster_parts_advice

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -109,7 +109,7 @@ class Cluster < ApplicationRecord
     cluster_checks.length
   end
 
-  def resolved_cases
+  def resolved_cases_count
     self.cases.where(state: 'resolved').count
   end
 

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -5,6 +5,11 @@
       <i class="fa fa-circle mr-2" aria-hidden="true"></i>
       <%= pluralize(cluster.credit_balance, 'credit') %>
     </p>
+    <p style="text-align: center;">
+    Cases pending closure: <%= link_to cluster.resolved_cases,
+                                       cluster_cases_path(state: 'resolved')
+                            %>
+    </p>
     <%= yield %>
   </div>
 </div>

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -6,7 +6,7 @@
       <%= pluralize(cluster.credit_balance, 'credit') %>
     </p>
     <p style="text-align: center;">
-    Cases pending closure: <%= link_to cluster.resolved_cases,
+    Cases pending closure: <%= link_to cluster.resolved_cases_count,
                                        cluster_cases_path(cluster, state: 'resolved')
                                      %>
     </p>

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -7,8 +7,8 @@
     </p>
     <p style="text-align: center;">
     Cases pending closure: <%= link_to cluster.resolved_cases,
-                                       cluster_cases_path(state: 'resolved')
-                            %>
+                                       cluster_cases_path(cluster, state: 'resolved')
+                                     %>
     </p>
     <%= yield %>
   </div>

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -6,9 +6,9 @@
       <%= pluralize(cluster.credit_balance, 'credit') %>
     </p>
     <p style="text-align: center;">
-    Cases pending closure: <%= link_to cluster.resolved_cases_count,
-                                       cluster_cases_path(cluster, state: 'resolved')
-                                     %>
+      Resolved cases pending closure: <%= link_to cluster.resolved_cases_count,
+                                         cluster_cases_path(cluster, state: 'resolved')
+                                       %>
     </p>
     <%= yield %>
   </div>


### PR DESCRIPTION
This PR addresses #389 by adding a visible count to indicate the number of resolved but unclosed cases for a cluster. Visible on both the cluster dashboard and the credit usage page below the number of available credits:

<img src="https://user-images.githubusercontent.com/36155339/43960833-2b06b280-9cab-11e8-989e-8cefc6aa5121.png" width=200 height=70>

[Trello](https://trello.com/c/cvj2IK1I/409-show-number-of-resolved-but-unclosed-cases-on-credit-usage-page)