### PR TITLE
Fix handling daily admin mail via Resque

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,7 +3,10 @@ class AdminMailer < ApplicationMailer
 
   def daily_open_cases_list(admin, cases)
     @admin = admin
-    @cases = cases.decorate
+    # Because we Resque serialise this job, cases here will be a plain array
+    # rather than an ActiveRecord association, so we can't just call `decorate`
+    # on the whole.
+    @cases = cases.map(&:decorate)
 
     mail(
       to: admin.email,


### PR DESCRIPTION
Because of the way we serialise/deserialise mailer arguments through Resque, we need to treat `cases` here as an array, not an ActiveRecord association (it doesn't have a `decorate` method).