### PR TITLE
Display the correct number of open assigned cases in dropdown

### DIFF
--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -18,7 +18,7 @@ class AllSitesDecorator < ApplicationDecorator
 
       tab[:dropdown].unshift(
         {
-          text: "My Cases (#{Case.assigned_to(h.current_user).size})",
+          text: "My Cases (#{Case.assigned_to(h.current_user).where(state: 'open').size})",
           path: h.root_path
         }
       )


### PR DESCRIPTION
This value was still considering resolved/closed cases. It has been updated to only count the number of assigned cases that are open for the current user. Addresses a mistake in #542.

[Trello](https://trello.com/c/qPJRB17o/450-display-correct-number-of-assigned-open-cases-for-the-current-user-in-dropdown)

