### PR TITLE
Allow case association form to be submitted when empty.

### DIFF
--- a/app/assets/javascripts/cluster_tree.js
+++ b/app/assets/javascripts/cluster_tree.js
@@ -80,9 +80,6 @@ function _init_cluster_tree(idx) {
 
       }
     );
-
-    // Don't allow form to be submitted with no associations selected.
-    $('#association-form-submit').prop('disabled', target.html() === '');
   }.bind(this);
 
   $(this).find('input[type=checkbox]').on(

--- a/app/controllers/case_associations_controller.rb
+++ b/app/controllers/case_associations_controller.rb
@@ -42,7 +42,7 @@ class CaseAssociationsController < ApplicationController
   end
 
   def map_association_params
-    params[:associations].map do |assoc|
+    assoc_param.map do |assoc|
       assoc_data = ASSOCIATION_PARAM_REGEX.match(assoc)
       if assoc_data
         Kernel.const_get(assoc_data[:type]).find(assoc_data[:id])
@@ -67,6 +67,10 @@ class CaseAssociationsController < ApplicationController
         @case.associations = old_assocs
       end
     end
+  end
+
+  def assoc_param
+    params[:associations] || []
   end
 
 end

--- a/spec/features/case_associations/edit_spec.rb
+++ b/spec/features/case_associations/edit_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'Case association edit form', type: :feature, js: true do
 
         expect(cluster_tree_summary.text).to eq 'Group A Component a1 Component a2 Component a3'
 
-        expect(SlackNotifier).to receive(:case_association_notification).with(kase, admin)
+        expect(SlackNotifier).to receive(:case_association_notification).with(kase, admin, anything)
 
         click_button 'Save'
 
@@ -206,6 +206,34 @@ RSpec.describe 'Case association edit form', type: :feature, js: true do
 
         expect(kase.associated_audits.where(auditable_type: 'CaseAssociation').length)
           .to eq initial_number_of_audits  # No new audits added
+      end
+    end
+
+    context 'for a case whose issue does not require an association' do
+      let(:issue) {
+        create(:issue, requires_service: false, service_type: nil, name: 'Other')
+      }
+      let!(:service) do
+        create(:service, cluster: cluster)
+      end
+      let(:kase) {
+        create(
+          :open_case,
+          cluster: cluster,
+          services: [service],
+          issue: issue
+        )
+      }
+
+      it 'allows removal of all associations' do
+
+        expect(checkbox_for[service]).to be_checked
+        checkbox_for[service].click
+        click_button 'Save'
+
+        kase.reload
+        expect(kase.associations).to be_empty
+
       end
     end
   end


### PR DESCRIPTION
As title.

Trello: https://trello.com/c/fFnYjfNT/455-allow-case-association-form-to-clear-all-associations