### PR TITLE
Set last update for administrative cases to 'N/A'

### DIFF
--- a/app/views/partials/_case_table_row.html.erb
+++ b/app/views/partials/_case_table_row.html.erb
@@ -21,7 +21,7 @@
   <td><%= render 'partials/table_cell_link', url: url, cell_content: kase.credit_charge&.amount %></td>
   <% if current_user.admin? %>
     <% if kase.last_update.nil?  %>
-      <td class="text-danger">None</td>
+      <td class="text-danger"><%= kase.administrative? ? 'N/A' : 'None' %></td>
     <% else %>
       <%= timestamp_td(description: 'Last update', timestamp: kase.last_update) do
           render 'partials/table_cell_link', url: url, cell_content: kase.formatted_time_since_last_update


### PR DESCRIPTION
Fixes #599. The `Last update` field for administrative cases now displays as 'N/A'. This uses the same styling as before with 'None' so is in red text, is this something you'd want displayed differently @mjtko?

[Trello](https://trello.com/c/nmZ9ei0u/463-display-n-a-in-the-last-update-field-for-administrative-cases)