### PR TITLE
Global topics (and articles) are available to all flight platform users

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,8 @@
 class TopicsController < ApplicationController
   def index
-    if current_user.nil?
+    # Check for `signed_in_without_account?` here as Flight Platform users
+    # without a Flight Center account have access to topics.  
+    if current_user.nil? && !signed_in_without_account?
       render status: :unauthorized,
         json: { error: 'Authentication required' }
       return

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -1,7 +1,9 @@
 class TopicPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if user.admin?
+      if user.nil?
+        scope.where(site_id: nil)
+      elsif user.admin?
         scope.where(site_id: nil)
       else
         scope.where(site_id: nil).or(scope.where(site_id: user.site))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,8 @@ Rails.application.routes.draw do
 
   constraints Clearance::Constraints::SignedOut.new do
     root 'sso_sessions#new', as: 'sign_in'
+    # We add :topics here as Platform users without a Flight Center account
+    # still have access to topics.
     resources :topics, only: [:index]
   end
 


### PR DESCRIPTION
The `flight support` cluster CLI tool is to be available to cluster users.  We wish to provide them with access to the support topics and articles for their site/cluster and to use the tool to drive them towards the Flight Platform.

When a cluster user uses the tool, they will be prompted to sign up / sign in to the Flight Platform by using the `flight account` CLI tool.  When they have done so they can use `flight support` to view the support topics.  We don't require a Center account for such users as we 1) wish to avoid having to create lots of accounts in Center; and 2) Center is focused on cluster administrators not cluster users.

Currently, a request from a cluster user will display only global (non-site specific) topics.  Eventually, the HTTP request will be augmented to include the cluster from which the request is being made, at which point the correct site-specific topics can be included too.