### PR TITLE
Display cluster service plan dates

### DIFF
--- a/app/assets/stylesheets/clusters.scss
+++ b/app/assets/stylesheets/clusters.scss
@@ -15,6 +15,7 @@ p.credit-balance {
 .card.credit-balance .card-body {
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 li.credit-charge-entry {

--- a/app/assets/stylesheets/sites.scss
+++ b/app/assets/stylesheets/sites.scss
@@ -4,17 +4,10 @@
 
 .cluster-list {
   .list-group-item {
-    display: flex;
-    justify-content: space-between;
-    justify-items: center;
-
     h4 {
-      margin: 0.75rem 0;
-    }
-
-    & > span {
-      line-height: 3rem;
-      text-align: right;
+      .badge {
+        font-size: small;
+      }
     }
   }
 }

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -109,7 +109,7 @@ class ClusterDecorator < ApplicationDecorator
     end
   end
 
-  SERVICE_PLAN_WARNING_THRESHOLD = 60.days.freeze
+  SERVICE_PLAN_WARNING_THRESHOLD ||= 60.days.freeze
 
   def service_plan_badge
     current = current_service_plan

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -111,18 +111,20 @@ class ClusterDecorator < ApplicationDecorator
 
   SERVICE_PLAN_WARNING_THRESHOLD ||= 60.days.freeze
 
+  SERVICE_PLAN_DATE_FORMAT ||= :friendly_date
+
   def service_plan_badge
     current = current_service_plan
     if current
       if current.end_date > SERVICE_PLAN_WARNING_THRESHOLD.from_now
-        badge('success', "Service plan expires on #{current.end_date.to_formatted_s(:short)}")
+        badge('success', "Service plan expires on #{current.end_date.to_formatted_s(SERVICE_PLAN_DATE_FORMAT)}")
       else
-        badge('warning', "Service plan expires on #{current.end_date.to_formatted_s(:short)}")
+        badge('warning', "Service plan expires on #{current.end_date.to_formatted_s(SERVICE_PLAN_DATE_FORMAT)}")
       end
     else
       prev = previous_service_plan
       if prev
-        badge('danger', "Service plan expired on #{prev.end_date.to_formatted_s(:short)}")
+        badge('danger', "Service plan expired on #{prev.end_date.to_formatted_s(SERVICE_PLAN_DATE_FORMAT)}")
       else
         badge('danger', 'No service plan')
       end

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -109,6 +109,26 @@ class ClusterDecorator < ApplicationDecorator
     end
   end
 
+  SERVICE_PLAN_WARNING_THRESHOLD = 60.days.freeze
+
+  def service_plan_badge
+    current = current_service_plan
+    if current
+      if current.end_date > SERVICE_PLAN_WARNING_THRESHOLD.from_now
+        badge('success', "Service plan expires on #{current.end_date.to_formatted_s(:short)}")
+      else
+        badge('warning', "Service plan expires on #{current.end_date.to_formatted_s(:short)}")
+      end
+    else
+      prev = previous_service_plan
+      if prev
+        badge('danger', "Service plan expired on #{prev.end_date.to_formatted_s(:short)}")
+      else
+        badge('danger', 'No service plan')
+      end
+    end
+  end
+
   private
 
   def other_service_json
@@ -139,6 +159,12 @@ class ClusterDecorator < ApplicationDecorator
     def applicable_issues
       self.class.other_service_issues
     end
+  end
+
+  def badge(colour, text)
+    h.raw(
+      "<span class=\"badge badge-pill badge-#{colour} pull-right\">#{text}</span>"
+    )
   end
 
 end

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -116,6 +116,18 @@ class Cluster < ApplicationRecord
                  .last
   end
 
+  def service_plans_covering(from, to)
+    service_plans.where(start_date: from..to)
+      .or(service_plans.where(end_date: from..to))
+      .or(
+        service_plans.where(
+          'start_date <= ? AND end_date >= ?',
+          from,
+          to
+        )
+      ).order(:start_date)
+  end
+
   private
 
   def validate_all_cluster_parts_advice

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -23,6 +23,8 @@ class Cluster < ApplicationRecord
   has_many :checks, through: :cluster_checks
   has_many :check_results, through: :cluster_checks
 
+  has_many :service_plans
+
   validates_associated :site
   validates :name, presence: true
   validates :support_type, inclusion: { in: SUPPORT_TYPES }, presence: true

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -102,6 +102,20 @@ class Cluster < ApplicationRecord
     self.cases.where(state: 'resolved').count
   end
 
+  def current_service_plan
+    service_plans.where(
+      'start_date <= ? AND end_date >= ?',
+      Date.current,
+      Date.current
+    ).first
+  end
+
+  def previous_service_plan
+    service_plans.where('end_date < ?', Date.current)
+                 .order(:start_date)
+                 .last
+  end
+
   private
 
   def validate_all_cluster_parts_advice

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -3,4 +3,13 @@ class ServicePlan < ApplicationRecord
 
   validates :start_date, presence: true
   validates :end_date, presence: true
+
+  validate :end_after_start
+
+  private
+
+  def end_after_start
+    return unless start_date.present? && end_date.present?
+    errors.add(:end_date, 'must be on or after the start date') if end_date < start_date
+  end
 end

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -1,0 +1,6 @@
+class ServicePlan < ApplicationRecord
+  belongs_to :cluster
+
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+end

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -1,6 +1,8 @@
 class ServicePlan < ApplicationRecord
   belongs_to :cluster
 
+  delegate :site, to: :cluster
+
   validates :start_date, presence: true
   validates :end_date, presence: true
 

--- a/app/views/clusters/_credit_balance.html.erb
+++ b/app/views/clusters/_credit_balance.html.erb
@@ -1,6 +1,7 @@
 <div class="card credit-balance">
   <div class="card-body">
     <h4>Support credit balance</h4>
+    <%= cluster.service_plan_badge %>
     <p class="credit-balance <%= cluster.credit_balance_class %>">
       <i class="fa fa-circle mr-2" aria-hidden="true"></i>
       <%= pluralize(cluster.credit_balance, 'credit') %>

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -46,16 +46,16 @@
   <div class="col-sm-12 col-md-6">
     <%= render 'clusters/credit_balance', cluster: cluster do %>
       <%= link_to 'See detailed usage', cluster_credit_usage_path(cluster),
-                  class: 'btn btn-primary'
+                  class: 'btn btn-primary btn-block'
       %>
     <% end %>
     <%= render 'clusters/cluster_checks', cluster: cluster do %>
       <%= link_to 'See check history', cluster_checks_path(cluster),
-                  class: 'btn btn-primary'
+                  class: 'btn btn-primary btn-block'
       %>
       <% if policy(cluster).enter_check_results? && cluster.last_checked != Date.today %>
         <%= link_to 'Set check results for today', cluster_check_submission_path(cluster),
-                    class: 'btn btn-danger'
+                    class: 'btn btn-danger btn-block'
         %>
       <% end %>
     <% end %>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -18,28 +18,16 @@
                 <i class="fa fa-warning fa-2x fa-pull-left"></i>
                 No service plans cover this period.
               </div>
-            <% elsif service_plans.count == 1 %>
-              <div class="mt-2 alert alert-info">
-                <i class="fa fa-info fa-2x fa-pull-left"></i>
-                This period includes the service plan running from
-                <%= service_plans.first.start_date.to_formatted_s(:friendly_date) %>
-                to
-                <%= service_plans.first.end_date.to_formatted_s(:friendly_date) %>.
-              </div>
             <% else %>
-              <div class="mt-2 alert alert-info">
-                <i class="fa fa-info fa-2x fa-pull-left"></i>
-                This period includes the service plans running from:
-
-                <ul>
-                  <% service_plans.each do |sp| %>
-                    <li>
-                      <%= sp.start_date.to_formatted_s(:friendly_date) %>
-                      to
-                      <%= sp.end_date.to_formatted_s(:friendly_date) %>
-                    </li>
-                  <% end %>
-                </ul>
+              <div class="text-center mb-2">
+                <% service_plans.each do |sp| %>
+                  <div class="badge badge-info">
+                    Service plan:
+                    <%= sp.start_date.to_formatted_s(:friendly_date) %>
+                    to
+                    <%= sp.end_date.to_formatted_s(:friendly_date) %>
+                  </div>
+                <% end %>
               </div>
             <% end %>
             <table class="table table-sm">

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -12,6 +12,36 @@
         <div class="card">
           <div class="card-body">
             <h4>Usage for <%= quarter_display_name(@start_date) %>:</h4>
+            <% service_plans = cluster.service_plans_covering(@start_date, @end_date) %>
+            <% if service_plans.empty? %>
+              <div class="mt-2 alert alert-warning">
+                <i class="fa fa-warning fa-2x fa-pull-left"></i>
+                No service plans cover this period.
+              </div>
+            <% elsif service_plans.count == 1 %>
+              <div class="mt-2 alert alert-info">
+                <i class="fa fa-info fa-2x fa-pull-left"></i>
+                This period includes the service plan running from
+                <%= service_plans.first.start_date.to_formatted_s(:friendly_date) %>
+                to
+                <%= service_plans.first.end_date.to_formatted_s(:friendly_date) %>.
+              </div>
+            <% else %>
+              <div class="mt-2 alert alert-info">
+                <i class="fa fa-info fa-2x fa-pull-left"></i>
+                This period includes the service plans running from:
+
+                <ul>
+                  <% service_plans.each do |sp| %>
+                    <li>
+                      <%= sp.start_date.to_formatted_s(:friendly_date) %>
+                      to
+                      <%= sp.end_date.to_formatted_s(:friendly_date) %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
             <table class="table table-sm">
               <tr class="text-success">
                 <th>Total accrued</th>

--- a/app/views/clusters/credit_usage.html.erb
+++ b/app/views/clusters/credit_usage.html.erb
@@ -23,9 +23,9 @@
                 <% service_plans.each do |sp| %>
                   <div class="badge badge-info">
                     Service plan:
-                    <%= sp.start_date.to_formatted_s(:friendly_date) %>
+                    <%= sp.start_date.to_formatted_s(ClusterDecorator::SERVICE_PLAN_DATE_FORMAT) %>
                     to
-                    <%= sp.end_date.to_formatted_s(:friendly_date) %>
+                    <%= sp.end_date.to_formatted_s(ClusterDecorator::SERVICE_PLAN_DATE_FORMAT) %>
                   </div>
                 <% end %>
               </div>

--- a/app/views/sites/_cluster_box.html.erb
+++ b/app/views/sites/_cluster_box.html.erb
@@ -1,0 +1,29 @@
+<div class="list-group-item">
+  <h4><%= cluster.name %></h4>
+  <span>
+    <%= link_to "Manage this cluster",
+                cluster_path(cluster),
+                class: [
+                    'btn',
+                    'btn-primary'
+                ]
+    %>
+    <%= link_to "View cases",
+                cluster_cases_path(cluster, state: 'open'),
+                class: [
+                    'btn',
+                    'btn-primary'
+                ]
+    %>
+
+    <%= link_to "Create case",
+                new_cluster_case_path(cluster),
+                PolicyDependentOptions.wrap(
+                    {class: ['btn', 'btn-danger']},
+                    policy: policy(Case).create?,
+                    action_description: 'create a case',
+                    user: current_user
+                )
+    %>
+  </span>
+</div>

--- a/app/views/sites/_cluster_box.html.erb
+++ b/app/views/sites/_cluster_box.html.erb
@@ -1,6 +1,9 @@
 <div class="list-group-item">
-  <h4><%= cluster.name %></h4>
-  <span>
+  <h4>
+    <%= cluster.name %>
+    <%= cluster.service_plan_badge %>
+  </h4>
+  <div>
     <%= link_to "Manage this cluster",
                 cluster_path(cluster),
                 class: [
@@ -25,5 +28,5 @@
                     user: current_user
                 )
     %>
-  </span>
+  </div>
 </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -53,35 +53,7 @@
       <h3>Clusters</h3>
       <div class="list-group cluster-list">
         <% site.clusters.each do |cluster| %>
-          <div class="list-group-item">
-            <h4><%= cluster.name %></h4>
-            <span>
-              <%= link_to "Manage this cluster",
-                          cluster_path(cluster),
-                          class: [
-                            'btn',
-                            'btn-primary'
-                          ]
-              %>
-              <%= link_to "View cases",
-                          cluster_cases_path(cluster, state: 'open'),
-                          class: [
-                            'btn',
-                            'btn-primary'
-                          ]
-              %>
-
-              <%= link_to "Create case",
-                          new_cluster_case_path(cluster),
-                          PolicyDependentOptions.wrap(
-                            {class: ['btn', 'btn-danger']},
-                            policy: policy(Case).create?,
-                            action_description: 'create a case',
-                            user: current_user
-                          )
-              %>
-            </span>
-          </div>
+          <%= render 'sites/cluster_box', cluster: cluster %>
         <% end %>
       </div>
     </div>

--- a/db/migrate/20180828100631_create_service_plans.rb
+++ b/db/migrate/20180828100631_create_service_plans.rb
@@ -1,0 +1,9 @@
+class CreateServicePlans < ActiveRecord::Migration[5.2]
+  def change
+    create_table :service_plans do |t|
+      t.references :cluster, foreign_key: true, null: false
+      t.date :start_date, null: false
+      t.date :end_date, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_24_095501) do
+ActiveRecord::Schema.define(version: 2018_08_28_100631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -353,6 +353,13 @@ ActiveRecord::Schema.define(version: 2018_08_24_095501) do
     t.index ["cluster_id"], name: "index_notes_on_cluster_id"
   end
 
+  create_table "service_plans", force: :cascade do |t|
+    t.bigint "cluster_id", null: false
+    t.date "start_date", null: false
+    t.date "end_date", null: false
+    t.index ["cluster_id"], name: "index_service_plans_on_cluster_id"
+  end
+
   create_table "service_types", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
@@ -454,6 +461,7 @@ ActiveRecord::Schema.define(version: 2018_08_24_095501) do
   add_foreign_key "maintenance_window_state_transitions", "users"
   add_foreign_key "maintenance_windows", "cases"
   add_foreign_key "notes", "clusters"
+  add_foreign_key "service_plans", "clusters"
   add_foreign_key "services", "clusters"
   add_foreign_key "services", "service_types"
   add_foreign_key "sites", "users", column: "default_assignee_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -151,4 +151,10 @@ FactoryBot.define do
     meta { { author: 'Alces Flight' } }
     association :topic, factory: :global_topic
   end
+
+  factory :service_plan do
+    association :cluster
+    start_date { '2018-01-01' }
+    end_date { '2020-12-30' }
+  end
 end

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -286,5 +286,16 @@ RSpec.describe Cluster, type: :model do
         expect(cluster.previous_service_plan).to eq plan_2
       end
     end
+
+    it 'identifies service plans covering a date range' do
+      expect(cluster.service_plans_covering('2018-01-01', '2019-05-01'))
+        .to eq [plan_1, plan_2]
+
+      expect(cluster.service_plans_covering('2018-02-01', '2018-02-28'))
+        .to eq [plan_1]
+
+      expect(cluster.service_plans_covering('2018-06-01', '2018-09-30'))
+        .to eq [plan_1, plan_2]
+    end
   end
 end

--- a/spec/models/cluster_spec.rb
+++ b/spec/models/cluster_spec.rb
@@ -209,4 +209,82 @@ RSpec.describe Cluster, type: :model do
       expect(subject.credit_balance).to eq -12
     end
   end
+
+  describe 'service plans' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    let(:cluster) { create(:cluster) }
+
+    let!(:plan_1) {
+      create(
+        :service_plan,
+        cluster: cluster,
+        start_date: '2018-01-01',
+        end_date: '2018-08-31'
+      )
+    }
+
+    let!(:plan_2) {
+      create(
+        :service_plan,
+        cluster: cluster,
+        start_date: '2018-09-05',
+        end_date: '2019-04-30'
+      )
+    }
+
+    it 'locates current plan' do
+      travel_to Time.zone.local(2017, 12, 30) do
+        expect(cluster.current_service_plan).to eq nil
+      end
+      travel_to Time.zone.local(2018, 1, 1) do
+        expect(cluster.current_service_plan).to eq plan_1
+      end
+      travel_to Time.zone.local(2018, 8, 31) do
+        expect(cluster.current_service_plan).to eq plan_1
+      end
+      travel_to Time.zone.local(2018, 9, 1) do
+        expect(cluster.current_service_plan).to eq nil
+      end
+      travel_to Time.zone.local(2018, 9, 4) do
+        expect(cluster.current_service_plan).to eq nil
+      end
+      travel_to Time.zone.local(2018, 9, 5) do
+        expect(cluster.current_service_plan).to eq plan_2
+      end
+      travel_to Time.zone.local(2019, 4, 30) do
+        expect(cluster.current_service_plan).to eq plan_2
+      end
+      travel_to Time.zone.local(2019, 5, 1) do
+        expect(cluster.current_service_plan).to eq nil
+      end
+    end
+
+    it 'locates previous plan' do
+      travel_to Time.zone.local(2017, 12, 30) do
+        expect(cluster.previous_service_plan).to eq nil
+      end
+      travel_to Time.zone.local(2018, 1, 1) do
+        expect(cluster.previous_service_plan).to eq nil
+      end
+      travel_to Time.zone.local(2018, 8, 31) do
+        expect(cluster.previous_service_plan).to eq nil
+      end
+      travel_to Time.zone.local(2018, 9, 1) do
+        expect(cluster.previous_service_plan).to eq plan_1
+      end
+      travel_to Time.zone.local(2018, 9, 4) do
+        expect(cluster.previous_service_plan).to eq plan_1
+      end
+      travel_to Time.zone.local(2018, 9, 5) do
+        expect(cluster.previous_service_plan).to eq plan_1
+      end
+      travel_to Time.zone.local(2019, 4, 30) do
+        expect(cluster.previous_service_plan).to eq plan_1
+      end
+      travel_to Time.zone.local(2019, 5, 1) do
+        expect(cluster.previous_service_plan).to eq plan_2
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #403 by adding the concept of "service plans", associated with clusters, and displaying that information in a variety of places.

On the site dashboard:
![selection_046](https://user-images.githubusercontent.com/3471844/44737051-d8215d80-aae8-11e8-9614-0d81be04fb5f.png)

With different colours for nearly-expired and expired service plans:
![selection_047](https://user-images.githubusercontent.com/3471844/44737088-ec655a80-aae8-11e8-97cd-fbb0ca82367b.png)
![selection_048](https://user-images.githubusercontent.com/3471844/44737092-ef604b00-aae8-11e8-9da0-75bb4ea3dc7a.png)

For each period viewed on the credit usage report, we list any overlapping service plans:
![selection_049](https://user-images.githubusercontent.com/3471844/44737130-0e5edd00-aae9-11e8-9530-6a6392d36824.png)
![selection_050](https://user-images.githubusercontent.com/3471844/44737338-9e048b80-aae9-11e8-8a77-0b6953aef6d5.png)

and warn when the period is not covered by a service plan:
![selection_051](https://user-images.githubusercontent.com/3471844/44737328-9218c980-aae9-11e8-869c-23b770ec169d.png)

@mjtko @ste78 Any comments or changes you'd like to how this information is presented?

Trello: https://trello.com/c/VicFrPKR/443-store-and-display-service-plan-dates-for-clusters