### PR TITLE
Italicise name and date when showing case creation details.

### DIFF
--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -67,9 +67,9 @@
         <th>Created</th>
         <td>
           By
-          <%= @case.user.name %>
+          <em><%= @case.user.name %></em>
           on
-          <%= @case.created_at.to_formatted_s(:short) %>
+          <em><%= @case.created_at.to_formatted_s(:short) %></em>
         </td>
         <th>Assigned to</th>
         <td id="case-assignment">

--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -6,7 +6,7 @@
     description:  'Support case created',
     timestamp: kase.created_at
   ) do |content|
-      render 'partials/table_cell_link', url: url, cell_content: "By #{kase.user.name} on #{content}"
+      render 'partials/table_cell_link', url: url, cell_content: raw("By <em>#{kase.user.name}</em> on <em>#{content}</em>")
   end %>
   <td><%= render 'partials/table_cell_link', url: url, cell_content: kase.user_facing_state %></td>
   <td><%= render 'partials/table_cell_link', url: url, cell_content: kase.subject %></td>


### PR DESCRIPTION
Fixes #503.

Trello: https://trello.com/c/VHXLdXBk/444-italicise-date-and-creator-in-case-created-column