### PR TITLE
Hide checks tab when a cluster has no associated checks

### DIFF
--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -20,7 +20,7 @@ class ClusterDecorator < ApplicationDecorator
       tabs_builder.overview,
       documents.empty? ? nil : { id: :documents, path: h.cluster_documents_path(self) },
       { id: :credit_usage, path: h.cluster_credit_usage_path(self) },
-      { id: :checks, path: h.cluster_checks_path(self) },
+      ({ id: :checks, path: h.cluster_checks_path(self) } unless self.cluster_check_count.zero? ),
       tabs_builder.logs,
       tabs_builder.cases,
       tabs_builder.maintenance,

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -105,6 +105,10 @@ class Cluster < ApplicationRecord
     end
   end
 
+  def cluster_check_count
+    cluster_checks.length
+  end
+
   private
 
   def validate_all_cluster_parts_advice

--- a/app/views/clusters/_cluster_checks.html.erb
+++ b/app/views/clusters/_cluster_checks.html.erb
@@ -1,5 +1,5 @@
-<% no_of_cluster_checks = cluster.cluster_checks.length %>
-<% unless no_of_cluster_checks == 0 %>
+<% no_of_cluster_checks = cluster.cluster_check_count %>
+<% unless no_of_cluster_checks.zero? %>
   <div class="card credit-balance">
     <div class="card-body">
       <h4>Cluster checks</h4>


### PR DESCRIPTION
When hiding the widget under the same circumstances in #498 I hadn't done the same for the `Checks` tab; see #501. This PR resolves this so that now if a cluster has no cluster checks **both** the widget and the tab are hidden.

[Trello](https://trello.com/c/GRU0oFKz/432-hide-cluster-checks-tab-when-a-cluster-has-no-associated-checks)