### PR TITLE
Swap the tabs around within the Global Dashboard

### DIFF
--- a/app/decorators/all_sites_decorator.rb
+++ b/app/decorators/all_sites_decorator.rb
@@ -3,8 +3,8 @@ class AllSitesDecorator < ApplicationDecorator
 
   def tabs
     [
-      { id: :all_sites, path: h.sites_path },
-      cases_tab
+      cases_tab,
+      { id: :all_sites, path: h.sites_path }
     ]
   end
 


### PR DESCRIPTION
The landing page for admins is now the first tab on the Global Dashboard which fixes #564.

[Trello ](https://trello.com/c/8NFdvNqo/461-swap-order-of-tabs-on-the-global-dashboard)