### PR TITLE
Update CR email text

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -149,10 +149,12 @@ class ChangeRequestsController < ApplicationController
       # the record to the database (or raised an exception). Hence we can be
       # certain that, if we reach this point, the model is saved and valid, so
       # it's safe to send the email.
+
+      last_transition = cr.transitions.last.decorate
       email(
         [
           cr.case,
-          "The change request for this case #{cr.transitions.last.decorate.text_for_event}",
+          "#{last_transition.article_for_event} change request for this case #{last_transition.text_for_event}",
           current_user,
           @recipients ||= @case.email_recipients
         ]

--- a/app/decorators/change_request_state_transition_decorator.rb
+++ b/app/decorators/change_request_state_transition_decorator.rb
@@ -28,6 +28,15 @@ class ChangeRequestStateTransitionDecorator < ApplicationDecorator
     end
   end
 
+  def article_for_event
+    case object.event
+    when 'propose'
+      'A'
+    else
+      'The'
+    end
+  end
+
   private
 
   def cr_link

--- a/app/mailers/case_mailer.rb
+++ b/app/mailers/case_mailer.rb
@@ -82,12 +82,12 @@ class CaseMailer < ApplicationMailer
 
   def change_request(my_case, text, user, recipients)
     @case = my_case
-    @text = text
+    @text = text.gsub(/ customer /, ' your ')
     mail(
       cc: recipients,
       subject: @case.email_reply_subject
     )
-    SlackNotifier.change_request_notification(@case, @text, user)
+    SlackNotifier.change_request_notification(@case, text, user)
   end
 
   def change_association(my_case, user)

--- a/spec/controllers/change_requests_controller_spec.rb
+++ b/spec/controllers/change_requests_controller_spec.rb
@@ -27,9 +27,12 @@ RSpec.describe ChangeRequestsController, type: :controller do
       it "transitions from #{initial_state} to #{next_state}" do
 
         cr = create(:change_request, case: kase, state: initial_state)
+
+        article = action == :propose ? 'A' : 'The'
+
         expect(CaseMailer).to receive(:change_request).with(
           kase,
-          "The change request for this case #{message}",
+          "#{article} change request for this case #{message}",
           send(user),
           [contact.email]
         ).and_return(stub_mail)


### PR DESCRIPTION
This PR fixes #487 by changing the text of the CR-proposed email to use "your" rather than "customer", and the article from "the" to "a" everywhere this text is used.

Trello: https://trello.com/c/jUxmNlgo/438-update-text-in-cr-proposed-email