### PR TITLE
Fix the site picker arrow on Firefox

### DIFF
--- a/app/views/partials/_site_picker.html.erb
+++ b/app/views/partials/_site_picker.html.erb
@@ -1,4 +1,4 @@
-<li class="nav-item dropdown">
+<li class="nav-item dropdown nowrap">
   <% if active_site %>
   <a href="<%= site_path(active_site) %>" class="nav-link <%= active ? 'nav-link--active' : '' %>">
     <span class="fa fa-institution"></span> <%= active_site.name %>


### PR DESCRIPTION
This stops the arrow on the site picker from wrapping to a new line on Firefox.

[Trello](https://trello.com/c/EZe0deyz/475-fix-site-picker-arrow-on-firefox)