### PR TITLE
Try again to get daily admin emails working

### DIFF
--- a/app/mailer_previews/admin_mailer_preview.rb
+++ b/app/mailer_previews/admin_mailer_preview.rb
@@ -4,7 +4,7 @@ class AdminMailerPreview < ApplicationMailerPreview
 
     AdminMailer.daily_open_cases_list(
        admin,
-       admin.assigned_cases.active.prioritised
+       admin.assigned_cases.active.prioritised.map(&:id)
     )
   end
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,12 +1,9 @@
 class AdminMailer < ApplicationMailer
   default to: Rails.application.config.email_bcc_address
 
-  def daily_open_cases_list(admin, cases)
+  def daily_open_cases_list(admin, case_ids)
     @admin = admin
-    # Because we Resque serialise this job, cases here will be a plain array
-    # rather than an ActiveRecord association, so we can't just call `decorate`
-    # on the whole.
-    @cases = cases.map(&:decorate)
+    @cases = case_ids.map { |id| Case.find(id).decorate }
 
     mail(
       to: admin.email,

--- a/app/services/daily_admin_reminder.rb
+++ b/app/services/daily_admin_reminder.rb
@@ -6,7 +6,7 @@ class DailyAdminReminder
         cases = admin.assigned_cases.active.prioritised
 
         unless cases.empty?
-          AdminMailer.daily_open_cases_list(admin, cases).deliver_later
+          AdminMailer.daily_open_cases_list(admin, cases.map(&:id)).deliver_later
         end
       end
     end


### PR DESCRIPTION
I'm not quite sure why the `daily_open_cases_list` method is now [being passed a Hash](https://sentry.io/alces-software-ltd/alces-flight-center-staging/issues/676737736) rather than [the array it was being passed](https://sentry.io/alces-software-ltd/alces-flight-center-staging/issues/672529010) when I applied the last bugfix (#561). But since passing ActiveRecord objects through Resque is clearly so unreliable, let's just bypass the issue by sending an array of IDs and rehydrating them in Resque-runner-land.