### PR TITLE
Add icon to hidden case events

### DIFF
--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -37,6 +37,20 @@
   }
 }
 
+.admin-card {
+  .card-header {
+    background-color: LemonChiffon;
+
+    span {
+      margin-left: 1rem;
+    }
+  }
+
+  .card-body {
+    background-color: LemonChiffon;
+  }
+}
+
 .case-table th {
   text-align: right;
 }

--- a/app/decorators/case_state_transition_decorator.rb
+++ b/app/decorators/case_state_transition_decorator.rb
@@ -16,7 +16,7 @@ class CaseStateTransitionDecorator < ApplicationDecorator
     when 'resolve'
       return 'This case was marked as resolved.', 'check-circle-o'
     when 'close'
-      return 'This case was closed.', 'lock'
+      return 'This case was closed.', 'times-circle-o'
     end
   end
 end

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -1,12 +1,10 @@
 <% if !local_assigns.fetch(:admin_only, false) || current_user.admin? %>
   <div class="card event-card">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
-      <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
       <% if local_assigns.fetch(:admin_only, false) %>
-        <div title="Only visible to engineers">
-          <%= icon('user-secret') =%>
-        </div>
+        <%= icon('lock', {:title=>'Only visible to engineers'}) =%>
       <% end %>
+      <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
       <div title="<%= details %>">
         <%= icon(type) %>
       </div>

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -2,8 +2,13 @@
   <div class="card event-card">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
       <span><%= date.to_formatted_s(:long) %> - <b><%= name %></b></span>
+      <% if local_assigns.fetch(:admin_only, false) %>
+        <div title="Only visible to engineers">
+          <%= icon('user-secret') =%>
+        </div>
+      <% end %>
       <div title="<%= details %>">
-          <%= icon(type) %>
+        <%= icon(type) %>
       </div>
     </div>
     <div class="card-body">

--- a/app/views/cases/_event.html.erb
+++ b/app/views/cases/_event.html.erb
@@ -1,5 +1,5 @@
 <% if !local_assigns.fetch(:admin_only, false) || current_user.admin? %>
-  <div class="card event-card">
+  <div class="<%=local_assigns.fetch(:admin_only, false) ? 'card event-card admin-card' : 'card event-card'%>">
     <div class="card-header d-inline-flex justify-content-between align-items-center">
       <% if local_assigns.fetch(:admin_only, false) %>
         <%= icon('lock', {:title=>'Only visible to engineers'}) =%>


### PR DESCRIPTION
Closes #518 when merged
Currently looks like so 
![image](https://user-images.githubusercontent.com/24327288/45354952-f726f180-b5b6-11e8-9a77-973fe03876a9.png)
How is this with people?
The icon wasn't my first choice but it seems like many are missing from rails-font-awesome (I thought [user-lock](https://fontawesome.com/icons/user-lock?style=solid) or [user-shield](https://fontawesome.com/icons/user-shield?style=solid) would probably be better)
Also had some issues (again) with the css - the hourglass appears much larger than the user-secret to me but both the icons are supposedly 32px tall. This made it fairly difficult to try and dynamically resize them to more similar heights, any ideas?