### PR TITLE
Don't assign contacts to administrative cases

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -394,6 +394,10 @@ class Case < ApplicationRecord
     [self.assignee, self.contact].include?(current_user)
   end
 
+  def administrative?
+    subject == 'Administrative'
+  end
+
   private
 
   # Picked up by state_machines-audit_trail due to `context` setting above, and

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -506,7 +506,11 @@ class Case < ApplicationRecord
 
   def validates_contact_assignment
     return if contact.nil?
-    errors.add(:contact, 'must belong to this site') unless (contact.site == site)
+    if administrative?
+      errors.add(:contact, "can't be assigned to an administrative case")
+    else
+      errors.add(:contact, 'must belong to this site') unless (contact.site == site)
+    end
   end
 
   def set_display_id

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -480,7 +480,7 @@ class Case < ApplicationRecord
   end
 
   def set_assigned_contact
-    if open? && contact.nil?
+    if open? && !administrative? && contact.nil?
       new_contact = if user.admin?
                   site.primary_contact
                 else

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -395,7 +395,7 @@ class Case < ApplicationRecord
   end
 
   def administrative?
-    subject == 'Administrative'
+    issue.administrative
   end
 
   private

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -20,7 +20,9 @@ class CasePolicy < ApplicationPolicy
   end
 
   def assign_contact?
-    user.admin? | user.contact?
+    unless record.administrative?
+      user.admin? | user.contact?
+    end
   end
 
   class Scope < Scope

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -426,6 +426,19 @@ RSpec.describe 'Case page', type: :feature do
             .to have_text 'This case is no longer assigned to a contact.'
         end
       end
+
+      context 'when viewing an administrative case' do
+        let(:issue) { create(:administrative_issue) }
+        let(:admin_case) { create(:open_case, issue: issue, cluster: cluster) }
+
+        it 'hides contact assignment controls' do
+          visit cluster_case_path(cluster, admin_case, as: user)
+
+          assignment_td = find('#case-contact-assignment')
+          expect { assignment_td.find('input') }.to raise_error(Capybara::ElementNotFound)
+          expect(assignment_td.text).to eq('Nobody')
+        end
+      end
     end
 
     context 'as an admin' do

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -595,4 +595,19 @@ RSpec.describe Case, type: :model do
       end
     end
   end
+
+  describe '#administrative?' do
+    let(:issue) { create(:administrative_issue) }
+    let(:admin_case) { create(:open_case, issue: issue) }
+    let(:open_case) { create(:open_case) }
+
+    it 'returns true when case issue is administrative' do
+      expect(admin_case.administrative?).to eq true
+    end
+
+
+    it 'returns false when case issue is not administrative' do
+      expect(open_case.administrative?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
When an administrative case has been created it will no longer assign a default contact to the case. To ensure contacts are not assigned after this the contact assignment controls are disabled for such cases and attempting to assign a contact via the rails admin interface will throw a validation error.

[Trello](https://trello.com/c/9Lh1Rbtx/457-no-site-assignee-should-be-set-for-administrative-cases)