### PR TITLE
Track time since last update for cases

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -240,6 +240,7 @@ class CasesController < ApplicationController
       :state,
       :assigned_to,
       :associations,
+      :prioritised,
       {
         state: [],
         assigned_to: [],

--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -48,6 +48,18 @@ class CaseDecorator < ApplicationDecorator
         .reject(&:special?)
   end
 
+  def formatted_time_since_last_update
+    tslu = time_since_last_update.parts
+    [].tap do |result|
+      # Exclude seconds (we don't need to be that precise)
+      ActiveSupport::Duration::PARTS[0..-2].each do |part|
+        if tslu.include?(part)
+          result << "#{tslu[part]}#{part.to_s[0]}"
+        end
+      end
+    end.join(' ')
+  end
+
   private
 
   def commenting

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,6 @@ module ApplicationHelper
       <<~EOF.strip_heredoc
         <td
           title="#{description} on #{timestamp.to_formatted_s(:long)}"
-          class="nowrap"
         >
           #{content}
         </td>

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -10,7 +10,7 @@ class CaseMailer < ApplicationMailer
     mail(
       cc: @case.email_recipients.reject { |contact| contact == @case.user.email }, # Exclude the user raising the case
       subject: @case.email_subject,
-      bypass_update_mail: true
+      bypass_timestamp_update: true
     )
     SlackNotifier.case_notification(@case)
   end
@@ -51,7 +51,7 @@ class CaseMailer < ApplicationMailer
     mail(
       cc: @case.email_recipients.reject { |contact| contact == @comment.user.email }, # Exclude the user making the comment
       subject: @case.email_reply_subject,
-      bypass_update_mail: !comment.user.admin?  # Only count admin comments towards update time
+      bypass_timestamp_update: !comment.user.admin?  # Only count admin comments towards update time
     )
     SlackNotifier.comment_notification(@case, @comment)
   end
@@ -93,7 +93,7 @@ class CaseMailer < ApplicationMailer
 
   def mail(**options)
     super(options)
-    return if options[:bypass_update_mail]
+    return if options[:bypass_timestamp_update]
     all_recipients = [options[:cc], options[:to]].flatten.compact
     # This is a bit of a hack - since we'd need to check each User model for
     # admin-ness to be fully correct - but that would be quite costly!

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -9,7 +9,8 @@ class CaseMailer < ApplicationMailer
     @case = my_case
     mail(
       cc: @case.email_recipients.reject { |contact| contact == @case.user.email }, # Exclude the user raising the case
-      subject: @case.email_subject
+      subject: @case.email_subject,
+      bypass_update_mail: true
     )
     SlackNotifier.case_notification(@case)
   end
@@ -91,6 +92,7 @@ class CaseMailer < ApplicationMailer
 
   def mail(**options)
     super(options)
+    return if options[:bypass_update_mail]
     all_recipients = [options[:cc], options[:to]].flatten.compact
     # This is a bit of a hack - since we'd need to check each User model for
     # admin-ness to be fully correct - but that would be quite costly!

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -98,9 +98,7 @@ class CaseMailer < ApplicationMailer
     # an email update to the customer.
     has_non_admin = !all_recipients.reject { |a| a.include? '@alces-' }.empty?
     if has_non_admin && @case
-      puts 'Case email being sent to non-admins, updating last_update timestamp'
-      @case.last_update = DateTime.now
-      @case.save!
+      @case.update_columns(last_update: DateTime.now)
     end
     super(options)
   end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -51,6 +51,7 @@ class CaseMailer < ApplicationMailer
     mail(
       cc: @case.email_recipients.reject { |contact| contact == @comment.user.email }, # Exclude the user making the comment
       subject: @case.email_reply_subject,
+      bypass_update_mail: !comment.user.admin?  # Only count admin comments towards update time
     )
     SlackNotifier.comment_notification(@case, @comment)
   end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -90,6 +90,7 @@ class CaseMailer < ApplicationMailer
   private
 
   def mail(**options)
+    super(options)
     all_recipients = [options[:cc], options[:to]].flatten.compact
     # This is a bit of a hack - since we'd need to check each User model for
     # admin-ness to be fully correct - but that would be quite costly!
@@ -100,6 +101,5 @@ class CaseMailer < ApplicationMailer
     if has_non_admin && @case
       @case.update_columns(last_update: DateTime.now)
     end
-    super(options)
   end
 end

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -102,7 +102,7 @@ class CaseMailer < ApplicationMailer
     # an email update to the customer.
     has_non_admin = !all_recipients.reject { |a| a.include? '@alces-' }.empty?
     if has_non_admin && @case
-      @case.update_columns(last_update: DateTime.now)
+      @case.update_columns(last_update: Time.now)
     end
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -149,6 +149,11 @@ class Case < ApplicationRecord
       )
   }
 
+  # _ parameter to work with URL filtering system
+  # Defaults to nil so we can just say `.prioritised`
+  # Uses reorder rather than order to overwrite the sorting of default_scope
+  scope :prioritised, ->(_=nil) { reorder('last_update ASC NULLS FIRST') }
+
   def to_param
     display_id.parameterize.upcase
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -348,6 +348,12 @@ class Case < ApplicationRecord
     )
   end
 
+  def time_since_last_update
+    ActiveSupport::Duration.build(
+      last_update.business_time_until(Time.current)
+    )
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -354,9 +354,19 @@ class Case < ApplicationRecord
   end
 
   def time_since_last_update
-    ActiveSupport::Duration.build(
-      last_update.business_time_until(Time.current)
-    )
+    # In which we redefine a "day" to be 8 hours long.
+    raw = last_update.business_time_until(Time.current)
+
+    days = (raw / 8.hours).floor
+    raw -= (8 * days.hours).seconds
+
+    hours = (raw / 1.hour).floor
+    raw -= hours.hours.seconds
+
+    minutes = (raw / 1.minutes).floor
+    raw -= minutes.minutes.seconds
+
+    days.days + hours.hours + minutes.minutes + raw.seconds
   end
 
   private

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -28,6 +28,9 @@ end %>
             <%= render 'cases/filters/filter_for', caption: 'Affected components', name: 'associations', filters: @filters, title: 'Filter by component' %>
           </th>
           <th>Credit usage</th>
+          <% if current_user.admin? %>
+            <th>Last update</th>
+          <% end %>
         </tr>
       </thead>
 

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -21,4 +21,11 @@
       <%= render 'partials/association_summary', associations: kase.associations %>
   </td>
   <td><%= render 'partials/table_cell_link', url: url, cell_content: kase.credit_charge&.amount %></td>
+  <% if current_user.admin? %>
+    <%=
+      timestamp_td(description: 'Last update', timestamp: kase.last_update) do
+        render 'partials/table_cell_link', url: url, cell_content: "Soon™"
+      end
+    %>
+  <% end %>
 </tr>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -24,7 +24,7 @@
   <% if current_user.admin? %>
     <%=
       timestamp_td(description: 'Last update', timestamp: kase.last_update) do
-        render 'partials/table_cell_link', url: url, cell_content: "Soon™"
+        render 'partials/table_cell_link', url: url, cell_content: kase.formatted_time_since_last_update
       end
     %>
   <% end %>

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -22,10 +22,13 @@
   </td>
   <td><%= render 'partials/table_cell_link', url: url, cell_content: kase.credit_charge&.amount %></td>
   <% if current_user.admin? %>
-    <%=
-      timestamp_td(description: 'Last update', timestamp: kase.last_update) do
-        render 'partials/table_cell_link', url: url, cell_content: kase.formatted_time_since_last_update
-      end
-    %>
+    <% if kase.last_update.nil?  %>
+      <td class="text-danger">None</td>
+    <% else %>
+      <%= timestamp_td(description: 'Last update', timestamp: kase.last_update) do
+          render 'partials/table_cell_link', url: url, cell_content: kase.formatted_time_since_last_update
+        end
+      %>
+    <% end %>
   <% end %>
 </tr>

--- a/db/data/20180814105742_populate_case_last_update_times.rb
+++ b/db/data/20180814105742_populate_case_last_update_times.rb
@@ -1,0 +1,75 @@
+class PopulateCaseLastUpdateTimes < ActiveRecord::Migration[5.2]
+
+  # These are the fields that, at time of writing this migration,
+  # trigger an email update to the customer when edited.
+  RELEVANT_AUDIT_FIELDS = %w(issue_id subject).freeze
+
+  def up
+    Case.all.each do |kase|
+      if kase.open?
+        kase.last_update = calculate_last_update(kase)
+      else
+        # The last admin action will have been to resolve or close the case;
+        # so let's use the ActiveRecord updated_at value.
+        kase.last_update = kase.updated_at
+      end
+      kase.save!
+    end
+  end
+
+  def down
+    Case.all.each do |kase|
+      kase.last_update = nil
+      kase.save!
+    end
+  end
+
+  private
+
+  def calculate_last_update(kase)
+    [
+      last_admin_comment(kase),
+      last_maintenance_window_transition(kase),
+      last_cr_transition(kase),
+      last_relevant_audit(kase),
+    ].compact.max
+  end
+
+  def last_admin_comment(kase)
+    kase.case_comments
+        .joins(:user)
+        .where(users: { role: 'admin' })
+        .order(:created_at)
+        .last
+        &.created_at
+  end
+
+  def last_maintenance_window_transition(kase)
+    kase.maintenance_windows
+        .map(&:transitions)
+        .flatten
+        .sort_by(&:created_at)
+        .select(&:event)
+        .last
+        &.created_at
+  end
+
+  def last_cr_transition(kase)
+    return unless kase.change_request.present?
+    kase.change_request
+        .transitions
+        .order(:created_at)
+        .last
+        &.created_at
+  end
+
+  def last_relevant_audit(kase)
+    kase.audits
+        .order(:created_at)
+        .select { |a|
+          RELEVANT_AUDIT_FIELDS.include?(a.audited_changes.keys.flatten[0])
+        }
+        .last
+        &.created_at
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180809095517)
+DataMigrate::Data.define(version: 20180814105742)

--- a/db/migrate/20180814105312_add_last_update_to_cases.rb
+++ b/db/migrate/20180814105312_add_last_update_to_cases.rb
@@ -1,0 +1,5 @@
+class AddLastUpdateToCases < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cases, :last_update, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_13_112637) do
+ActiveRecord::Schema.define(version: 2018_08_14_105312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 2018_08_13_112637) do
     t.string "display_id", null: false
     t.integer "time_worked"
     t.boolean "comments_enabled", default: false
+    t.datetime "last_update"
     t.index ["assignee_id"], name: "index_cases_on_assignee_id"
     t.index ["cluster_id"], name: "index_cases_on_cluster_id"
     t.index ["display_id"], name: "index_cases_on_display_id", unique: true

--- a/spec/features/case/index_spec.rb
+++ b/spec/features/case/index_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'Cases table', type: :feature do
 
     let(:kase1) { create(:open_case, cluster: cluster2, subject: 'Kase1') }
     let(:kase2) { create(:open_case, cluster: cluster2, subject: 'Kase2') }
-    let(:kase3) { create(:open_case, cluster: cluster2, subject: 'Kase3') }
+    let(:kase3) { create(:open_case, cluster: cluster2, subject: 'Kase3', tier_level: 3) }
 
     it 'sorts cases by last update' do
       travel_to Time.zone.local(2018, 8, 13, 9, 0, 0) do
@@ -182,6 +182,10 @@ RSpec.describe 'Cases table', type: :feature do
       travel_to Time.zone.local(2018, 8, 13, 12, 30, 0) do
         visit cluster_case_path(cluster2, kase2, as: admin)
         fill_in 'case_comment_text', with: 'Response!'
+        click_button 'Add new comment'
+
+        visit cluster_case_path(cluster2, kase3, as: cluster2_contact)
+        fill_in 'case_comment_text', with: 'This response doesn\'t count!'
         click_button 'Add new comment'
       end
 

--- a/spec/features/case/index_spec.rb
+++ b/spec/features/case/index_spec.rb
@@ -155,4 +155,53 @@ RSpec.describe 'Cases table', type: :feature do
       expect(cases).not_to have_text('CC3')
     end
   end
+
+  describe '#prioritised' do
+    include ActiveSupport::Testing::TimeHelpers
+    let(:cluster2) { create(:cluster) }
+    let!(:cluster2_contact) { create(:contact, site: cluster2.site )}
+
+    let(:kase1) { create(:open_case, cluster: cluster2, subject: 'Kase1') }
+    let(:kase2) { create(:open_case, cluster: cluster2, subject: 'Kase2') }
+    let(:kase3) { create(:open_case, cluster: cluster2, subject: 'Kase3') }
+
+    it 'sorts cases by last update' do
+      travel_to Time.zone.local(2018, 8, 13, 9, 0, 0) do
+        # Create all cases at 9am
+        kase1.reload
+        kase2.reload
+        kase3.reload
+      end
+
+      travel_to Time.zone.local(2018, 8, 13, 10, 30, 0) do
+        visit cluster_case_path(cluster2, kase1, as: admin)
+        fill_in 'case_comment_text', with: 'Response!'
+        click_button 'Add new comment'
+      end
+
+      travel_to Time.zone.local(2018, 8, 13, 12, 30, 0) do
+        visit cluster_case_path(cluster2, kase2, as: admin)
+        fill_in 'case_comment_text', with: 'Response!'
+        click_button 'Add new comment'
+      end
+
+      travel_to Time.zone.local(2018, 8, 13, 14, 0, 0) do
+        visit cluster_cases_path(cluster2, prioritised: true, as: admin)
+        cases = all('tr').map(&:text)
+
+        # Is the order correct?
+        expect(cases[1]).to have_text('Kase3')
+        expect(cases[2]).to have_text('Kase1')
+        expect(cases[3]).to have_text('Kase2')
+
+        # What about the durations?
+        expect(cases[1]).to have_text 'None None'  # Affected components also says 'None'
+        expect(cases[2]).to have_text '3h 30m'
+        expect(cases[3]).to have_text '1h 30m'
+
+      end
+
+    end
+
+  end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -548,6 +548,27 @@ RSpec.describe Case, type: :model do
     end
   end
 
+  describe '#time_since_last_update' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    let(:cluster) { create(:cluster) }
+    let(:admin) { create(:admin) }
+    let!(:kase) { create(:open_case, cluster: cluster) }
+
+    it 'handles business time in the expected way' do
+      # Where "expected" means "treats a day as eight hours long".
+
+      kase.last_update = Time.zone.local(2018, 8, 13, 9, 00)
+      kase.save!
+
+      travel_to Time.zone.local(2018, 8, 14, 10, 0) do
+        expect(kase.time_since_last_update).to eq 1.days + 1.hours
+      end
+
+    end
+
+  end
+
   describe '#maybe_set_default_assignee' do
     let(:site) { create(:site, default_assignee: default_assignee) }
     let(:cluster) { create(:cluster, site: site) }


### PR DESCRIPTION
This PR introduces a new field, `last_update`, to `Case`s, in order to track the last time it was updated by an admin (and therefore be able to calculate the time since the last such update).

There's a data migration here that initialises this value for all current cases:
- If the case is resolved or closed, we set `last_update` to the case's Rails automagic `updated_at` field.
- If it's open, then we consider the following events and take the date/time of the most recent (possibly null):
  - Admin comments
  - Maintenance window transitions
  - CR transitions
  - Edits to subject or issue

This corresponds to the list on #507 of things for which we currently send a customer-facing email.

Updating this field is handled by `CaseMailer`: every time an email is sent about a case that is received by someone not `@alces` the value is reset to the current time, with two exceptions:
1. the initial case creation email
2. comments added by non-admins

Justification:
1. A brand new case hasn't been seen by an admin, much less updated by one; it's misleading to suggest otherwise
2. Hopefully obvious

Admins now see an additional column in cases tables, which displays the business time elapsed since the last update.

I've also added a new scope to `Case`, `prioritised`, which orders cases oldest-update-first (with cases with no updates at all very first). @atoghill can use this in his work on the new admin home page which forms another part of #479.

This PR itself forms part of #479.

Trello: https://trello.com/c/9FPVIydd/430-time-since-last-alces-update-for-cases and https://trello.com/c/3l2BErOt/401-show-time-since-last-admin-update-in-case-table.