### PR TITLE
Assign cases to admins when they create a case

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -463,9 +463,15 @@ class Case < ApplicationRecord
   end
 
   def maybe_set_default_assignee
-    if assignee.nil? && !site.default_assignee.nil?
+    new_assignee = if user.admin?
+                     user
+                   elsif site.default_assignee
+                     site.default_assignee
+                   end
+
+    if assignee.nil? && !new_assignee.nil?
       transaction do # to make sure audits.last is our assignee change
-        self.assignee = site.default_assignee
+        self.assignee = new_assignee
         save!
         la = audits.last
         # This will show as 'Flight Center' rather than the customer's name

--- a/spec/features/case/new_spec.rb
+++ b/spec/features/case/new_spec.rb
@@ -107,5 +107,15 @@ RSpec.describe 'Case form', type: :feature, js: true do
     it 'has an assigned contact' do
       expect(assigned_case.contact.name).to eq('Mary Pri')
     end
+
+    context "when the admin isn't the default assignee" do
+      let(:new_admin) { create(:admin, name: 'Adam Min') }
+      let(:new_case) { create(:open_case, cluster: cluster, user: new_admin) }
+
+      it 'assigns the case to the admin creating the case' do
+        expect(site.default_assignee).not_to eq(new_admin)
+        expect(new_case.assignee).to eq(new_admin)
+      end
+    end
   end
 end


### PR DESCRIPTION
If an admin creates a case then they are automatically assigned as the engineer for that case, regardless of their status as default assignee.

Fixes #591 

[Trello](https://trello.com/c/jdRlWghG/474-if-an-admin-creates-a-case-assign-them-as-the-engineer-for-it)