### PR TITLE
Handle null values in time worked form.

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -149,7 +149,15 @@ class CasesController < ApplicationController
 
   def set_time
     times = params.require(:time).permit(:hours, :minutes)
-    total_time = (times.require(:hours).to_i * 60) + times.require(:minutes).to_i
+
+    total_time = nil
+
+    if times[:hours] && !times[:hours].empty?
+      total_time = times[:hours].to_i * 60
+    end
+    if times[:minutes] && !times[:minutes].empty?
+      total_time = (total_time || 0) + times[:minutes].to_i
+    end
 
     change_action "Updated 'time worked' for support case %s." do |kase|
       kase.time_worked = total_time

--- a/app/decorators/audited/audit_decorator.rb
+++ b/app/decorators/audited/audit_decorator.rb
@@ -77,11 +77,15 @@ module Audited
     end
 
     def format_minutes(mins)
-      hours, minutes = mins.divmod(60)
-      if hours > 0
-        "#{hours}h #{minutes}m"
+      if mins.nil?
+        'unset'
       else
-        "#{minutes}m"
+        hours, minutes = mins.divmod(60)
+        if hours > 0
+          "#{hours}h #{minutes}m"
+        else
+          "#{minutes}m"
+        end
       end
     end
 

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -535,6 +535,33 @@ RSpec.describe 'Case page', type: :feature do
         expect(subject.time_worked).to eq (3 * 60) + 42
       end
 
+      it 'allows null values in time worked' do
+        visit cluster_case_path(cluster,subject, as: admin)
+
+        fill_in 'time[hours]', with: ''
+        fill_in 'time[minutes]', with: '42'
+        click_button time_form_submit_button
+
+        subject.reload
+
+        expect(subject.time_worked).to eq 42
+
+        fill_in 'time[hours]', with: ''
+        fill_in 'time[minutes]', with: ''
+        click_button time_form_submit_button
+
+        subject.reload
+
+        expect(subject.time_worked).to eq nil
+
+        fill_in 'time[hours]', with: '1'
+        fill_in 'time[minutes]', with: ''
+        click_button time_form_submit_button
+
+        subject.reload
+
+        expect(subject.time_worked).to eq 60
+      end
 
     end
 


### PR DESCRIPTION
If both values are nil or empty then we unset `time_worked`; else we treat the missing value as 0 and take the time from the value that was given.

Refs #505.

Trello: https://trello.com/c/zubBs61C/436-handle-null-values-from-time-worked-form