### PR TITLE
Administrative cases

### DIFF
--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -139,7 +139,10 @@ class ClusterDecorator < ApplicationDecorator
       other_service
       .decorate
       .case_form_json
-      .merge(IssuesJsonBuilder.build_for(self))
+      .merge(IssuesJsonBuilder.build_for(
+        self,
+        !current_user || current_user.admin?
+      ))
   end
 
   def other_service
@@ -155,11 +158,15 @@ class ClusterDecorator < ApplicationDecorator
     private
 
     def self.other_service_issues
-      Issue.where(requires_component: false, requires_service: false).decorate.reject(&:special?)
+      Issue.where(requires_component: false, requires_service: false)
+           .decorate
+           .reject(&:special?)
     end
 
     def applicable_issues
-      self.class.other_service_issues
+      self.class.other_service_issues.reject { |i|
+        !@admin && i.administrative?
+      }
     end
   end
 

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -141,7 +141,7 @@ class ClusterDecorator < ApplicationDecorator
       .case_form_json
       .merge(IssuesJsonBuilder.build_for(
         self,
-        !current_user || current_user.admin?
+        current_user
       ))
   end
 
@@ -165,7 +165,7 @@ class ClusterDecorator < ApplicationDecorator
 
     def applicable_issues
       self.class.other_service_issues.reject { |i|
-        !@admin && i.administrative?
+        i.administrative? && @user && !@user.admin?
       }
     end
   end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -50,7 +50,6 @@ class Case < ApplicationRecord
   has_one :credit_charge, required: false
 
   delegate :category, to: :issue
-  delegate :email_recipients, to: :site
   delegate :site, to: :cluster, allow_nil: true
 
   state_machine initial: :open do
@@ -211,6 +210,14 @@ class Case < ApplicationRecord
       "[helpdesk.alces-software.com ##{rt_ticket_id}]"
     else
       "[Alces Flight Center #{display_id}]"
+    end
+  end
+
+  def email_recipients
+    if issue.administrative?
+      []
+    else
+      site.email_recipients
     end
   end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -263,7 +263,7 @@ class Case < ApplicationRecord
   def comments_could_be_enabled?
     # If this condition is met then comments by contacts are enabled iff
     # comments_enabled is true.
-    open? && !consultancy?
+    open? && !consultancy? && !issue.administrative?
   end
 
   def can_create_change_request?

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -116,6 +116,8 @@ class Case < ApplicationRecord
 
   validates_with AssociatedModelValidator
 
+  validates_with IssueValidator
+
   validate :validates_user_assignment
 
   validate :validate_not_resolved_with_open_cr

--- a/app/models/case/issue_validator.rb
+++ b/app/models/case/issue_validator.rb
@@ -1,0 +1,12 @@
+
+class Case
+  class IssueValidator < ActiveModel::Validator
+    def validate(record)
+      if record.issue.administrative?
+        unless record.maintenance_windows.unfinished.empty?
+          record.errors.add(:issue, 'cannot be administrative if there are unfinished maintenance windows')
+        end
+      end
+    end
+  end
+end

--- a/app/models/case/issue_validator.rb
+++ b/app/models/case/issue_validator.rb
@@ -2,7 +2,7 @@
 class Case
   class IssueValidator < ActiveModel::Validator
     def validate(record)
-      if record.issue.administrative?
+      if record.issue.respond_to?(:administrative?) && record.issue.administrative?
         unless record.maintenance_windows.unfinished.empty?
           record.errors.add(:issue, 'cannot be administrative if there are unfinished maintenance windows')
         end

--- a/app/models/case_commenting.rb
+++ b/app/models/case_commenting.rb
@@ -14,6 +14,8 @@ class CaseCommenting
       viewer_cannot_comment_message
     elsif !kase.open?
       not_open_message
+    elsif kase.issue.administrative? && !user.admin?
+      administrative_message
     elsif user.contact? && kase.comments_could_be_enabled? && !kase.comments_enabled
       non_consultancy_message
     else
@@ -39,5 +41,9 @@ class CaseCommenting
       request additional support please either escalate this case, or open a
       new support case.
     MESSAGE
+  end
+
+  def administrative_message
+    'Commenting is disabled as this is an administrative case.'
   end
 end

--- a/app/models/maintenance_window.rb
+++ b/app/models/maintenance_window.rb
@@ -91,6 +91,10 @@ class MaintenanceWindow < ApplicationRecord
     end
   end
 
+  def finished?
+    self.class.finished_states.include? state
+  end
+
   def associated_models
     component_groups + components + services + clusters
   end

--- a/app/models/maintenance_window/validator.rb
+++ b/app/models/maintenance_window/validator.rb
@@ -7,6 +7,7 @@ class MaintenanceWindow < ApplicationRecord
       validate_at_least_one_associated_model
       validate_homogenous_cluster
       validate_requested_period
+      validate_case_not_administrative
     end
 
     private
@@ -75,6 +76,14 @@ class MaintenanceWindow < ApplicationRecord
       unless clusters.length == 1
         record.errors.add(
           :base, 'All associated components must belong to the same cluster'
+        )
+      end
+    end
+
+    def validate_case_not_administrative
+      if !record.finished? && record.case&.issue&.administrative?
+        record.errors.add(
+          :case, 'must not be an administrative case'
         )
       end
     end

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -88,7 +88,7 @@
                           role: 'button'
               %>
             <% end %>
-            <% if policy(MaintenanceWindow).create? %>
+            <% if policy(MaintenanceWindow).create? && !@case.issue.administrative? %>
               <%= link_to 'Request maintenance',
                           @case.request_maintenance_path,
                           class: 'btn btn-secondary ml-2 btn-sm',

--- a/db/data/20180829150212_add_administrative_issue.rb
+++ b/db/data/20180829150212_add_administrative_issue.rb
@@ -1,0 +1,22 @@
+class AddAdministrativeIssue < ActiveRecord::Migration[5.2]
+
+  ADMIN_ISSUE_NAME = 'Administrative'.freeze
+
+  def up
+    issue = Issue.create!(
+      name: ADMIN_ISSUE_NAME,
+      administrative: true,
+      requires_component: false,
+      requires_service: false,
+      service_type: nil
+    )
+
+    tier = issue.tiers.first
+    tier.level = 2
+    tier.save!
+  end
+
+  def down
+    Issue.find_by_name(ADMIN_ISSUE_NAME).destroy!
+  end
+end

--- a/db/data/20180829150212_add_administrative_issue.rb
+++ b/db/data/20180829150212_add_administrative_issue.rb
@@ -3,6 +3,7 @@ class AddAdministrativeIssue < ActiveRecord::Migration[5.2]
   ADMIN_ISSUE_NAME = 'Administrative'.freeze
 
   def up
+    Issue.reset_column_information
     issue = Issue.create!(
       name: ADMIN_ISSUE_NAME,
       administrative: true,

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20180824162550)
+DataMigrate::Data.define(version: 20180829150212)

--- a/db/migrate/20180829145124_add_administrative_to_issues.rb
+++ b/db/migrate/20180829145124_add_administrative_to_issues.rb
@@ -1,0 +1,5 @@
+class AddAdministrativeToIssues < ActiveRecord::Migration[5.2]
+  def change
+    add_column :issues, :administrative, :bool, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_28_100631) do
+ActiveRecord::Schema.define(version: 2018_08_29_145124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -293,6 +293,7 @@ ActiveRecord::Schema.define(version: 2018_08_28_100631) do
     t.boolean "requires_service", default: false, null: false
     t.bigint "service_type_id"
     t.bigint "category_id"
+    t.boolean "administrative", default: false, null: false
     t.index ["category_id"], name: "index_issues_on_category_id"
     t.index ["service_type_id"], name: "index_issues_on_service_type_id"
   end

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
   factory :issue do
     name 'New user/group'
     requires_component false
+    administrative false
 
     factory :issue_with_category do
       name 'Motd change request'
@@ -39,6 +40,10 @@ FactoryBot.define do
 
     factory :special_issue do
       identifier Issue::IDENTIFIER_NAMES.first
+    end
+
+    factory :administrative_issue do
+      administrative true
     end
   end
 end

--- a/spec/mailers/case_mailer_spec.rb
+++ b/spec/mailers/case_mailer_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe 'Case mailer', :type => :mailer do
     end
 
     include_examples 'Slack'
+
+    context 'where case is for an administrative issue' do
+      let(:issue) { create(:administrative_issue) }
+
+      it 'excludes all site email addresses' do
+        expect(subject.to).to eq nil
+        expect(subject.cc).to match_array []
+        expect(subject.bcc).to match_array(['tickets@alces-software.com'])
+      end
+    end
   end
 
   describe 'Comment email' do
@@ -125,6 +135,17 @@ RSpec.describe 'Case mailer', :type => :mailer do
       expect(subject.bcc).to match_array(['tickets@alces-software.com'])
 
       expect(subject.body.encoded).to match('I can haz comment')
+    end
+
+
+    context 'where case is for an administrative issue' do
+      let(:issue) { create(:administrative_issue) }
+
+      it 'excludes all site email addresses' do
+        expect(subject.to).to eq nil
+        expect(subject.cc).to match_array []
+        expect(subject.bcc).to match_array(['tickets@alces-software.com'])
+      end
     end
 
     include_examples 'Slack'
@@ -195,6 +216,17 @@ RSpec.describe 'Case mailer', :type => :mailer do
       let (:slack_args) { [kase, text, requestor] }
 
       include_examples 'Slack'
+
+
+      context 'where case is for an administrative issue' do
+        let(:issue) { create(:administrative_issue) }
+
+        it 'excludes all site email addresses' do
+          expect(subject.to).to eq nil
+          expect(subject.cc).to match_array []
+          expect(subject.bcc).to match_array(['tickets@alces-software.com'])
+        end
+      end
     end
   end
 

--- a/spec/models/case_commenting_spec.rb
+++ b/spec/models/case_commenting_spec.rb
@@ -107,5 +107,30 @@ RSpec.describe CaseCommenting do
         end
       end
     end
+
+    context 'when Case has administrative issue' do
+      let(:issue) { create(:administrative_issue) }
+      let(:kase) { create("#{state}_case".to_sym, issue: issue) }
+
+      include_examples 'commenting disabled for viewer'
+
+      context 'for admin' do
+        let(:user) { create(:admin) }
+
+        include_examples 'commenting enabled'
+      end
+
+      context 'for contact' do
+        let(:user) { create(:contact) }
+
+        it 'should have commenting disabled' do
+          expect(subject).to be_disabled
+          expect(subject.disabled_text).to include(
+            'this is an administrative case'
+          )
+        end
+      end
+
+    end
   end
 end

--- a/spec/models/maintenance_window_spec.rb
+++ b/spec/models/maintenance_window_spec.rb
@@ -541,4 +541,17 @@ RSpec.describe MaintenanceWindow, type: :model do
       end
     end
   end
+
+  it 'cannot be created for an administrative case' do
+    cluster = create(:cluster)
+    issue = create(:administrative_issue)
+    kase = create(:open_case, issue: issue, clusters: [cluster])
+    mw = build(:maintenance_window, case: kase)
+
+    expect do
+      mw.save!
+    end.to raise_exception ActiveRecord::RecordInvalid
+
+    expect(mw.errors[:case]).to include 'must not be an administrative case'
+  end
 end


### PR DESCRIPTION
This PR introduces the concept of "administrative" cases - that is, cases that are read-only for site users.

We achieve this by introducing a new class of `Issue` available only to admins, `administrative`; cases with an administrative issue set enjoy a reduced set of functionality:
- Site contacts (and viewers) are unable to comment
- Emails are not sent to site email addresses
- Maintenance cannot be requested (nor can a case with outstanding maintenance windows be assigned an administrative issue) since this presupposes interaction with customers

Other than in the scenario outlined above, it's possible to move a case into and out of being "administrative" by changing its assigned issue. Usual restrictions (issues requiring a service need the case to have an association to that sort of service) apply.

This PR also creates our first administrative `Issue`, imaginatively titled "Administrative". It requires no service nor a component. It's only available in the new case form for admin users and lives under the "Other or N/A" pseudoservice.

> Sidebar on why an issue to represent this:
> 
> The original request, #526, suggested using an additional tier to represent this state. Customers normally raise issues at tier 2 (or 3). We already have existing tiers 0 and 1. So we'd either have to have a -1st tier (weird) or else administrative-ness belongs on a separate axis to tier-ism. The latter makes the most sense.
> 
> The category/issue system is designed to facilitate customers in raising cases that contain the information we need to solve their problems. Once a case has been raised, we don't really use it for anything other than having some sort of value to display (and making sure a minimum set of required associations is maintained). Logically, it makes sense to use this to determine administrativeness-ness: 
> > All of _these_ cases are to create new users, _these_ are suspected hardware issues, and _those_ are admin ones that we've raised to track things...

Note that there is one aspect of #526 not covered by this PR, that which specifies that "no site contact is assigned" to administrative cases. Site contacts for cases aren't yet merged to `develop` (see #555) so that can't happen yet!

Trello: https://trello.com/c/xsh9DNES/449-add-administrative-internal-cases