### PR TITLE
Feature/markdown information

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,23 +187,30 @@ a.filter {
 
 .markdown-modal {
   text-align: center;
-  
-  table {
-    align: center;
 
-    tr {
-      border-top: 1px solid;
-      border-bottom: 1px solid;
-      border-collapse: collapse;
+  .modal-dialog {
+    position: relative;
+    display: table;
+    overflow-x: auto;
+    width: auto;
 
-      ul {
-        float: left;
-        width: 85%;
-      }
+    table {
+      text-align:left;
+      width: 100%;
 
-      ol {
-        float: left;
-        width: 85%;
+      tr {
+        border-top: 1px solid;
+        border-bottom: 1px solid;
+        border-collapse: collapse;
+
+        td {
+          padding: 3px;
+          padding-left: 10px;
+
+          ul {
+            padding-left: 10px;
+          }
+        }
       }
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -189,10 +189,8 @@ a.filter {
   text-align: center;
 
   .modal-dialog {
-    position: relative;
     display: table;
     overflow-x: auto;
-    width: auto;
 
     table {
       text-align:left;
@@ -201,7 +199,6 @@ a.filter {
       tr {
         border-top: 1px solid;
         border-bottom: 1px solid;
-        border-collapse: collapse;
 
         td {
           padding: 3px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -184,3 +184,18 @@ a.filter {
     margin-right: -1rem;
   }
 }
+
+.markdown-modal {
+  text-align: center;
+
+  tr {
+    border-top: 1px solid;
+    border-bottom: 1px solid;
+    border-collapse: collapse;
+
+    ul {
+      float: left;
+      width: 85%;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -189,7 +189,6 @@ a.filter {
   text-align: center;
 
   .modal-dialog {
-    display: table;
     overflow-x: auto;
 
     table {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,15 +187,24 @@ a.filter {
 
 .markdown-modal {
   text-align: center;
+  
+  table {
+    align: center;
 
-  tr {
-    border-top: 1px solid;
-    border-bottom: 1px solid;
-    border-collapse: collapse;
+    tr {
+      border-top: 1px solid;
+      border-bottom: 1px solid;
+      border-collapse: collapse;
 
-    ul {
-      float: left;
-      width: 85%;
+      ul {
+        float: left;
+        width: 85%;
+      }
+
+      ol {
+        float: left;
+        width: 85%;
+      }
     }
   }
 }

--- a/app/views/partials/_markdown_editor_layout.html.erb
+++ b/app/views/partials/_markdown_editor_layout.html.erb
@@ -15,7 +15,9 @@
             %>
         </li>
         <li class='nav-item text-muted nav-item-text text-right'>
-          Styling with Markdown is supported
+          Styling with
+          <%= render 'partials/markdown_information', label:  'Markdown'%>
+          is supported
         </li>
     </ul>
 

--- a/app/views/partials/_markdown_information.html.erb
+++ b/app/views/partials/_markdown_information.html.erb
@@ -46,6 +46,16 @@
             <td>### text</td>
           </tr>
           <tr>
+            <td>
+              Horizontal Rule<br/>
+              <hr>
+            </td>
+            <td>
+              Horizontal Rule<br/>
+              ---
+            </td>
+          </tr>
+          <tr>
             <td><code>blocks<br/>of<br/>code</code></td>
             <td>```<br/>text<br/>```<br/></td>
           </tr>
@@ -69,8 +79,28 @@
               * text<br/>
             </td>
           </tr>
+          <tr>
+            <td>
+              <ol>
+                <li>
+                  List
+                </li>
+                <li>
+                  List
+                </li>
+                <li>
+                  List
+                </li>
+              </ol>
+            </td>
+            <td>
+              1. text<br/>
+              2. text<br/>
+              3. text<br/>
+            </td>
+          </tr>
         </table>
-        Any character can be escaped with \
+        Any character can be escaped with \<br/>
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
       </div>
     </div>

--- a/app/views/partials/_markdown_information.html.erb
+++ b/app/views/partials/_markdown_information.html.erb
@@ -4,7 +4,7 @@
     <div class="modal-content">
       <div class="modal-body">
         This input has Markdown enabled styling<br/>
-        <table>
+        <table class="markdown">
           <tr>
             <td><i>Italics</i></td>
             <td>*text* or _text_</td>
@@ -79,29 +79,9 @@
               * text<br/>
             </td>
           </tr>
-          <tr>
-            <td>
-              <ol>
-                <li>
-                  List
-                </li>
-                <li>
-                  List
-                </li>
-                <li>
-                  List
-                </li>
-              </ol>
-            </td>
-            <td>
-              1. text<br/>
-              2. text<br/>
-              3. text<br/>
-            </td>
-          </tr>
         </table>
         Any character can be escaped with \<br/>
-        More information at <a href="commonmark.org/help/">commonmark.org/help/</a>
+        More information at <a href="https://commonmark.org/help/">commonmark.org/help</a>
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
       </div>
     </div>

--- a/app/views/partials/_markdown_information.html.erb
+++ b/app/views/partials/_markdown_information.html.erb
@@ -1,0 +1,78 @@
+<a href="#markdown-modal" data-toggle="modal"><%=label%></a>
+<div class="modal fade markdown-modal" id="markdown-modal" role="dialog">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        This input has Markdown enabled styling<br/>
+        <table>
+          <tr>
+            <td><i>Italics</i></td>
+            <td>*text* or _text_</td>
+          </tr>
+          <tr>
+            <td><b>Bold</b></td>
+            <td>**text** or __text__</td>
+          <tr>
+          <tr>
+            <td><i><b>Both</b></i></td>
+            <td>***text*** or ___text___</td>
+          </tr>
+          <tr>
+            <td><s>Strikethrough</s></td>
+            <td>~text~</td>
+          </tr>
+          <tr>
+            <td><code>Code</code></td>
+            <td>`text`</td>
+          </tr>
+          <tr>
+            <td><a href>Link</a></td>
+            <td>[text](www.website.com)</td>
+          </tr>
+          <tr>
+            <td>Image</td>
+            <td>![text](www.imagelocation.com)</td>
+          </tr>
+          <tr>
+            <td><h1>Heading 1</h1></td>
+            <td># text</td>
+          </tr>
+          <tr>
+            <td><h2>Heading 2</h2></td>
+            <td>## text</td>
+          </tr>
+          <tr>
+            <td><h3>Heading 3</h3></td>
+            <td>### text</td>
+          </tr>
+          <tr>
+            <td><code>blocks<br/>of<br/>code</code></td>
+            <td>```<br/>text<br/>```<br/></td>
+          </tr>
+          <tr>
+            <td>
+              <ul>
+                <li>
+                  List
+                </li>
+                <li>
+                  List
+                </li>
+                <li>
+                  List
+                </li>
+              </ul>
+            </td>
+            <td>
+              * text<br/>
+              * text<br/>
+              * text<br/>
+            </td>
+          </tr>
+        </table>
+        Any character can be escaped with \
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/partials/_markdown_information.html.erb
+++ b/app/views/partials/_markdown_information.html.erb
@@ -12,7 +12,7 @@
           <tr>
             <td><b>Bold</b></td>
             <td>**text** or __text__</td>
-          <tr>
+          </tr>
           <tr>
             <td><i><b>Both</b></i></td>
             <td>***text*** or ___text___</td>

--- a/app/views/partials/_markdown_information.html.erb
+++ b/app/views/partials/_markdown_information.html.erb
@@ -27,11 +27,11 @@
           </tr>
           <tr>
             <td><a href>Link</a></td>
-            <td>[text](www.website.com)</td>
+            <td>[text](www.example.com)</td>
           </tr>
           <tr>
             <td>Image</td>
-            <td>![text](www.imagelocation.com)</td>
+            <td>![text](www.example.com/image.png)</td>
           </tr>
           <tr>
             <td><h1>Heading 1</h1></td>

--- a/app/views/partials/_markdown_information.html.erb
+++ b/app/views/partials/_markdown_information.html.erb
@@ -101,6 +101,7 @@
           </tr>
         </table>
         Any character can be escaped with \<br/>
+        More information at <a href="commonmark.org/help/">commonmark.org/help/</a>
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
       </div>
     </div>

--- a/spec/features/log/index_spec.rb
+++ b/spec/features/log/index_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature Log, type: :feature do
       log_details = fill_details_input
       submit_log
       visit current_path
-      log_row_html = page.find(logs_selector).native.inner_html
+      log_row_html = page.first(logs_selector).native.inner_html
 
       expect(log_row_html).to include(MarkdownRenderer.render(log_details))
     end


### PR DESCRIPTION
Looks like so, any changes welcome: 
![image](https://user-images.githubusercontent.com/24327288/45228484-30134d80-b2bb-11e8-8dc6-4e7a636c25a4.png)
Couldn't see a view folder that would logically take the new partial so put it in the general one, can move it if desired.
Trello:https://trello.com/c/jbdFP53M/398-add-link-to-markdown-message-that-displays-modal-dialog-describing-basic-markdown-syntax