### PR TITLE
Update files to account for necessary environment variables for a development environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ export AWS_DOCUMENTS_PREFIX=development-documents
 #
 # TERMINAL_SERVICE_BASE_URL=ABC - base URL for terminal service client app. In
 # production, should be `https://terminal-service.alces-flight.com`.
+# For development assign this as `https://example.com`.
 #
 # JSON_WEB_TOKEN_SECRET - Shared secret for verifying SSO token signatures.
 # This should be the same value as that for `flight-sso` in the environment

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@
 7. Perform required/suggested additional manual setup steps output at the end
    of `bin/setup` script.
 
+8. Read through the `.env.example` file and set up any necessary environment
+   variables.
+
 
 ### To run development server(s)
 


### PR DESCRIPTION
Now that the Flight terminal service is starting to be used the `TERMINAL_SERVICE_BASE_URL` env var needs to be set in order for any site that is using this to have their main page working in `Development`. I have updated the `readme.md` and `.env.example` files to account for this.

[Trello](https://trello.com/c/qcMs8QKf/453-update-files-to-account-for-necessary-environment-variables-for-a-development-environment)