### PR TITLE
Add a site picker dropdown for admins

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -174,6 +174,13 @@ a.filter {
   width: 100%;
 }
 
-.product-bar .dropdown-item {
-  color: white;
+.product-bar {
+  .dropdown-item {
+    color: white;
+  }
+
+  .nav-item .dropdown-toggle {
+    padding: 0.5rem;
+    margin-right: -1rem;
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -173,3 +173,7 @@ a.filter {
   display: block;
   width: 100%;
 }
+
+.product-bar .dropdown-item {
+  color: white;
+}

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -23,23 +23,28 @@ class ScopeNavLinksBuilder
 
   def global_link
     if h.current_user&.admin?
-      nav_link_proc(text: 'Global',
-                    path: h.root_path,
-                    nav_icon: 'fa-globe')
+      nav_link_proc(
+        active: model_from_scope(:site).nil?,
+        text: 'Global',
+        path: h.root_path,
+        nav_icon: 'fa-globe'
+      )
     end
   end
 
   def site_link
     site = model_from_scope :site
-    return nil unless site
-    path_for_site = if h.current_user.admin?
-                      site
-                    else
-                      h.root_path
-                    end
-    nav_link_proc(model: site,
-                  path: path_for_site,
-                  nav_icon: 'fa-institution')
+
+    if h.current_user&.admin?
+      site_picker_proc(site)
+    else
+      return nil unless site
+      nav_link_proc(model: site,
+                    path: h.root_path,
+                    nav_icon: 'fa-institution')
+    end
+
+
   end
 
   def cluster_link
@@ -90,6 +95,12 @@ class ScopeNavLinksBuilder
   def nav_link_proc(**inputs_to_partial)
     Proc.new do |**additional_inputs|
       h.render 'partials/nav_link', **additional_inputs, **inputs_to_partial
+    end
+  end
+
+  def site_picker_proc(active_site)
+    Proc.new do |**additional_inputs|
+      h.render 'partials/site_picker', active_site: active_site, **additional_inputs
     end
   end
 end

--- a/app/helpers/scope_nav_links_builder.rb
+++ b/app/helpers/scope_nav_links_builder.rb
@@ -8,7 +8,7 @@ class ScopeNavLinksBuilder
 
   def build
     [
-      all_sites_link,
+      global_link,
       site_link,
       cluster_link,
       component_group_link,
@@ -21,7 +21,7 @@ class ScopeNavLinksBuilder
 
   attr_reader :scope
 
-  def all_sites_link
+  def global_link
     if h.current_user&.admin?
       nav_link_proc(text: 'Global',
                     path: h.root_path,

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -23,7 +23,7 @@
 <li class='nav-item<%= ' dropdown' if dropdown %>'>
   <%= link_to icon_span(text, nav_icon), path, link_options %>
   <% if dropdown %>
-    <div class='dropdown-menu dropdown-menu-right'>
+    <div class='dropdown-menu'>
       <% dropdown.each do |dropitem| %>
         <% if dropitem[:heading] %>
           <h6 class="dropdown-header"><%= dropitem[:text] %></h6>

--- a/app/views/partials/_nav_link.html.erb
+++ b/app/views/partials/_nav_link.html.erb
@@ -23,7 +23,7 @@
 <li class='nav-item<%= ' dropdown' if dropdown %>'>
   <%= link_to icon_span(text, nav_icon), path, link_options %>
   <% if dropdown %>
-    <div class='dropdown-menu'>
+    <div class='dropdown-menu dropdown-menu-right'>
       <% dropdown.each do |dropitem| %>
         <% if dropitem[:heading] %>
           <h6 class="dropdown-header"><%= dropitem[:text] %></h6>

--- a/app/views/partials/_site_picker.html.erb
+++ b/app/views/partials/_site_picker.html.erb
@@ -1,14 +1,14 @@
-<%=
-  render 'partials/nav_link',
-         active: active && active_site,
-         model: active_site,
-         text: active_site.nil? ? 'Choose site' : nil,
-         path: active_site || root_path,
-         nav_icon: 'fa-institution',
-         dropdown: Site.all.map { |site|
-           {
-               text: raw("<i class='fa fa-institution mr-2'></i> #{site.name}"),
-               path: site
-           }
-         }
-%>
+<li class="nav-item dropdown">
+  <a href="<%= active_site ? site_path(active_site) : root_path %>" class="nav-link <%= active && active_site ? 'nav-link--active' : '' %>">
+    <span class="fa fa-institution"></span> <%= active_site&.name || 'Choose site' %>
+    <span class="dropdown-toggle ml-2" data-toggle="dropdown" data-target="#site-chooser"></span>
+  </a>
+  <div class="dropdown-menu" id="site-chooser">
+    <% Site.all.map {|site| %>
+      <a class="dropdown-item" href="<%= site_path(site) %>">
+        <span class="fa fa-institution"></span> <%= site.name %>
+      </a>
+    <% }
+    %>
+  </div>
+</li>

--- a/app/views/partials/_site_picker.html.erb
+++ b/app/views/partials/_site_picker.html.erb
@@ -1,0 +1,14 @@
+<%=
+  render 'partials/nav_link',
+         active: active && active_site,
+         model: active_site,
+         text: active_site.nil? ? 'Choose site' : nil,
+         path: active_site || root_path,
+         nav_icon: 'fa-institution',
+         dropdown: Site.all.map { |site|
+           {
+               text: site.name,
+               path: site
+           }
+         }
+%>

--- a/app/views/partials/_site_picker.html.erb
+++ b/app/views/partials/_site_picker.html.erb
@@ -7,7 +7,7 @@
          nav_icon: 'fa-institution',
          dropdown: Site.all.map { |site|
            {
-               text: site.name,
+               text: raw("<i class='fa fa-institution mr-2'></i> #{site.name}"),
                path: site
            }
          }

--- a/app/views/partials/_site_picker.html.erb
+++ b/app/views/partials/_site_picker.html.erb
@@ -1,9 +1,15 @@
 <li class="nav-item dropdown">
-  <a href="<%= active_site ? site_path(active_site) : root_path %>" class="nav-link <%= active && active_site ? 'nav-link--active' : '' %>">
-    <span class="fa fa-institution"></span> <%= active_site&.name || 'Choose site' %>
+  <% if active_site %>
+  <a href="<%= site_path(active_site) %>" class="nav-link <%= active ? 'nav-link--active' : '' %>">
+    <span class="fa fa-institution"></span> <%= active_site.name %>
     <span class="dropdown-toggle ml-2" data-toggle="dropdown" data-target="#site-chooser"></span>
   </a>
-  <div class="dropdown-menu" id="site-chooser">
+  <% else %>
+    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" data-target="#site-chooser">
+      <span class="fa fa-institution"></span> Choose site
+    </a>
+  <% end %>
+    <div class="dropdown-menu" id="site-chooser">
     <% Site.all.map {|site| %>
       <a class="dropdown-item" href="<%= site_path(site) %>">
         <span class="fa fa-institution"></span> <%= site.name %>

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -20,12 +20,19 @@ RSpec.feature 'Navigation Bar', type: :feature do
       expect(site_nav_items[0]).to have_link(href: '/')
     end
 
-    it 'only the last link is active' do
+    it 'only the last (non-picker) link is active' do
       active_css = '.nav-link--active'
-      site_nav_items[0..-2].each do |item|
-        expect(item).not_to have_css active_css
+
+      if site_nav_items.last&.text == 'Choose site'
+        expect(site_nav_items.length).to eq 2
+        expect(site_nav_items.first).to have_css active_css
+        expect(site_nav_items.last).not_to have_css active_css
+      else
+        site_nav_items[0..-2].each do |item|
+          expect(item).not_to have_css active_css
+        end
+        expect(site_nav_items.last).to have_css active_css
       end
-      expect(site_nav_items.last).to have_css active_css
     end
   end
 
@@ -61,8 +68,8 @@ RSpec.feature 'Navigation Bar', type: :feature do
 
       it_behaves_like 'a common navigation bar'
 
-      it 'only has the root navigation link' do
-        expect(site_nav_items.length).to eq(1)
+      it 'only has the root navigation link (and site picker for admins)' do
+        expect(site_nav_items.length).to eq(user&.admin? ? 2 : 1)
       end
     end
 


### PR DESCRIPTION
This PR gives admins a quick-access dropdown to switch between sites:
![alces flight center - google chrome_058](https://user-images.githubusercontent.com/3471844/45108311-2f03e400-b134-11e8-8a3d-1df2d25a8c4b.png)

It does pretty much what you'd expect. The site name remains a link the site dashboard, only the caret toggles the dropdown (though 'Choose site' also toggles the dropdown).

Trello: https://trello.com/c/Z60a7m88/459-quick-site-switcher-for-admins