### PR TITLE
Daily reminder email for admins

### DIFF
--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -49,6 +49,7 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def formatted_time_since_last_update
+    return 'None' unless time_since_last_update
     tslu = time_since_last_update.parts
     [].tap do |result|
       # Exclude seconds (we don't need to be that precise)

--- a/app/mailer_previews/admin_mailer_preview.rb
+++ b/app/mailer_previews/admin_mailer_preview.rb
@@ -1,0 +1,10 @@
+class AdminMailerPreview < ApplicationMailerPreview
+  def daily_open_cases_list
+    admin = Case.active.map(&:assignee).compact.uniq.sample
+
+    AdminMailer.daily_open_cases_list(
+       admin,
+       admin.assigned_cases.active.prioritised
+    )
+  end
+end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,13 @@
+class AdminMailer < ApplicationMailer
+
+  def daily_open_cases_list(admin, cases)
+    @admin = admin
+    @cases = cases.decorate
+
+    mail(
+      to: admin.email,
+      subject: 'Flight Center daily summary'
+    )
+  end
+
+end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -354,6 +354,7 @@ class Case < ApplicationRecord
   end
 
   def time_since_last_update
+    return unless last_update
     # In which we redefine a "day" to be 8 hours long.
     raw = last_update.business_time_until(Time.current)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
 
   belongs_to :site, required: false
 
+  has_many :assigned_cases, class_name: 'Case', foreign_key: :assignee
+
   validates_associated :site
   validates :name, presence: true
   validates :email,

--- a/app/services/daily_admin_reminder.rb
+++ b/app/services/daily_admin_reminder.rb
@@ -1,0 +1,15 @@
+class DailyAdminReminder
+  class << self
+
+    def process
+      User.admins.each do |admin|
+        cases = admin.assigned_cases.active.prioritised
+
+        unless cases.empty?
+          AdminMailer.daily_open_cases_list(admin, cases).deliver_later
+        end
+      end
+    end
+
+  end
+end

--- a/app/views/admin_mailer/daily_open_cases_list.html.erb
+++ b/app/views/admin_mailer/daily_open_cases_list.html.erb
@@ -1,0 +1,38 @@
+<p>Hello <%= @admin.name.split(' ').first %>,</p>
+
+<p>The following cases are unresolved and assigned to you in Flight Center:</p>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Subject</th>
+      <th>Raised</th>
+      <th>Last update</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @cases.each do |kase| %>
+      <tr>
+        <td><%= link_to kase.display_id, case_url(kase) %></td>
+        <td><%= link_to kase.subject, case_url(kase) %></td>
+        <%=
+          timestamp_td(
+              description: 'Support case created',
+              timestamp: kase.created_at
+          ) do |content|
+            "By <em>#{kase.user.name}</em> on <em>#{content}</em>"
+          end
+        %>
+        <% if kase.last_update.nil? %>
+          <td class="text-danger">None</td>
+        <% else %>
+          <%= timestamp_td(description: 'Last update', timestamp: kase.last_update) do
+            kase.formatted_time_since_last_update
+          end
+          %>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin_mailer/daily_open_cases_list.html.erb
+++ b/app/views/admin_mailer/daily_open_cases_list.html.erb
@@ -36,3 +36,6 @@
     <% end %>
   </tbody>
 </table>
+
+<p>Have a nice day,</p>
+<p><em>Flight Center</em></p>

--- a/app/views/admin_mailer/daily_open_cases_list.text.erb
+++ b/app/views/admin_mailer/daily_open_cases_list.text.erb
@@ -1,0 +1,18 @@
+Hello <%= @admin.name.split(' ').first %>,
+
+The following cases are unresolved and assigned to you in Flight Center:
+
+--------------------------------------------------------------------------------
+<% @cases.each do |kase| %>
+  <%= kase.display_id %>: <%= kase.subject %>
+  Created by <%= kase.user.name %> on <%= kase.created_at.to_formatted_s(:long) %>
+  Last update: <% if kase.last_update.nil? %>None
+  <% else %><%= kase.last_update.to_formatted_s(:long) %> (<%= kase.formatted_time_since_last_update %> ago)
+  <% end %>
+  < <%= case_url(kase) %> >
+--------------------------------------------------------------------------------
+<% end %>
+
+Have a nice day,
+
+Flight Center

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -12,7 +12,7 @@ A message from Alces Flight Center.
 -------------------------------------------------------------------------------
 
 <%= content_for(:notes) %>
-Add <center@alces-flight.com> to your address book to ensure
+Add < center@alces-flight.com > to your address book to ensure
 messages from Alces Flight aren't marked as spam.
 
 Replies to this email are not monitored. To request help or to send us any
@@ -25,7 +25,7 @@ or our Community Support Portal at
 < https://community.alces-flight.com >.
 
 ===============================================================================
-Alces Flight is a service provided by Alces Flight Ltd
+Alces Flight Center is a service provided by Alces Flight Ltd
 < http://www.alces-flight.com/ >
 
 Reg. No 10095215 • 4 Murdock Road • Bicester • Oxon • OX26 4PP

--- a/app/views/layouts/mailer/_inline_main.scss
+++ b/app/views/layouts/mailer/_inline_main.scss
@@ -112,6 +112,55 @@ dd {
     padding: 5px;
 }
 
+.table {
+  // Bootstrap table
+  max-width: 100%;
+  margin-bottom: $spacer;
+
+  th,
+  td {
+    padding: $table-cell-padding-sm;  // .table-sm
+    vertical-align: top;
+    border-top: $table-border-width solid $table-border-color;
+  }
+
+  thead th {
+    vertical-align: bottom;
+    border-bottom: (2 * $table-border-width) solid $table-border-color;
+  }
+
+  tbody + tbody {
+    border-top: (2 * $table-border-width) solid $table-border-color;
+  }
+
+  background-color: $body-bg;
+
+  // Bootstrap table-bordered
+
+  border: $table-border-width solid $table-border-color;
+
+  th,
+  td {
+    border: $table-border-width solid $table-border-color;
+  }
+
+  thead {
+    th,
+    td {
+      border-bottom-width: (2 * $table-border-width);
+    }
+  }
+}
+
+// Bootstrap .thead-dark
+thead {
+  th {
+    color: $table-dark-color;
+    background-color: $table-dark-bg;
+    border-color: $table-dark-border-color;
+  }
+}
+
 .markdown {
   h1 {
     font-size: 1.75rem;
@@ -151,52 +200,7 @@ dd {
   }
 
   table {
-    // Bootstrap table
-    max-width: 100%;
-    margin-bottom: $spacer;
-
-    th,
-    td {
-      padding: $table-cell-padding-sm;  // .table-sm
-      vertical-align: top;
-      border-top: $table-border-width solid $table-border-color;
-    }
-
-    thead th {
-      vertical-align: bottom;
-      border-bottom: (2 * $table-border-width) solid $table-border-color;
-    }
-
-    tbody + tbody {
-      border-top: (2 * $table-border-width) solid $table-border-color;
-    }
-
-    background-color: $body-bg;
-
-    // Bootstrap table-bordered
-
-    border: $table-border-width solid $table-border-color;
-
-    th,
-    td {
-      border: $table-border-width solid $table-border-color;
-    }
-
-    thead {
-      th,
-      td {
-        border-bottom-width: (2 * $table-border-width);
-      }
-    }
-  }
-
-  // Bootstrap .thead-dark
-  thead {
-    th {
-      color: $table-dark-color;
-      background-color: $table-dark-bg;
-      border-color: $table-dark-border-color;
-    }
+    @extend .table
   }
 }
 

--- a/lib/deployment/crontab.erb
+++ b/lib/deployment/crontab.erb
@@ -1,7 +1,7 @@
 # Flight Center<%= remote == :staging ? ' staging' : '' %> tasks.
-* * * * * dokku enter <%= app_name %> cron rake alces:cron:every_minute
-@hourly   dokku enter <%= app_name %> cron rake alces:cron:hourly
-0 9 * * * dokku enter <%= app_name %> cron rake alces:cron:daily
+* * * *  *  dokku enter <%= app_name %> cron rake alces:cron:every_minute
+@hourly     dokku enter <%= app_name %> cron rake alces:cron:hourly
+0 9 * * 1-5 dokku enter <%= app_name %> cron rake alces:cron:daily
 <% if remote == :production -%>
 0 */3 * * * /home/ubuntu/flight-center-backup-database
 <% end -%>

--- a/lib/deployment/crontab.erb
+++ b/lib/deployment/crontab.erb
@@ -1,6 +1,7 @@
 # Flight Center<%= remote == :staging ? ' staging' : '' %> tasks.
 * * * * * dokku enter <%= app_name %> cron rake alces:cron:every_minute
 @hourly   dokku enter <%= app_name %> cron rake alces:cron:hourly
+0 9 * * * dokku enter <%= app_name %> cron rake alces:cron:daily
 <% if remote == :production -%>
 0 */3 * * * /home/ubuntu/flight-center-backup-database
 <% end -%>

--- a/lib/tasks/admin_mailer.rake
+++ b/lib/tasks/admin_mailer.rake
@@ -1,0 +1,8 @@
+namespace :alces do
+  namespace :admin_mailer do
+    desc 'Daily reminder email'
+    task daily_reminder: :environment do
+      ::DailyAdminReminder.process
+    end
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -10,6 +10,6 @@ namespace :alces do
     task hourly: nil
 
     desc 'Tasks to run at the start of every business day'
-    task daily: nil
+    task daily: 'alces:admin_mailer:daily_reminder'
   end
 end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -8,5 +8,8 @@ namespace :alces do
 
     desc 'Tasks to run every hour'
     task hourly: nil
+
+    desc 'Tasks to run at the start of every business day'
+    task daily: nil
   end
 end

--- a/spec/services/daily_admin_reminder_spec.rb
+++ b/spec/services/daily_admin_reminder_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe DailyAdminReminder do
+  let(:emails) { ActionMailer::Base.deliveries }
+
+  let!(:admin_alpha) { create(:admin, name: 'Alpha One', email: 'alpha@example.com') }
+  let!(:admin_beta) { create(:admin, name: 'Beta Two', email: 'beta@example.com') }
+  let!(:admin_gamma) { create(:admin, name: 'Gamma Three', email: 'gamma@example.com') }
+
+  let!(:case_a) { create(:open_case, assignee: admin_alpha, last_update: 2.hours.ago) }
+  let!(:case_b) { create(:open_case, assignee: admin_alpha, last_update: 2.days.ago) }
+
+  let!(:case_c) { create(:open_case, assignee: admin_beta, last_update: 4.hours.ago) }
+  let!(:case_d) { create(:resolved_case, assignee: admin_beta) }
+
+  let!(:case_e) { create(:resolved_case, assignee: admin_gamma) }
+  let!(:case_f) { create(:closed_case, assignee: admin_gamma) }
+
+  before(:each) do
+    emails.clear
+    DailyAdminReminder.process
+  end
+
+
+  it 'ignores admins with no assigned open cases' do
+    expect(emails.count).to eq 2
+    expect(emails.map(&:to).flatten).to eq [admin_alpha.email, admin_beta.email]
+  end
+
+  it 'includes only open cases in email' do
+    expect(emails[1].parts.first.body.raw_source)
+      .to include(case_c.display_id)
+    expect(emails[1].parts.first.body.raw_source)
+      .not_to include(case_d.display_id)
+  end
+
+  it 'lists cases in priority order' do
+    expect(emails[0].parts.first.body.raw_source.delete("\n"))
+      .to match(/#{case_b.display_id}.*#{case_a.display_id}/)
+  end
+end


### PR DESCRIPTION
This PR introduces a new email, sent daily to admins, listing their currently assigned and unresolved cases.

They say a picture is worth a thousand words:

![selection_041](https://user-images.githubusercontent.com/3471844/44163052-1dda3100-a0ba-11e8-9bef-915f4b4b9dab.png)

(Note: as in FC itself, hovering over the "Last update" entries will give the timestamp of the last update.)

Only admins currently assigned open cases will be sent an email.

A cronjob will be added to the server to run this task at 9am every weekday.

Part of #479. Fixes #417 (doesn't match the requirements stated there but exceeds them).

Trello: https://trello.com/c/c6xcgSZK/431-morning-update-email-for-admins