### PR TITLE
Correctly assign contacts to open cases

### DIFF
--- a/db/data/20180831145350_initialise_assigned_contacts_for_open_cases.rb
+++ b/db/data/20180831145350_initialise_assigned_contacts_for_open_cases.rb
@@ -1,5 +1,6 @@
 class InitialiseAssignedContactsForOpenCases < ActiveRecord::Migration[5.2]
   def change
+    Case.reset_column_information
     Case.active.each do |kase|
       next if kase.administrative?
       user = kase.user
@@ -12,6 +13,7 @@ class InitialiseAssignedContactsForOpenCases < ActiveRecord::Migration[5.2]
                        end
 
         kase.save!
+        kase.reload
       end
     end
   end

--- a/db/data/20180831145350_initialise_assigned_contacts_for_open_cases.rb
+++ b/db/data/20180831145350_initialise_assigned_contacts_for_open_cases.rb
@@ -13,7 +13,6 @@ class InitialiseAssignedContactsForOpenCases < ActiveRecord::Migration[5.2]
                        end
 
         kase.save!
-        kase.reload
       end
     end
   end


### PR DESCRIPTION
This should now ensure that the migration correctly does what it is told and all open cases will now have an assigned contact.

Once merged this fixes #589

[Trello](https://trello.com/c/s4QfEIfk/460-fix-migration-for-assigning-contacts-to-currently-open-cases)