### PR TITLE
Clean up orphaned Bootstrap tooltips and popovers on Turbolinks load.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,10 +22,16 @@
 //
 
 function enableTooltips() {
+  // Get rid of any left over from Turbolinks' cached version of the page.
+  // NB we can't do this on before-visit because timing issues means we'll
+  // still leave an orphan behind.
+  $('.tooltip').remove();
+  // and regenerate
   $('[title]').tooltip({delay: {show: 500, hide: 100}, placement: 'left'});
 }
 
 function enablePopovers() {
+  $('.popover').remove();
   $('[data-toggle="popover"]').popover();
 }
 


### PR DESCRIPTION
Fixes #521.

Trello: https://trello.com/c/YdiIb9iX/437-fix-turbolinks-leaving-orphaned-popovers-tooltips