### PR TITLE
Remove escalation confirmation modal and change button wording

### DIFF
--- a/app/views/cases/_escalation_controls.html.erb
+++ b/app/views/cases/_escalation_controls.html.erb
@@ -5,62 +5,20 @@
     <% end %>
   <% else %>
     <% if @case.tier_level < 3 %>
-      <%
-          modal_id = 'escalateModal'
-          modal_label = 'escalateModalLabel'
+      <%= link_to 'Open for comments',
+                   escalate_case_path(@case.id),
+                   PolicyDependentOptions.wrap(
+                       {
+                           class: "btn btn-warning btn-sm ml-2",
+                           id: 'confirm-escalate-button',
+                           method: :post,
+                           role: 'button'
+                       },
+                       policy: policy(@case).escalate?,
+                       action_description: 'open a case for comments',
+                       user: current_user
+                   )
       %>
-
-      <%= button_tag 'Escalate',
-        PolicyDependentOptions.wrap(
-          {
-            class: "btn btn-warning btn-sm ml-2",
-            data: {
-              toggle: 'modal',
-              target: "##{modal_id}",
-            },
-          },
-          policy: policy(@case).escalate?,
-          action_description: 'escalate a case',
-          user: current_user
-      )
-      %>
-
-      <div
-        class="modal fade"
-        id="<%= modal_id %>"
-        tabindex="-1"
-        role="dialog"
-        aria-labelledby="<%= modal_label %>"
-        aria-hidden="true"
-      >
-        <div class="modal-dialog modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="<%= modal_label %>">
-                Escalating a case, please note:
-              </h5>
-              <button class="close" data-dismiss="modal">×</button>
-            </div>
-            <div class="modal-body">
-              <p>Escalating a support case means that you authorise potential use
-              of available account credit to help resolve your issue.</p>
-              <p>Do you wish to continue?</p>
-            </div>
-            <div class="modal-footer">
-              <button class="btn btn-outline-primary" data-dismiss="modal">
-                Cancel
-              </button>
-              <%= link_to 'Escalate',
-                          escalate_case_path(@case.id),
-                          class: 'btn btn-outline-warning',
-                          id: 'confirm-escalate-button',
-                          method: :post,
-                          role: 'button'
-              %>
-            </div>
-          </div>
-        </div>
-      </div>
     <% elsif @case.can_create_change_request? && policy(ChangeRequest).create? %>
       <%= link_to 'Create change request',
                   new_cluster_case_change_request_path(@case.cluster.id, @case.display_id),

--- a/spec/features/case/show_spec.rb
+++ b/spec/features/case/show_spec.rb
@@ -751,7 +751,7 @@ RSpec.describe 'Case page', type: :feature do
   end
 
   describe 'escalation' do
-    let(:escalate_button_text) { 'Escalate' }
+    let(:escalate_button_text) { 'Open for comments' }
 
     context 'for open tier 2 case' do
       subject do
@@ -762,23 +762,20 @@ RSpec.describe 'Case page', type: :feature do
         visit cluster_case_path(cluster,subject, as: admin)
 
         expect do
-          find_button escalate_button_text
+          find_link escalate_button_text
         end.not_to raise_error
 
-        click_button escalate_button_text
-
-        # Using find(...).click instead of click_button waits for modal to appear
-        find('#confirm-escalate-button').click
+        click_link escalate_button_text
 
         subject.reload
         expect(subject.tier_level).to eq 3
       end
 
-      it_behaves_like 'button is disabled for viewers' do
+      it_behaves_like 'button is disabled for viewers', button_link: true do
         let(:path) { cluster_case_path(subject.cluster, subject, as: user) }
         let(:button_text) { escalate_button_text }
         let(:disabled_button_title) do
-          'As a viewer you cannot escalate a case'
+          'As a viewer you cannot open a case for comments'
         end
       end
     end
@@ -788,7 +785,7 @@ RSpec.describe 'Case page', type: :feature do
         visit cluster_case_path(cluster, subject, as: admin)
 
         expect do
-          find_button escalate_button_text
+          find_link escalate_button_text
         end.to raise_error(Capybara::ElementNotFound)
       end
     end


### PR DESCRIPTION
This PR removes the escalation warning dialog that popped up when trying to escalate a case to tier 3; it also changes the wording of the button to say "Open for comments" because "Escalate" is scary.

Fixes #577. Relates to #576, but only in passing.

Trello: https://trello.com/c/0c8A9L0O/465-make-escalate-button-less-scary-for-customers