### PR TITLE
Upload documents to S3 bucket directly

### DIFF
--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -114,6 +114,9 @@ class ClustersController < ApplicationController
       flash[:error] = 'Could not upload document.'
     end
 
+  rescue Aws::S3::Errors::ServiceError => e
+    flash[:error] = "Could not upload document: #{e.message}"
+  ensure
     redirect_to cluster_documents_path(@cluster)
   end
 

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -100,6 +100,21 @@ class ClustersController < ApplicationController
 
   def upload_document
     authorize @cluster
+
+    doc = params[:cluster_document]
+
+    result = @cluster.upload_document(
+      doc.original_filename,
+      doc.path
+    )
+
+    if result
+      flash[:success] = 'Document uploaded.'
+    else
+      flash[:error] = 'Could not upload document.'
+    end
+
+    redirect_to cluster_documents_path(@cluster)
   end
 
   private

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -98,6 +98,10 @@ class ClustersController < ApplicationController
     authorize @cluster
   end
 
+  def upload_document
+    authorize @cluster
+  end
+
   private
 
   def start_date

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -51,7 +51,7 @@ class Cluster < ApplicationRecord
   end
 
   def documents
-    @documents ||= DocumentsRetriever.retrieve(documents_path)
+    @documents ||= DocumentsHandler.retrieve(documents_path)
   end
 
   def unfinished_related_maintenance_windows

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -54,6 +54,10 @@ class Cluster < ApplicationRecord
     @documents ||= DocumentsHandler.retrieve(documents_path)
   end
 
+  def upload_document(name, file)
+    DocumentsHandler.store(name, file, documents_path)
+  end
+
   def unfinished_related_maintenance_windows
     parts = [self, *components, *component_groups, *services]
     parts

--- a/app/models/cluster/documents_handler.rb
+++ b/app/models/cluster/documents_handler.rb
@@ -29,14 +29,19 @@ module Cluster::DocumentsHandler
       []
     end
 
+    def store(name, file, documents_path)
+      p "Going to upload #{name} from #{file} to #{documents_path}"
+
+      obj_path = File.join(documents_path, name)
+      bucket = s3.bucket(BUCKET)
+
+      obj = bucket.object(obj_path)
+      obj.upload_file(file)
+    end
+
     private
 
     def objects_under_path(path)
-      s3 = Aws::S3::Resource.new(
-        access_key_id: ACCESS_KEY_ID,
-        secret_access_key: SECRET_ACCESS_KEY,
-        region: REGION
-      )
       response = s3.client.list_objects(
         bucket: BUCKET,
         prefix: path
@@ -51,6 +56,14 @@ module Cluster::DocumentsHandler
         bucket: BUCKET,
         key: object.key,
         expires_in: 60.minutes.to_i
+      )
+    end
+
+    def s3
+      @s3 ||= Aws::S3::Resource.new(
+        access_key_id: ACCESS_KEY_ID,
+        secret_access_key: SECRET_ACCESS_KEY,
+        region: REGION
       )
     end
   end

--- a/app/models/cluster/documents_handler.rb
+++ b/app/models/cluster/documents_handler.rb
@@ -30,8 +30,6 @@ module Cluster::DocumentsHandler
     end
 
     def store(name, file, documents_path)
-      p "Going to upload #{name} from #{file} to #{documents_path}"
-
       obj_path = File.join(documents_path, name)
       bucket = s3.bucket(BUCKET)
 

--- a/app/models/cluster/documents_handler.rb
+++ b/app/models/cluster/documents_handler.rb
@@ -1,5 +1,5 @@
 
-module Cluster::DocumentsRetriever
+module Cluster::DocumentsHandler
   Document = Struct.new(:name, :url)
 
   class << self

--- a/app/policies/cluster_policy.rb
+++ b/app/policies/cluster_policy.rb
@@ -8,6 +8,7 @@ class ClusterPolicy < ApplicationPolicy
   alias_method :write?, :admin?
   alias_method :create?, :admin?
   alias_method :import_components?, :admin?
+  alias_method :upload_document?, :admin?
 
   class Scope < Scope
     def resolve

--- a/app/views/clusters/documents.html.erb
+++ b/app/views/clusters/documents.html.erb
@@ -41,10 +41,10 @@
     <% if policy(cluster).upload_document? %>
       <%= form_tag cluster_upload_document_path(@cluster), multipart: true, class: 'form-inline' do %>
         <div class="form-group">
-          <label class="mx-2" for="cluster-document">Or upload a document:</label>
+          <label class="mx-2" for="cluster_document">Or upload a document:</label>
           <div class="input-group">
             <%=
-              file_field_tag 'cluster-document', class: 'form-control'
+              file_field_tag 'cluster_document', class: 'form-control'
             %>
             <div class="input-group-append">
               <%= submit_tag 'Upload', class: 'btn btn-primary' %>

--- a/app/views/clusters/documents.html.erb
+++ b/app/views/clusters/documents.html.erb
@@ -29,13 +29,13 @@
       <% end %>
     <% end %>
   </ul>
-  <div class="d-flex">
+  <div class="d-flex my-2 mx-2">
     <% if policy(Note).create? %>
       <%=
         link_to 'Create new document',
                 new_cluster_note_path(cluster),
                 class: 'btn btn-primary',
-                style: 'flex-grow: 1;'
+                style: 'align-self: center; flex-grow: 1;'
       %>
     <% end %>
     <% if policy(cluster).upload_document? %>

--- a/app/views/clusters/documents.html.erb
+++ b/app/views/clusters/documents.html.erb
@@ -31,7 +31,7 @@
   </ul>
   <% if policy(Note).create? %>
     <%=
-      link_to 'Add new document',
+      link_to 'Create new document',
               new_cluster_note_path(cluster),
               class: 'btn btn-primary'
     %>

--- a/app/views/clusters/documents.html.erb
+++ b/app/views/clusters/documents.html.erb
@@ -29,11 +29,29 @@
       <% end %>
     <% end %>
   </ul>
-  <% if policy(Note).create? %>
-    <%=
-      link_to 'Create new document',
-              new_cluster_note_path(cluster),
-              class: 'btn btn-primary'
-    %>
-  <% end %>
+  <div class="d-flex">
+    <% if policy(Note).create? %>
+      <%=
+        link_to 'Create new document',
+                new_cluster_note_path(cluster),
+                class: 'btn btn-primary',
+                style: 'flex-grow: 1;'
+      %>
+    <% end %>
+    <% if policy(cluster).upload_document? %>
+      <%= form_tag cluster_upload_document_path(@cluster), multipart: true, class: 'form-inline' do %>
+        <div class="form-group">
+          <label class="mx-2" for="cluster-document">Or upload a document:</label>
+          <div class="input-group">
+            <%=
+              file_field_tag 'cluster-document', class: 'form-control'
+            %>
+            <div class="input-group-append">
+              <%= submit_tag 'Upload', class: 'btn btn-primary' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,8 @@ Rails.application.routes.draw do
       post '/checks/submit/preview', to: 'cluster_checks#preview'
       post '/checks/submit/write', to: 'cluster_checks#write'
 
+      post :documents, to: 'clusters#upload_document', as: :upload_document
+
       resources :components, only: [] do
         collection do
           get :import, to: 'clusters#import_components'

--- a/spec/features/cluster/documents_spec.rb
+++ b/spec/features/cluster/documents_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec::Matchers.define :file_contents do |expected|
+  match { |actual| File.read(actual) == File.read(expected) }
+end
+
+RSpec.describe 'Cluster documents', type: :feature do
+  let(:cluster) { create(:cluster) }
+
+  before(:each) do
+    visit cluster_documents_path(cluster, as: user)
+  end
+
+  context 'when user is admin' do
+    let(:user) { create(:admin) }
+
+    let(:textfile) { Rails.root + 'spec/fixtures/test-upload.txt' }
+
+    it 'allows upload to S3' do
+
+      expect(Cluster::DocumentsHandler).to \
+        receive(:store).with(
+          'test-upload.txt',
+          file_contents(textfile),
+          cluster.documents_path
+        ).and_return(true)
+
+      attach_file 'Or upload a document:', textfile
+      click_button 'Upload'
+
+      expect(find('.alert-success')).to have_text('Document uploaded.')
+    end
+
+    it 'gracefully handles S3 errors' do
+      expect(Cluster::DocumentsHandler).to \
+        receive(:store).and_raise(Aws::S3::Errors::ServiceError.new(nil, 'You can\'t handle the truth'))
+
+      attach_file 'Or upload a document:', textfile
+      click_button 'Upload'
+
+      expect(find('.alert-danger')).to have_text('You can\'t handle the truth')
+    end
+
+  end
+
+  RSpec.shared_examples 'no upload form' do
+    it 'does not show upload form' do
+      expect do
+        find('#cluster_document')
+      end.to raise_exception Capybara::ElementNotFound
+    end
+  end
+
+  context 'when user is contact' do
+    let(:user) { create(:contact, site: cluster.site) }
+
+    include_examples 'no upload form'
+  end
+
+  context 'when user is viewer' do
+    let(:user) { create(:viewer, site: cluster.site) }
+
+    include_examples 'no upload form'
+  end
+
+
+end

--- a/spec/features/cluster_tabs_spec.rb
+++ b/spec/features/cluster_tabs_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'cluster tabs', type: :feature do
       subject do
         cluster.tap do |c|
           allow_any_instance_of(Cluster).to receive(:documents).and_return([
-             Cluster::DocumentsRetriever::Document.new(
+             Cluster::DocumentsHandler::Document.new(
                  'Fake Document',
                  'http://www.example.com')
           ])

--- a/spec/fixtures/test-upload.txt
+++ b/spec/fixtures/test-upload.txt
@@ -1,0 +1,1 @@
+Hello, world


### PR DESCRIPTION
This PR enables engineers to upload files directly to the S3 bucket from the cluster documents page.

![selection_060](https://user-images.githubusercontent.com/3471844/45305599-99d96480-b512-11e8-9d15-091e03b6fb56.png)

Files are automatically uploaded to the correct bucket and path based on environment/site/cluster. I've modified the `AlcesFlightCenterS3Access` IAM policy to allow Flight Center to `PutObject` within its bucket. As with current files, world-readable permissions are *not* set, nor are they required - we generate a pre-signed URL when making them available through the Documents page.

As with the existing S3 document functionality, all uploaded documents are made available to engineers and to all site users.

Fixes #492.

Trello: https://trello.com/c/3CmfIjpV/464-upload-cluster-documents-to-s3