### PR TITLE
Fix confusion caused by two "Other" issues

### DIFF
--- a/app/decorators/case_decorator.rb
+++ b/app/decorators/case_decorator.rb
@@ -38,15 +38,6 @@ class CaseDecorator < ApplicationDecorator
   end
 
   def available_issues
-    # Note: There are two "Other"s available: one that requires a service (any
-    # service) and one which does not. To avoid having two indistinguishable
-    # "Other"s in the list, we need to test for service association here
-    # and include the correct "Other". This means not including issues that do
-    # not require a service if we have at least one service (even though these
-    # would be valid issues for this case).
-    # At the moment only "Other" is affected by this but if we ever add Issues
-    # that require no service but that should be available to all cases we'll
-    # need to try harder.
     if services.empty?
       Issue.where(requires_component: false, requires_service: false)
            .decorate
@@ -57,7 +48,7 @@ class CaseDecorator < ApplicationDecorator
         .uniq
         .map(&:decorate)
         .sort_by { |i| i.category&.name || '' } +
-        Issue.where(requires_component: false, requires_service: true, service_type: nil)
+        Issue.where(requires_component: false, service_type: nil)
           .decorate
           .reject(&:special?)
     end

--- a/db/data/20180824162550_rename_servicey_other_issue.rb
+++ b/db/data/20180824162550_rename_servicey_other_issue.rb
@@ -1,0 +1,17 @@
+class RenameServiceyOtherIssue < ActiveRecord::Migration[5.2]
+
+  OLD_NAME = 'Other'.freeze
+  NEW_NAME = 'Other (related to service)'.freeze
+
+  def up
+    other = Issue.find_by(name: OLD_NAME, requires_service: true)
+    other.name = NEW_NAME
+    other.save!
+  end
+
+  def down
+    other = Issue.find_by(name: NEW_NAME)
+    other.name = OLD_NAME
+    other.save!
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180822140300)
+DataMigrate::Data.define(version: 20180824162550)


### PR DESCRIPTION
This PR makes further changes to the "Other" issue functionality by distinguishing the names of the "Other" that requires a `Service` and the one that does not, and displaying them both in the issue-selection dropdown.

Before these changes, it was possible to encounter a confusing scenario as follows:
- Create a case with no service and "Other" issue
- Associate a service to the case

The original, serviceless "Other" would then no longer appear in the dropdown, meaning that no issue would be preselected and the case would appear to be associated with the first issue in the list. Now the serviceless "Other" is included in the options, and distinguished from the service-ful "Other" by changing the name of the latter.

Trello: https://trello.com/c/vtcgGurR/456-further-other-tweaks