### PR TITLE
Don't log audits on case assocs when we're doing a trial-run validation.

### DIFF
--- a/app/controllers/case_associations_controller.rb
+++ b/app/controllers/case_associations_controller.rb
@@ -58,11 +58,15 @@ class CaseAssociationsController < ApplicationController
   end
 
   def validate_as_if_set(new_assocs)
-    old_assocs = @case.associations
-    @case.associations = new_assocs
-    @case.validate!
-  ensure
-    @case.associations = old_assocs
+    @case.without_auditing do
+      CaseAssociation.without_auditing do
+        old_assocs = @case.associations
+        @case.associations = new_assocs
+        @case.validate!
+      ensure
+        @case.associations = old_assocs
+      end
+    end
   end
 
 end

--- a/spec/features/case_associations/edit_spec.rb
+++ b/spec/features/case_associations/edit_spec.rb
@@ -192,6 +192,8 @@ RSpec.describe 'Case association edit form', type: :feature, js: true do
       }
 
       it 'does not allow removing the association' do
+        initial_number_of_audits = kase.associated_audits.where(auditable_type: 'CaseAssociation').count
+
         expect(checkbox_for[service]).to be_checked
         checkbox_for[service].click
         click_button 'Save'
@@ -201,6 +203,9 @@ RSpec.describe 'Case association edit form', type: :feature, js: true do
         expect(find('.alert-danger')).to have_text \
           "for issue '#{issue.name}' must be associated with " \
                 "#{service_type.name} service but not given one"
+
+        expect(kase.associated_audits.where(auditable_type: 'CaseAssociation').length)
+          .to eq initial_number_of_audits  # No new audits added
       end
     end
   end


### PR DESCRIPTION
Fixes #533.

Side note: the documentation for Audited (since https://github.com/collectiveidea/audited/issues/18) makes reference to the ability to globally disable auditing, which might have been useful here but hasn't yet made it into a released version of the gem. 

Trello: https://trello.com/c/2d8bnRju/440-dont-log-spurious-audits-as-side-effect-of-case-association-validation