### PR TITLE
Maintenance windows should appear once on cluster dashboard

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -71,6 +71,7 @@ class Cluster < ApplicationRecord
     parts
       .map(&:maintenance_windows)
       .flat_map(&:unfinished)
+      .uniq
       .sort_by(&:created_at)
       .reverse
   end

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -92,7 +92,7 @@ class MaintenanceWindow < ApplicationRecord
   end
 
   def associated_models
-    clusters + services + component_groups + components
+    component_groups + components + services + clusters
   end
 
   def expected_end

--- a/spec/features/maintenance_windows_spec.rb
+++ b/spec/features/maintenance_windows_spec.rb
@@ -420,4 +420,23 @@ RSpec.feature "Maintenance windows", type: :feature do
       end
     end
   end
+
+  context 'when maintenance window associated with multiple cluster components' do
+    let! :window do
+      create(
+        :requested_maintenance_window,
+        clusters: [cluster],
+        components: [component],
+        case: support_case
+      )
+    end
+
+    let(:user) { create(:contact, site: cluster.site) }
+
+    it 'only appears once on cluster dashboard page' do
+      visit cluster_maintenance_windows_path(cluster, as: user)
+
+      expect(all('tr').length).to eq 2 # heading row plus one MW
+    end
+  end
 end


### PR DESCRIPTION
Don't display the same maintenance window more than once.

Also tweaked the order in which we list associations for a MW to match that of cases.

Fixes #530, and should also become a hotfix release for 2018.6.