### PR TITLE
Genericise terminal service configs

### DIFF
--- a/app/assets/stylesheets/sites.scss
+++ b/app/assets/stylesheets/sites.scss
@@ -39,7 +39,7 @@
   }
 }
 
-.site-services {
+.site-console-services, .cluster-console-services {
     h5 {
         display: inline-block;
         margin-right: 0.75rem;

--- a/app/controllers/terminal_services_controller.rb
+++ b/app/controllers/terminal_services_controller.rb
@@ -1,6 +1,6 @@
 class TerminalServicesController < ApplicationController
   def show
-    config = @site.flight_directory_config
+    config = @site.terminal_service
     if config.nil?
       render json: {}, status: 404
       return
@@ -10,6 +10,11 @@ class TerminalServicesController < ApplicationController
     site = config.site
 
     render json: {
+      ssh: {
+        hostname: config.hostname,
+        username: config.username,
+        key: config.encrypted_ssh_key,
+      },
       flight_directory_config: {
         hostname: config.hostname,
         username: config.username,

--- a/app/controllers/terminal_services_controller.rb
+++ b/app/controllers/terminal_services_controller.rb
@@ -15,13 +15,16 @@ class TerminalServicesController < ApplicationController
         username: config.username,
         key: config.encrypted_ssh_key,
       },
+      ui: config.console_ui,
+      site: {
+        name: site.name,
+      },
+      # Deprecated structure.  Remove once flight console and flight console
+      # api have been deployed to not use it.
       flight_directory_config: {
         hostname: config.hostname,
         username: config.username,
         ssh_key: config.encrypted_ssh_key,
-      },
-      site: {
-        name: site.name,
       },
     }
   end

--- a/app/controllers/terminal_services_controller.rb
+++ b/app/controllers/terminal_services_controller.rb
@@ -1,6 +1,6 @@
 class TerminalServicesController < ApplicationController
   def show
-    config = @site.terminal_services.find_by(service_type: params[:service_type])
+    config = @scope.terminal_services.find_by(service_type: params[:service_type])
     if config.nil?
       render json: {}, status: 404
       return
@@ -17,8 +17,10 @@ class TerminalServicesController < ApplicationController
       },
       ui: config.console_ui,
       site: {
+        id: site.id,
         name: site.name,
       },
+      cluster: cluster_json,
       # Deprecated structure.  Remove once flight console and flight console
       # api have been deployed to not use it.
       flight_directory_config: {
@@ -26,6 +28,16 @@ class TerminalServicesController < ApplicationController
         username: config.username,
         ssh_key: config.encrypted_ssh_key,
       },
+    }
+  end
+
+  private
+
+  def cluster_json
+    return nil unless @scope.is_a?(Cluster)
+    {
+      id: @scope.id,
+      name: @scope.name,
     }
   end
 end

--- a/app/controllers/terminal_services_controller.rb
+++ b/app/controllers/terminal_services_controller.rb
@@ -1,6 +1,6 @@
 class TerminalServicesController < ApplicationController
   def show
-    config = @site.terminal_service
+    config = @site.terminal_services.find_by(service_type: params[:service_type])
     if config.nil?
       render json: {}, status: 404
       return

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -62,7 +62,11 @@ class ClusterDecorator < ApplicationDecorator
 
   def terminal_service_url(service)
     base_url = ENV.fetch('TERMINAL_SERVICE_BASE_URL')
-    "#{base_url}/clusters/#{id}/#{service.service_type}"
+    "#{base_url}#{terminal_service_path(service)}"
+  end
+
+  def terminal_service_path(service)
+    "/clusters/#{to_param}/#{service.service_type}"
   end
 
   def terminal_services

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -65,6 +65,10 @@ class ClusterDecorator < ApplicationDecorator
     "#{base_url}/clusters/#{id}/#{service.service_type}"
   end
 
+  def terminal_services
+    super.sort_by {|s| s.center_ui['title']}
+  end
+
   # List the first day of each quarter since this cluster was created, including
   # the current quarter (as defined by `Date.today`).
   def all_quarter_start_dates

--- a/app/decorators/cluster_decorator.rb
+++ b/app/decorators/cluster_decorator.rb
@@ -60,6 +60,11 @@ class ClusterDecorator < ApplicationDecorator
     end
   end
 
+  def terminal_service_url(service)
+    base_url = ENV.fetch('TERMINAL_SERVICE_BASE_URL')
+    "#{base_url}/clusters/#{id}/#{service.service_type}"
+  end
+
   # List the first day of each quarter since this cluster was created, including
   # the current quarter (as defined by `Date.today`).
   def all_quarter_start_dates

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -22,10 +22,14 @@ class SiteDecorator < ApplicationDecorator
 
   def terminal_service_url(service)
     base_url = ENV.fetch('TERMINAL_SERVICE_BASE_URL')
+    "#{base_url}#{terminal_service_path(service)}"
+  end
+
+  def terminal_service_path(service)
     if current_user.admin?
-      "#{base_url}/sites/#{id}/#{service.service_type}"
+      "/sites/#{to_param}/#{service.service_type}"
     else
-      "#{base_url}/#{service.service_type}"
+      "/#{service.service_type}"
     end
   end
 

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -29,6 +29,10 @@ class SiteDecorator < ApplicationDecorator
     end
   end
 
+  def terminal_services
+    super.sort_by {|s| s.center_ui['title']}
+  end
+
   private
 
   # When a Site user is signed in we don't want/need the `/sites/:site_id`

--- a/app/decorators/site_decorator.rb
+++ b/app/decorators/site_decorator.rb
@@ -20,12 +20,12 @@ class SiteDecorator < ApplicationDecorator
     )
   end
 
-  def directory_service_url
+  def terminal_service_url(service)
     base_url = ENV.fetch('TERMINAL_SERVICE_BASE_URL')
     if current_user.admin?
-      "#{base_url}/sites/#{id}/directory"
+      "#{base_url}/sites/#{id}/#{service.service_type}"
     else
-      "#{base_url}/directory"
+      "#{base_url}/#{service.service_type}"
     end
   end
 

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -24,6 +24,7 @@ class Cluster < ApplicationRecord
   has_many :check_results, through: :cluster_checks
 
   has_many :service_plans
+  has_many :terminal_services, class_name: 'ClusterTerminalService'
 
   validates_associated :site
   validates :name, presence: true

--- a/app/models/cluster_terminal_service.rb
+++ b/app/models/cluster_terminal_service.rb
@@ -1,0 +1,6 @@
+class ClusterTerminalService < TerminalService
+  include AdminConfig::TerminalService
+
+  belongs_to :cluster
+  delegate :site, to: :cluster
+end

--- a/app/models/cluster_terminal_service.rb
+++ b/app/models/cluster_terminal_service.rb
@@ -1,5 +1,5 @@
 class ClusterTerminalService < TerminalService
-  include AdminConfig::TerminalService
+  include AdminConfig::ClusterTerminalService
 
   belongs_to :cluster
   delegate :site, to: :cluster

--- a/app/models/concerns/admin_config/cluster_terminal_service.rb
+++ b/app/models/concerns/admin_config/cluster_terminal_service.rb
@@ -1,0 +1,15 @@
+module AdminConfig::ClusterTerminalService
+  extend ActiveSupport::Concern
+
+  included do
+    include AdminConfig::TerminalService
+
+    rails_admin do
+      edit do
+        configure :site_id do
+          hide
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/admin_config/site_terminal_service.rb
+++ b/app/models/concerns/admin_config/site_terminal_service.rb
@@ -1,0 +1,14 @@
+module AdminConfig::SiteTerminalService
+  extend ActiveSupport::Concern
+
+  included do
+    include AdminConfig::TerminalService
+    rails_admin do
+      edit do
+        configure :cluster_id do
+          hide
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/admin_config/terminal_service.rb
+++ b/app/models/concerns/admin_config/terminal_service.rb
@@ -1,4 +1,4 @@
-module AdminConfig::FlightDirectoryConfig
+module AdminConfig::TerminalService
   extend ActiveSupport::Concern
 
   included do
@@ -28,7 +28,7 @@ module AdminConfig::FlightDirectoryConfig
     end
   end
 
-  # Creating new FlightDirectoryConfigs with rails admin breaks without this
+  # Creating new TerminalService with rails admin breaks without this
   # method being added.
   def ssh_key
     nil

--- a/app/models/concerns/admin_config/terminal_service.rb
+++ b/app/models/concerns/admin_config/terminal_service.rb
@@ -24,6 +24,9 @@ module AdminConfig::TerminalService
         configure :encrypted_ssh_key do
           hide
         end
+        configure :type do
+          hide
+        end
       end
     end
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -11,7 +11,7 @@ class Site < ApplicationRecord
   has_many :cases, through: :clusters
   has_many :components, through: :clusters
   has_many :services, through: :clusters
-  has_one :terminal_service
+  has_many :terminal_services
 
   belongs_to :default_assignee,
              class_name: 'User',

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -11,7 +11,7 @@ class Site < ApplicationRecord
   has_many :cases, through: :clusters
   has_many :components, through: :clusters
   has_many :services, through: :clusters
-  has_one :flight_directory_config
+  has_one :terminal_service
 
   belongs_to :default_assignee,
              class_name: 'User',

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -11,7 +11,7 @@ class Site < ApplicationRecord
   has_many :cases, through: :clusters
   has_many :components, through: :clusters
   has_many :services, through: :clusters
-  has_many :terminal_services
+  has_many :terminal_services, class_name: 'SiteTerminalService'
 
   belongs_to :default_assignee,
              class_name: 'User',

--- a/app/models/site_terminal_service.rb
+++ b/app/models/site_terminal_service.rb
@@ -1,5 +1,5 @@
 class SiteTerminalService < TerminalService
-  include AdminConfig::TerminalService
+  include AdminConfig::SiteTerminalService
 
   belongs_to :site
 end

--- a/app/models/site_terminal_service.rb
+++ b/app/models/site_terminal_service.rb
@@ -1,0 +1,5 @@
+class SiteTerminalService < TerminalService
+  include AdminConfig::TerminalService
+
+  belongs_to :site
+end

--- a/app/models/terminal_service.rb
+++ b/app/models/terminal_service.rb
@@ -1,7 +1,4 @@
 class TerminalService < ApplicationRecord
-  include AdminConfig::TerminalService
-
-  belongs_to :site
 
   validates :hostname, presence: true
   validates :username, presence: true

--- a/app/models/terminal_service.rb
+++ b/app/models/terminal_service.rb
@@ -1,5 +1,5 @@
-class FlightDirectoryConfig < ApplicationRecord
-  include AdminConfig::FlightDirectoryConfig
+class TerminalService < ApplicationRecord
+  include AdminConfig::TerminalService
 
   belongs_to :site
 

--- a/app/policies/cluster_terminal_service_policy.rb
+++ b/app/policies/cluster_terminal_service_policy.rb
@@ -1,11 +1,11 @@
-class TerminalServicePolicy < ApplicationPolicy
+class ClusterTerminalServicePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       if user.admin?
         scope
       elsif user.contact?
         scope.
-          joins(site: :users).
+          joins(cluster: { site: :users }).
           where(users: {id: user.id})
       else
         scope.none

--- a/app/policies/site_terminal_service_policy.rb
+++ b/app/policies/site_terminal_service_policy.rb
@@ -1,0 +1,15 @@
+class SiteTerminalServicePolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user.admin?
+        scope
+      elsif user.contact?
+        scope.
+          joins(site: :users).
+          where(users: {id: user.id})
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/app/policies/terminal_service_policy.rb
+++ b/app/policies/terminal_service_policy.rb
@@ -1,4 +1,4 @@
-class FlightDirectoryConfigPolicy < ApplicationPolicy
+class TerminalServicePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       if user.admin?

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -42,6 +42,20 @@
         %>
       </li>
     </ul>
+    <div class="cluster-console-services">
+      <h4>Console services</h4>
+      <% if !cluster.terminal_services.empty? %>
+        <ul>
+          <% cluster.terminal_services.each do |service| %>
+            <li>
+              <%= render 'clusters/service', service: service %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        No console services are currently available for this cluster.
+      <% end %>
+    </div>
   </div>
   <div class="col-sm-12 col-md-6">
     <%= render 'clusters/credit_balance', cluster: cluster do %>

--- a/app/views/clusters/_details.html.erb
+++ b/app/views/clusters/_details.html.erb
@@ -42,7 +42,7 @@
         %>
       </li>
     </ul>
-    <div class="cluster-console-services">
+    <div class="cluster-console-services mt-2">
       <h4>Console services</h4>
       <% if !cluster.terminal_services.empty? %>
         <ul>

--- a/app/views/clusters/_service.html.erb
+++ b/app/views/clusters/_service.html.erb
@@ -1,0 +1,12 @@
+<h5><%= service.center_ui['title'] %></h5>
+<span>
+<%= link_to service.center_ui['linkText'],
+            cluster.terminal_service_url(service),
+            PolicyDependentOptions.wrap(
+              {class: ['btn', 'btn-primary']},
+              policy: policy(service).show?,
+              action_description: service.center_ui['description'],
+              user: current_user
+            )
+%>
+</span>

--- a/app/views/sites/_service.html.erb
+++ b/app/views/sites/_service.html.erb
@@ -1,0 +1,12 @@
+<h5><%= service.center_ui['title'] %></h5>
+<span>
+<%= link_to service.center_ui['linkText'],
+            site.terminal_service_url(service),
+            PolicyDependentOptions.wrap(
+              {class: ['btn', 'btn-primary']},
+              policy: policy(service).show?,
+              action_description: service.center_ui['description'],
+              user: current_user
+            )
+%>
+</span>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -25,8 +25,8 @@
           <% end %>
         </ul>
       <% end %>
-      <div class="site-services">
-        <h4>Site services</h4>
+      <div class="site-console-services">
+        <h4>Console services</h4>
         <% if !site.terminal_services.empty? %>
           <ul>
             <% site.terminal_services.each do |service| %>
@@ -36,7 +36,7 @@
             <% end %>
           </ul>
         <% else %>
-          No site services are currently available for this site.
+          No console services are currently available for this site.
         <% end %>
       </div>
     </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -27,7 +27,7 @@
       <% end %>
       <div class="site-services">
         <h4>Site services</h4>
-        <% if site.flight_directory_config.present? %>
+        <% if site.terminal_service.present? %>
           <ul>
             <li>
               <h5>User and group directory</h5>
@@ -36,7 +36,7 @@
                             site.directory_service_url,
                             PolicyDependentOptions.wrap(
                               {class: ['btn', 'btn-primary']},
-                              policy: policy(site.flight_directory_config).show?,
+                              policy: policy(site.terminal_service).show?,
                               action_description: 'manage user and group directory',
                               user: current_user
                             )

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -27,7 +27,7 @@
       <% end %>
       <div class="site-services">
         <h4>Site services</h4>
-        <% if site.terminal_service.present? %>
+        <% if site.terminal_services.find_by(service_type: 'directory').present? %>
           <ul>
             <li>
               <h5>User and group directory</h5>
@@ -36,7 +36,7 @@
                             site.directory_service_url,
                             PolicyDependentOptions.wrap(
                               {class: ['btn', 'btn-primary']},
-                              policy: policy(site.terminal_service).show?,
+                              policy: policy(site.terminal_services.find_by(service_type: 'directory')).show?,
                               action_description: 'manage user and group directory',
                               user: current_user
                             )

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -27,22 +27,13 @@
       <% end %>
       <div class="site-services">
         <h4>Site services</h4>
-        <% if site.terminal_services.find_by(service_type: 'directory').present? %>
+        <% if !site.terminal_services.empty? %>
           <ul>
-            <li>
-              <h5>User and group directory</h5>
-              <span>
-                <%= link_to "Manage",
-                            site.directory_service_url,
-                            PolicyDependentOptions.wrap(
-                              {class: ['btn', 'btn-primary']},
-                              policy: policy(site.terminal_services.find_by(service_type: 'directory')).show?,
-                              action_description: 'manage user and group directory',
-                              user: current_user
-                            )
-                %>
-              </span>
-            </li>
+            <% site.terminal_services.each do |service| %>
+              <li>
+                <%= render 'sites/service', service: service %>
+              </li>
+            <% end %>
           </ul>
         <% else %>
           No site services are currently available for this site.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
           post :import
         end
       end
+      terminal_services.call
     end
 
     resources :components, only: []  do
@@ -178,6 +179,7 @@ Rails.application.routes.draw do
 
       get '/credit-usage(/:start_date)', to: 'clusters#credit_usage', as: :credit_usage
       get '/checks(/:date)', to: 'clusters#view_checks', as: :checks
+      terminal_services.call
     end
 
     resources :components, only: :show do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,11 @@ Rails.application.routes.draw do
     end
   end
 
+  terminal_services = Proc.new do
+    resource :terminal_services,
+      only: [:show]
+  end
+
   constraints Clearance::Constraints::SignedIn.new { |user| user.admin? } do
 
     mount Resque::Server, at: '/resque'
@@ -52,7 +57,7 @@ Rails.application.routes.draw do
     root 'cases#assigned'
     resources :sites, only: [:show, :index] do
       cases.call(only: [:index, :new])
-      resource :terminal_services, only: [:show]
+      terminal_services.call
     end
 
     cases.call(only: []) do
@@ -198,7 +203,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resource :terminal_services, only: [:show]
+    terminal_services.call
     resource :users, only: [:show]
     resources :topics, only: [:index]
 

--- a/db/migrate/20180905115743_genericize_terminal_service_config.rb
+++ b/db/migrate/20180905115743_genericize_terminal_service_config.rb
@@ -1,0 +1,11 @@
+class GenericizeTerminalServiceConfig < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :flight_directory_configs, :terminal_services
+    add_column :terminal_services, :service_type, :string,
+      null: false,
+      default: 'directory'
+    change_column_default :terminal_services, :service_type,
+      from: 'directory',
+      to: nil
+  end
+end

--- a/db/migrate/20180905165332_add_ui_columns_to_terminal_services.rb
+++ b/db/migrate/20180905165332_add_ui_columns_to_terminal_services.rb
@@ -1,0 +1,27 @@
+class AddUiColumnsToTerminalServices < ActiveRecord::Migration[5.2]
+  def change
+    center_ui_default = {
+      description: "manage user and group directory",
+      linkText: "Manage",
+      title: "User and group directory",
+    }
+    console_ui_default = {
+      icon: "id-card",
+      name: "directory",
+      title: "Directory",
+    }
+
+    add_column :terminal_services, :center_ui, :jsonb,
+      null: false,
+      default: center_ui_default
+    add_column :terminal_services, :console_ui, :jsonb,
+      null: false,
+      default: console_ui_default
+    change_column_default :terminal_services, :center_ui,
+      from: center_ui_default,
+      to: nil
+    change_column_default :terminal_services, :console_ui,
+      from: console_ui_default,
+      to: nil
+  end
+end

--- a/db/migrate/20180910010015_support_cluster_terminal_services.rb
+++ b/db/migrate/20180910010015_support_cluster_terminal_services.rb
@@ -1,0 +1,15 @@
+class SupportClusterTerminalServices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :terminal_services, :type, :string,
+      null: false,
+      default: 'SiteTerminalService'
+    change_column_default :terminal_services, :type,
+      from: 'SiteTerminalService',
+      to: nil
+
+    change_column_null :terminal_services, :site_id, true
+    add_reference :terminal_services, :cluster,
+      null: true,
+      foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_115743) do
+ActiveRecord::Schema.define(version: 2018_09_05_165332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -392,6 +392,8 @@ ActiveRecord::Schema.define(version: 2018_09_05_115743) do
     t.datetime "updated_at", null: false
     t.string "encrypted_ssh_key", limit: 4096, null: false
     t.string "service_type", null: false
+    t.jsonb "center_ui", null: false
+    t.jsonb "console_ui", null: false
     t.index ["site_id"], name: "index_terminal_services_on_site_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_090755) do
+ActiveRecord::Schema.define(version: 2018_09_05_115743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -276,16 +276,6 @@ ActiveRecord::Schema.define(version: 2018_09_05_090755) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "flight_directory_configs", force: :cascade do |t|
-    t.string "hostname", limit: 255, null: false
-    t.string "username", limit: 255, null: false
-    t.bigint "site_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "encrypted_ssh_key", limit: 4096, null: false
-    t.index ["site_id"], name: "index_flight_directory_configs_on_site_id"
-  end
-
   create_table "issues", force: :cascade do |t|
     t.string "name", null: false
     t.boolean "requires_component", default: false, null: false
@@ -394,6 +384,17 @@ ActiveRecord::Schema.define(version: 2018_09_05_090755) do
     t.index ["default_assignee_id"], name: "index_sites_on_default_assignee_id"
   end
 
+  create_table "terminal_services", force: :cascade do |t|
+    t.string "hostname", limit: 255, null: false
+    t.string "username", limit: 255, null: false
+    t.bigint "site_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "encrypted_ssh_key", limit: 4096, null: false
+    t.string "service_type", null: false
+    t.index ["site_id"], name: "index_terminal_services_on_site_id"
+  end
+
   create_table "tiers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -457,7 +458,6 @@ ActiveRecord::Schema.define(version: 2018_09_05_090755) do
   add_foreign_key "credit_charges", "users"
   add_foreign_key "credit_deposits", "clusters"
   add_foreign_key "credit_deposits", "users"
-  add_foreign_key "flight_directory_configs", "sites"
   add_foreign_key "issues", "categories"
   add_foreign_key "issues", "service_types"
   add_foreign_key "logs", "components"
@@ -470,6 +470,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_090755) do
   add_foreign_key "services", "clusters"
   add_foreign_key "services", "service_types"
   add_foreign_key "sites", "users", column: "default_assignee_id"
+  add_foreign_key "terminal_services", "sites"
   add_foreign_key "topics", "sites"
   add_foreign_key "users", "sites"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_165332) do
+ActiveRecord::Schema.define(version: 2018_09_10_010015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -387,13 +387,16 @@ ActiveRecord::Schema.define(version: 2018_09_05_165332) do
   create_table "terminal_services", force: :cascade do |t|
     t.string "hostname", limit: 255, null: false
     t.string "username", limit: 255, null: false
-    t.bigint "site_id", null: false
+    t.bigint "site_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "encrypted_ssh_key", limit: 4096, null: false
     t.string "service_type", null: false
     t.jsonb "center_ui", null: false
     t.jsonb "console_ui", null: false
+    t.string "type", null: false
+    t.bigint "cluster_id"
+    t.index ["cluster_id"], name: "index_terminal_services_on_cluster_id"
     t.index ["site_id"], name: "index_terminal_services_on_site_id"
   end
 
@@ -472,6 +475,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_165332) do
   add_foreign_key "services", "clusters"
   add_foreign_key "services", "service_types"
   add_foreign_key "sites", "users", column: "default_assignee_id"
+  add_foreign_key "terminal_services", "clusters"
   add_foreign_key "terminal_services", "sites"
   add_foreign_key "topics", "sites"
   add_foreign_key "users", "sites"


### PR DESCRIPTION
This PR makes the terminal services more generic in two distinct ways.

The first of these is to remove all hardcoding of a "directory" terminal
service.  To do this each terminal service now has a `service_type` which
identifies the particular service.  This is used by the terminal service API
and client to request the correct terminal service configuration.

The hardcoding has also been removed from the Center and console UIs; the
terminal services now contain a JSON blob which the Center and console UI
use to construct their respective UIs.

The second way in which the terminal services are more generic is that it is
now possible for clusters to have terminal services.  This has been
implemented with STI and splitting the `TerminalService` model into
`SiteTerminalService` and `ClusterTerminalService` models.  The controller
makes use of the standard `@scope`.
