### PR TITLE
Avoid using `:identifier` for default scope before it exists.

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,5 +1,6 @@
 class SitesController < ApplicationController
   def index
-    @sites = Site.all
+    # TODO remove order call when it's redundant (see Site#default_scope)
+    @sites = Site.all.order(:identifier)
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,7 +2,8 @@ class Site < ApplicationRecord
   include AdminConfig::Site
   include MarkdownDescription
 
-  default_scope { order(:identifier) }
+  # TODO uncomment this when identifier migration has happened & been deployed
+  # default_scope { order(:identifier) }
 
   has_many :users, dependent: :destroy
   has_many :additional_contacts, dependent: :destroy

--- a/app/views/partials/_site_picker.html.erb
+++ b/app/views/partials/_site_picker.html.erb
@@ -10,7 +10,8 @@
     </a>
   <% end %>
     <div class="dropdown-menu" id="site-chooser">
-    <% Site.all.map {|site| %>
+    <%# TODO remove order call when it's redundant (see Site#default_scope) %>
+    <% Site.all.order(:identifier).map {|site| %>
       <a class="dropdown-item" href="<%= site_path(site) %>">
         <span class="fa fa-institution"></span> <%= site.name %>
       </a>


### PR DESCRIPTION
I can't think of a way to do this other than to comment it out and later re-enable it once we've deployed this live. Answers on a postcard please...