### PR TITLE
Order users in assignment controls by name

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -303,7 +303,7 @@ class Case < ApplicationRecord
   end
 
   def potential_assignees
-    User.where(role: :admin)
+    User.where(role: :admin).order(:name)
   end
 
   def potential_contacts


### PR DESCRIPTION
The dropdown box for assigning an engineer to a case was not sorted, making it a pain to find the user you wanted to select. Now both the assignment dropdowns are sorted by name hopefully making this process a
bit easier.

Fixes #590 

[Trello](https://trello.com/c/zeHr5mmu/473-sort-assignment-controls-by-name)